### PR TITLE
test: anchor the newflow-ceiling harness's node selection on the local node's own row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,17 @@ make test-iperf-throughput-lib # Self-test the #6897 iperf3 throughput parse +
                      #   NOTHING while still summarising "0 failed". Hermetic.
 make test-newflow-ceiling-lib # Self-test the #4800 connection-rate analysis
                      #   layer (synthetic snapshot pairs -> new-flows/sec +
-                     #   which contention site saturated) and the newflow-gen
+                     #   which contention site saturated), the newflow-gen
                      #   generator crate, which lives outside the dataplane
-                     #   workspaces so root `cargo test` does not reach it.
+                     #   workspaces so root `cargo test` does not reach it,
+                     #   AND the #6962 harness NODE SELECTION. That defect
+                     #   was an unanchored `grep -qi "primary"` over `show
+                     #   chassis cluster status`, which prints BOTH nodes'
+                     #   rows on whichever node you ask — so it matched the
+                     #   PEER's row and always chose $FW0. It failed to a
+                     #   PLAUSIBLE VALUE (a node name), not to an error. The
+                     #   fixtures give the two nodes DIFFERENT states, the
+                     #   only shape in which the anchor is observable.
                      #   Hermetic — no cluster. See
                      #   docs/userspace-newflow-ceiling.md
 make test-ssh        # Shell into VM

--- a/Makefile
+++ b/Makefile
@@ -496,11 +496,14 @@ test-iperf-throughput-lib:
 # pairs only; no incus, cluster, network or helper. Also builds and unit-
 # tests the connection-rate generator, which lives outside the dataplane
 # workspaces so `cargo test` at the root does not reach it.
-# Run this after touching newflow_ceiling_analyze.py or newflow-gen.
+# Run this after touching newflow_ceiling_analyze.py, newflow-gen, or the
+# harness's node selection (#6962 — newflow-ceiling-lib.sh + its selftest).
 test-newflow-ceiling-lib:
 	cd test/incus && python3 -m unittest newflow_ceiling_analyze_test
 	cargo test --release --manifest-path test/incus/newflow-gen/Cargo.toml
 	bash -n ./test/incus/newflow-ceiling-harness.sh
+	bash -n ./test/incus/newflow-ceiling-lib.sh
+	bash ./test/incus/newflow-ceiling-selftest.sh
 
 test-ssh:
 	./test/incus/setup.sh ssh

--- a/docs/log/6962.md
+++ b/docs/log/6962.md
@@ -1,0 +1,69 @@
+# #6962 — the new-flow ceiling harness selected the SECONDARY node
+
+- **Timestamp**: 2026-08-28
+  - **Action**: Replaced `newflow-ceiling-harness.sh`'s node selection with an
+    ANCHORED, total verdict in a new sourceable lib
+    (`test/incus/newflow-ceiling-lib.sh`) plus a hermetic table-driven selftest
+    (`test/incus/newflow-ceiling-selftest.sh`), wired into
+    `make test-newflow-ceiling-lib` and `scripts/run-selftests.sh`.
+  - **The defect**: `show chassis cluster status` prints BOTH nodes' rows on
+    whichever node you ask (`pkg/cluster/status.go` FormatStatus renders the
+    local row, its two readiness lines, then the peer row). The selection loop
+    tested that text with `grep -qi "primary"` — no node token at all — so on
+    node0's own output it matched node1's row, set `ACTIVE_FW=$FW0` and broke.
+    `$FW0` always won. It is not a `secondary`-contains-`primary` substring
+    artifact; the pattern simply cannot tell whose row it matched.
+  - **Why it needed a fixture with DIFFERENT states**: the failure prints a node
+    name and proceeds, so "the harness reports a node" was true before and after.
+    The selftest's ground truth is node1 primary / node0 secondary, and
+    `UNANCHORED_CONTROL` runs the SHIPPED pattern against the same bytes to keep
+    "the anchor is the load-bearing difference" measured rather than asserted. A
+    fixture with both nodes in the same state would pass either way.
+  - **The residual the issue left open, decided**: the loop `break`ed on first
+    match, so with multiple RGs the first RG's row won silently. Policy chosen:
+    PRIMARY means primary for EVERY redundancy group the status reports. The
+    measured path spans two of them on this cluster — reth0 (WAN) is
+    `redundancy-group 1`, reth1 (LAN) is `redundancy-group 2`
+    (`docs/ha-cluster-userspace.conf`) — so a node owning one installs half the
+    flows, which is the same wrong-node error one level in and just as invisible
+    (the run completes and prints numbers). No `--rg` selector: the harness reads
+    one node's counters for the whole path, so a per-RG question is not one its
+    output can answer. Both nodes are now evaluated before deciding, which makes
+    two previously unreachable states nameable: a split cluster (no node owns
+    everything) and split-brain (both claim to) — the latter silently measured
+    `$FW0` before.
+  - **Census, because an issue's enumeration is a floor**: 38 shell sites read a
+    cluster-status row for primary/secondary
+    (`git grep -nE '(grep|awk)[^|]*\b(primary|secondary)\b' -- 'test/**/*.sh' 'scripts/**/*.sh'`).
+    33 carry a node token in the pattern. Of the 5 that do not:
+    `cluster-setup.sh:775` is a deliberate node-AGNOSTIC liveness wait ("has the
+    cluster manager started emitting a status at all"); three are in
+    `step1-capture.sh` (:151, :185, :402-403) and are RG0-scoped or anchor the
+    RESULT (`grep -qiE '^(node0|fw0)'`), so their failure direction is a spurious
+    `suspect`, i.e. fail-CLOSED; the fifth was this one — the only site that
+    both chooses which node to MEASURE and fails open. Left the other four alone:
+    no defect to point at, and touching them would be unbound churn.
+  - **Latent hazard recorded**: the `Takeover ready:` / `Transfer ready:`
+    readiness lines (#103) and `Held secondary:` (#6495) carry free text that can
+    contain the words "primary"/"secondary" — e.g. `no (peer secondary not ready
+    to become primary)`. Any unanchored match over this output can land on one.
+    The lib anchors on field 1 being a node token, and
+    `HELD_AND_READINESS_TEXT_IGNORED` pins it with reason strings that contain
+    both words.
+  - **Found while writing the wiring cell**: under `set -o pipefail`,
+    `sed ... | grep -q X` returns 141 when grep short-circuits and sed takes
+    SIGPIPE, so a MATCH read as a failed pipeline and the cell reported the
+    wiring missing while it was present. The stripped source is materialised once
+    into a variable instead, with a `HARNESS_READABLE` cell so an unreadable file
+    cannot make the wiring cells pass vacuously.
+  - **One statement not mutation-bound, stated rather than implied**: `cur = ""`
+    in the malformed-`Redundancy group:`-header branch. The verdict for a
+    malformed header is fail-closed UNKNOWN, which dominates any misattribution
+    the reset would prevent, so no cell can isolate it. Kept because it stops the
+    rows after a malformed header joining the previous group the moment anyone
+    relaxes that UNKNOWN, and labelled as defensive in the source.
+  - **File(s)**: `test/incus/newflow-ceiling-lib.sh` (new),
+    `test/incus/newflow-ceiling-selftest.sh` (new),
+    `test/incus/newflow-ceiling-harness.sh`, `Makefile`,
+    `scripts/run-selftests.sh`, `docs/userspace-newflow-ceiling.md`,
+    `CLAUDE.md`, `docs/log/6962.md`

--- a/docs/log/6962.md
+++ b/docs/log/6962.md
@@ -67,3 +67,38 @@
     `test/incus/newflow-ceiling-harness.sh`, `Makefile`,
     `scripts/run-selftests.sh`, `docs/userspace-newflow-ceiling.md`,
     `CLAUDE.md`, `docs/log/6962.md`
+
+- **Mutation matrix** (full selftest, no filter, fix committed before mutating,
+  each cell restored with `git checkout --`, every cell reporting its collected
+  count). Control **35 collected, 0 failed, rc 0**:
+
+  | mutation | failed | named failing cell(s) |
+  |---|---|---|
+  | harness reverts to the unanchored inline grep | 1 | `NO_UNANCHORED_GREP` |
+  | local node id never read | 12 | `WRONG_NODE_PEER_IS_PRIMARY`, `RIGHT_NODE_OWNS_EVERY_RG`, … |
+  | over-reach: never report PRIMARY | 6 | `RIGHT_NODE_OWNS_EVERY_RG`, `SELECT_THE_ACTUAL_PRIMARY`, … |
+  | any-RG instead of every-RG | 7 | `SPLIT_OWNS_ONLY_RG0`, `SPLIT_OWNS_ONLY_DATA_RGS`, … |
+  | empty status treated as a selection | 4 | `PROBE_BLIND_EMPTY`, `SELECT_WITH_PEER_UNREACHABLE`, … |
+  | split-brain accepted (first node wins) | 1 | `REFUSE_SPLIT_BRAIN` |
+  | refusal stops naming both nodes | 1 | `REFUSE_NAMES_BOTH_NODES` |
+  | node token matched as a PREFIX | 1 | `NODE10_IS_NOT_NODE1` |
+  | any node row answers for the local node | 10 | `WRONG_NODE_PEER_IS_PRIMARY`, `HELD_AND_READINESS_TEXT_IGNORED`, … |
+  | unparseable RG header no longer fails closed | 1 | `MALFORMED_RG_HEADER_NO_ROWS_AFTER` |
+  | stray row attributed to a group | 1 | `STRAY_ROW_ALONGSIDE_REAL_GROUPS` |
+  | stray-row check removed | 1 | `STRAY_ROW_ALONGSIDE_REAL_GROUPS` |
+  | missing local row in one RG ignored | 1 | `LOCAL_ROW_MISSING_IN_ONE_RG` |
+  | apostrophe inside the awk program | 68 | `NO_APOSTROPHE_IN_AWK` |
+
+  The last row's collected count is 77, not 35: the lib does not parse at all,
+  so every `check` runs its three assertions against a missing function. That is
+  the point of the cell — the failure was already loud both times it happened,
+  and what was missing was a line that says WHICH line did it.
+
+  **Three cells escaped on the first run and are why the matrix was worth
+  running.** (1) `NODE10_IS_NOT_NODE1` listed the prefix-colliding row BEFORE
+  the local row, so a prefix match was overwritten by the correct answer —
+  last-write-wins made a broken anchor pass. (2) `ROW_BEFORE_ANY_RG_HEADER` has
+  no groups, so the no-groups branch answered before the in-scope test was
+  reached. (3) The outer `f[1] ~ /^node[0-9]+$/` test was subsumed by the
+  `f[1] == local` equality one line in; deleting it changed no cell because it
+  could not, and it was removed rather than kept as decoration.

--- a/docs/userspace-newflow-ceiling.md
+++ b/docs/userspace-newflow-ceiling.md
@@ -243,6 +243,41 @@ newflow-gen --mode sink --bind 172.16.80.200 --ports 5300-5363
     --rates 5000,10000,20000,40000,80000 --duration 30 --threads 32
 ```
 
+### Which node it measures, and when it refuses to run (#6962)
+
+The harness reads NAT-pool and Prometheus counters off ONE node, so it has to
+pick the node that installs the flows before any traffic starts. It asks BOTH
+nodes for `show chassis cluster status` and takes the answer from each node's
+OWN row — `show chassis cluster status` prints both nodes' rows on whichever
+node you ask, so a pattern with no node token in it matches the PEER's row.
+That was the #6962 defect: the selection matched node1's `primary` row inside
+node0's output and always chose `$FW0`, whoever was actually primary. It failed
+to a plausible value, not to an error — the run completed, and the analyzer
+refused the cells three layers later as if the dataplane were at fault.
+
+"Primary" here means primary for EVERY redundancy group the status reports, not
+for some group. The measured path spans two of them on this cluster — reth0
+(WAN) is `redundancy-group 1` and reth1 (LAN) is `redundancy-group 2`
+(`docs/ha-cluster-userspace.conf`) — so a node owning only one installs part of
+the flows and its counters describe half a measurement. There is deliberately
+no `--rg` selector: the harness reads one node's counters for the whole path,
+so "measure the node that owns RG N only" is not a question its output can
+answer.
+
+It therefore refuses, before taking any traffic, when:
+
+* **no node** is primary for every RG (a split/active-active cluster), or
+* **both** nodes claim to be (split-brain), or
+* neither node's status can be read at all.
+
+Each refusal prints both nodes' verdicts, because the cost of a wrong choice is
+a wasted run under the shared cluster lock and the log has to be enough to tell
+the cases apart. The verdict and the selection live in
+`test/incus/newflow-ceiling-lib.sh`; `make test-newflow-ceiling-lib` proves them
+on fixtures where the two nodes carry DIFFERENT states, which is the only shape
+in which the anchoring is observable — a fixture with both nodes in the same
+state passes with or without it.
+
 ### What proves the run was valid
 
 Per cell, under `artifacts/newflow-ceiling/<UTC>/rate-<N>/`:

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -132,6 +132,9 @@ scripts/run-selftests.sh
 test/incus/fbf-steering-lib.sh
 test/incus/fbf-steering-selftest.sh
 test/incus/test-fbf-steering.sh
+test/incus/newflow-ceiling-lib.sh
+test/incus/newflow-ceiling-selftest.sh
+test/incus/newflow-ceiling-harness.sh
 "
 for s in $SH_SCRIPTS; do
 	[ -f "$s" ] || continue
@@ -210,6 +213,12 @@ run_shell test/mutation/selftest-bpf-exist-cannot-create_6923.sh
 # no network. Guards a negative cell that used to fail to a HEALTHY value:
 # "no leak" and "the probe returned nothing" both scored PASS. Needs bash.
 run_bash test/incus/fbf-steering-selftest.sh
+# #6962: the new-flow ceiling harness's node selection. Hermetic — no incus, no
+# cluster. Guards a grep that matched the PEER's row in `show chassis cluster
+# status` and therefore always selected $FW0: it failed to a PLAUSIBLE VALUE
+# (a node name), not to an error, so the run completed and was refused three
+# layers later by the analyzer as if the dataplane were at fault. Needs bash.
+run_bash test/incus/newflow-ceiling-selftest.sh
 
 # ── summary ──
 printf '\n\033[1m== selftest summary ==\033[0m\n'

--- a/test/incus/newflow-ceiling-harness.sh
+++ b/test/incus/newflow-ceiling-harness.sh
@@ -45,6 +45,12 @@ set -uo pipefail
 _CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${_CELL_DIR}/../.." && pwd)"
 
+# Node-selection verdict (#6962). Pure bash+awk, no side effects, sourced
+# before the --dry-run early exit so a syntax error in it cannot hide until a
+# run has already taken the shared cluster lock.
+# shellcheck source=newflow-ceiling-lib.sh
+source "${_CELL_DIR}/newflow-ceiling-lib.sh"
+
 ENV_FILE="${ENV_FILE:-$ROOT_DIR/test/incus/loss-userspace-cluster.env}"
 ANALYZER="${ANALYZER:-$ROOT_DIR/test/incus/newflow_ceiling_analyze.py}"
 
@@ -137,17 +143,29 @@ echo "newflow-ceiling: artifacts -> $ARTIFACT_ROOT"
 fail() { echo "newflow-ceiling: $*" >&2; exit 2; }
 
 # --- preflight ------------------------------------------------------------
-# Establish which node owns the tested RG BEFORE any traffic. Reading
+# Establish which node owns the measured path BEFORE any traffic. Reading
 # counters off the standby would report a firewall that installed nothing.
-ACTIVE_FW=""
-for fw in "$FW0" "$FW1"; do
-    if incus_cmd exec "$fw" -- cli -c "show chassis cluster status" 2>/dev/null \
-        | grep -qi "primary"; then
-        ACTIVE_FW="$fw"
-        break
-    fi
-done
-[[ -n "$ACTIVE_FW" ]] || fail "no node reports primary for the tested RG"
+#
+# #6962: this used to be `grep -qi "primary"` over the whole status. That text
+# contains BOTH nodes' rows on whichever node you ask, so it matched the PEER's
+# row and $FW0 always won — and it won by printing a node name, not by
+# erroring. Ask each node, ANCHOR the answer on that node's own row, and decide
+# only after both have answered. The verdict + selection are in
+# newflow-ceiling-lib.sh so `make test-newflow-ceiling-lib` can prove the
+# selection on fixtures where the two nodes carry DIFFERENT states, which is
+# the only shape in which the anchoring is observable.
+node_status() { # node_status <instance>
+    incus_cmd exec "$1" -- cli -c "show chassis cluster status" 2>/dev/null || true
+}
+V_FW0="$(newflow_cluster_primary_verdict "$(node_status "$FW0")")"
+V_FW1="$(newflow_cluster_primary_verdict "$(node_status "$FW1")")"
+echo "newflow-ceiling: $FW0 -> $V_FW0"
+echo "newflow-ceiling: $FW1 -> $V_FW1"
+SELECTION="$(newflow_select_active_node "$FW0" "$V_FW0" "$FW1" "$V_FW1")"
+if [[ "${SELECTION%% *}" != "SELECT" ]]; then
+    fail "${SELECTION#REFUSE }"
+fi
+ACTIVE_FW="${SELECTION#SELECT }"
 echo "newflow-ceiling: active node = $ACTIVE_FW"
 
 # The pool must already exist. This harness does NOT mutate the NAT config:
@@ -259,6 +277,11 @@ PY
     # different question — "did the generator run at all" — and must never
     # degrade to 0, because a silent 0 would disable the underdrive gate from
     # the other side.
+    # shellcheck disable=SC2034  # `offered` is deliberately WRITE-ONLY: the
+    # value is not used, the EXIT STATUS is. The python snippet raises when the
+    # generator reported no established connections, which is what refuses the
+    # cell; capturing stdout keeps the parse and the liveness check in one
+    # place. Named rather than assigned to `_` so the reason survives.
     if ! offered="$(python3 -c '
 import json, sys
 d = json.load(open(sys.argv[1]))

--- a/test/incus/newflow-ceiling-lib.sh
+++ b/test/incus/newflow-ceiling-lib.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Node-selection verdict for the #4800 new-flow ceiling harness (#6962).
+#
+# WHY THIS EXISTS
+#
+# `newflow-ceiling-harness.sh` must read NAT-pool and Prometheus counters off
+# the node that actually installs the sessions. It picked that node with:
+#
+#     for fw in "$FW0" "$FW1"; do
+#         if incus_cmd exec "$fw" -- cli -c "show chassis cluster status" \
+#             | grep -qi "primary"; then ACTIVE_FW="$fw"; break; fi
+#     done
+#
+# `show chassis cluster status` prints BOTH nodes' rows on whichever node you
+# ask (pkg/cluster/status.go FormatStatus emits the local node row and then the
+# peer's). So node0's own output contains node1's row:
+#
+#     Node name: node0
+#     Redundancy group: 0 , Failover count: 1
+#     node0   100      secondary      yes      no       None
+#     node1   200      primary        yes      no       None
+#
+# The unanchored grep matches the PEER's row, `ACTIVE_FW=$FW0`, `break`. $FW0
+# therefore always wins regardless of who is primary. This is not a
+# `secondary`-contains-`primary` substring artifact — there is no node token in
+# the pattern at all, so the pattern cannot tell whose row it matched.
+#
+# It FAILS TO A PLAUSIBLE VALUE, not to an error: the harness prints
+# "active node = xpf-userspace-fw0" and proceeds. Downstream the analyzer's
+# zero-allocations gate refuses the cell as INVALID, so the cost is a wasted run
+# under the shared cluster lock that looks like a dataplane problem. A fix
+# verified by "the harness now reports a node" proves nothing — it reported one
+# before. The selftest fixture therefore has node0 and node1 carrying DIFFERENT
+# states, which is the only shape in which the anchor is load-bearing.
+#
+# WHAT "PRIMARY" HAS TO MEAN HERE
+#
+# Not "primary for some redundancy group". On the loss userspace cluster the
+# measured path spans TWO RGs — reth0 (WAN, `redundancy-group 1`) and reth1
+# (LAN, `redundancy-group 2`), per docs/ha-cluster-userspace.conf — so a node
+# that owns only one of them installs only part of the flows and its pool
+# counters describe half a measurement. That is the same wrong-node error one
+# level in, and it would be invisible for the same reason: the run completes and
+# prints numbers.
+#
+# So the verdict is: the LOCAL node's row reads `primary` in EVERY redundancy
+# group the status reports. A split (active/active) cluster yields NOT-PRIMARY
+# from both nodes and the harness refuses the run, naming the split — rather
+# than measuring a node that owns half the path. There is deliberately no
+# `--rg` selector: the harness reads one node's counters for the whole path, so
+# "measure the node that owns RG N only" is not a question its output can
+# answer.
+#
+# Depends on nothing but bash + awk, so newflow-ceiling-selftest.sh
+# (`make test-newflow-ceiling-lib`) is hermetic — no cluster, no incus.
+
+# newflow_cluster_primary_verdict <show-chassis-cluster-status-output>
+#
+#   Print exactly one line:
+#
+#     PRIMARY     <msg>   the local node owns EVERY redundancy group
+#     NOT-PRIMARY <msg>   the status was readable and the answer is no
+#     UNKNOWN     <msg>   the status could not be read as a status at all
+#
+#   TOTAL BY CONSTRUCTION — every path prints exactly one verdict line, so this
+#   can never be the silent hole the bare grep was. UNKNOWN and NOT-PRIMARY are
+#   kept apart on purpose: they are the same decision for the harness (do not
+#   select this node) and different diagnoses for the operator ("I could not
+#   read the instrument" vs "I read it and this node is the standby").
+newflow_cluster_primary_verdict() {
+	local status="${1-}"
+	if [[ -z "${status//[[:space:]]/}" ]]; then
+		printf 'UNKNOWN %s\n' "cluster status was EMPTY — the node did not answer 'show chassis cluster status' (down, cli missing, or incus exec failed), so nothing about its role is known"
+		return 0
+	fi
+	awk '
+	{
+		line = $0
+		sub(/^[ \t]+/, "", line)
+		low = tolower(line)
+
+		# "Node name: nodeN" — the LOCAL node, the whole point of the anchor.
+		# Mirrors parseLocalNodeID in pkg/upgrade/cluster_cli.go.
+		if (low ~ /^node name:/) {
+			n = split(line, f, /[ \t]+/)
+			tok = tolower(f[n])
+			if (tok ~ /^node[0-9]+$/) local = tok
+			next
+		}
+
+		# "Redundancy group: N , Failover count: M".
+		#
+		# A header whose id does not parse is FAIL-CLOSED: the verdict this lib
+		# exists to give is "the local node owns EVERY redundancy group", and a
+		# group we could not read is a group whose ownership is unknown, so the
+		# END block returns UNKNOWN rather than answering about the groups that
+		# happened to parse. The `cur = ""` alongside it is DEFENSIVE, not
+		# load-bearing under that policy: it stops the rows after a malformed
+		# header being attributed to the PREVIOUS group (the same reset the Go
+		# parser does, pkg/upgrade/cluster_cli.go), which would matter again the
+		# moment anyone relaxes the UNKNOWN. No selftest cell can isolate it
+		# while the fail-closed verdict dominates, and it is kept for that
+		# reason rather than because a test proves it.
+		if (low ~ /^redundancy group:/) {
+			n = split(line, f, /[ \t]+/)
+			if (n >= 3 && f[3] ~ /^[0-9]+$/) {
+				cur = f[3]
+				if (!(cur in seen)) { seen[cur] = 1; order[++nrg] = cur }
+			} else {
+				cur = ""
+				malformed++
+			}
+			next
+		}
+
+		# A node row: "nodeN  <prio>  <state>  <preempt> <manual> <mon>".
+		# Anchored on field 1, so the PEER row can never answer for the local
+		# node — and the "  Takeover ready: ..." / "Held secondary: ..." lines,
+		# whose free-text reasons could contain any word, are not node rows.
+		n = split(line, f, /[ \t]+/)
+		if (n >= 3 && cur != "" && tolower(f[1]) ~ /^node[0-9]+$/) {
+			if (local != "" && tolower(f[1]) == local) {
+				state[cur] = tolower(f[3])
+				sawlocal[cur] = 1
+			}
+		}
+	}
+	END {
+		if (local == "") {
+			printf "UNKNOWN %s\n", "no \"Node name: nodeN\" line in the status — the local node cannot be identified, so no row can be attributed to it (this is the header FormatStatus always emits; its absence means the output is not a cluster status)"
+			exit 0
+		}
+		if (malformed > 0) {
+			printf "UNKNOWN %s\n", "status contains " malformed " unparseable \"Redundancy group:\" header(s) — a group whose id cannot be read is a group whose ownership is unknown, and this verdict is about owning EVERY group"
+			exit 0
+		}
+		if (nrg == 0) {
+			printf "UNKNOWN %s\n", "status names the local node " local " but contains no \"Redundancy group:\" block — there is no row to read a role from"
+			exit 0
+		}
+		seen_local = 0
+		for (i = 1; i <= nrg; i++) if (sawlocal[order[i]]) seen_local++
+		if (seen_local == 0) {
+			printf "UNKNOWN %s\n", "status has " nrg " redundancy group(s) but no row for " local " in any of them — the node cannot report on itself"
+			exit 0
+		}
+		summary = ""
+		notprimary = ""
+		missing = ""
+		for (i = 1; i <= nrg; i++) {
+			rg = order[i]
+			if (!sawlocal[rg]) {
+				summary = summary sprintf("%srg%s=<no row>", (summary == "" ? "" : " "), rg)
+				missing = missing sprintf("%srg%s", (missing == "" ? "" : ","), rg)
+				continue
+			}
+			summary = summary sprintf("%srg%s=%s", (summary == "" ? "" : " "), rg, state[rg])
+			if (state[rg] != "primary") {
+				notprimary = notprimary sprintf("%srg%s", (notprimary == "" ? "" : ","), rg)
+			}
+		}
+		if (missing != "") {
+			printf "NOT-PRIMARY %s\n", local " has no row in redundancy group(s) " missing " (" summary ") — ownership of the whole measured path cannot be confirmed, so this node is not selectable"
+			exit 0
+		}
+		if (notprimary != "") {
+			printf "NOT-PRIMARY %s\n", local " is not primary for redundancy group(s) " notprimary " (" summary ")"
+			exit 0
+		}
+		printf "PRIMARY %s\n", local " is primary for every redundancy group (" summary ")"
+	}
+	' <<<"$status"
+}
+
+# newflow_select_active_node <name0> <verdict0> <name1> <verdict1>
+#
+#   Decide which node the harness measures, from the two verdict lines above.
+#   Print exactly one line: "SELECT <name>" or "REFUSE <msg>".
+#
+#   Both nodes are evaluated before deciding. The loop this replaces broke on
+#   the first match, which meant $FW0 was answered for and $FW1 was never asked
+#   — so the two states that most need naming, "neither node owns the path"
+#   (a split cluster) and "both claim to" (split-brain), were unreachable: the
+#   first was reported as "no node reports primary for the tested RG" with no
+#   evidence, and the second silently measured $FW0.
+#
+#   TOTAL BY CONSTRUCTION, and every REFUSE carries both nodes' verdict text,
+#   because the cost of this decision is a wasted run under the shared cluster
+#   lock and the operator has to be able to tell WHY from the log alone.
+newflow_select_active_node() {
+	local n0="$1" v0="$2" n1="$3" v1="$4"
+	local w0="${v0%% *}" w1="${v1%% *}"
+	if [[ "$w0" == "PRIMARY" && "$w1" == "PRIMARY" ]]; then
+		printf 'REFUSE %s\n' "BOTH nodes report primary for every redundancy group — the cluster is split-brain, and whichever node were measured the other would be installing flows too. ${n0}: ${v0} | ${n1}: ${v1}"
+		return 0
+	fi
+	if [[ "$w0" == "PRIMARY" ]]; then
+		printf 'SELECT %s\n' "$n0"
+		return 0
+	fi
+	if [[ "$w1" == "PRIMARY" ]]; then
+		printf 'SELECT %s\n' "$n1"
+		return 0
+	fi
+	printf 'REFUSE %s\n' "no node is primary for EVERY redundancy group, so no single node installs the whole measured path. ${n0}: ${v0} | ${n1}: ${v1}"
+}

--- a/test/incus/newflow-ceiling-lib.sh
+++ b/test/incus/newflow-ceiling-lib.sh
@@ -114,14 +114,25 @@ newflow_cluster_primary_verdict() {
 		}
 
 		# A node row: "nodeN  <prio>  <state>  <preempt> <manual> <mon>".
-		# Anchored on field 1, so the PEER row can never answer for the local
-		# node — and the "  Takeover ready: ..." / "Held secondary: ..." lines,
-		# whose free-text reasons could contain any word, are not node rows.
+		#
+		# Field 1 must EQUAL the local node token. That one test is the whole
+		# anchor: the PEER row cannot answer for the local node, and the
+		# "  Takeover ready: ..." / "Held secondary: ..." lines — whose
+		# free-text reasons do contain the words "primary" and "secondary"
+		# (#103, #6495) — are not node tokens and so are not rows. Equality,
+		# not a prefix: node1 must not answer for node10.
+		#
+		# A local row with no group in scope (before the first header, or after
+		# a header whose id did not parse) is a STRAY: the output is not the
+		# grammar this verdict is written against, so it fails closed rather
+		# than being attributed to a group it might not belong to.
 		n = split(line, f, /[ \t]+/)
-		if (n >= 3 && cur != "" && tolower(f[1]) ~ /^node[0-9]+$/) {
-			if (local != "" && tolower(f[1]) == local) {
+		if (n >= 3 && local != "" && tolower(f[1]) == local) {
+			if (cur != "") {
 				state[cur] = tolower(f[3])
 				sawlocal[cur] = 1
+			} else {
+				stray++
 			}
 		}
 	}
@@ -132,6 +143,10 @@ newflow_cluster_primary_verdict() {
 		}
 		if (malformed > 0) {
 			printf "UNKNOWN %s\n", "status contains " malformed " unparseable \"Redundancy group:\" header(s) — a group whose id cannot be read is a group whose ownership is unknown, and this verdict is about owning EVERY group"
+			exit 0
+		}
+		if (stray > 0) {
+			printf "UNKNOWN %s\n", "status has " stray " row(s) for " local " outside any redundancy group — a node row with no group in scope means this is not the status grammar the verdict reads, so the ownership of no group can be claimed from it"
 			exit 0
 		}
 		if (nrg == 0) {

--- a/test/incus/newflow-ceiling-selftest.sh
+++ b/test/incus/newflow-ceiling-selftest.sh
@@ -253,6 +253,20 @@ Redundancy group: <corrupt> , Failover count: 0
 node0   200      primary        yes      no       None
 '
 
+# A malformed header with NO rows after it: the stray-row path cannot see this
+# one (there is no stray row), so it isolates the unparseable-header check.
+# Without it, a group that exists but could not be read would be silently
+# excluded from "every redundancy group" and the node would read as owning all
+# of them.
+check MALFORMED_RG_HEADER_NO_ROWS_AFTER UNKNOWN 'Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+node1   100      secondary      yes      no       None
+
+Redundancy group: <corrupt> , Failover count: 0
+'
+
 # --- node-token anchoring must be exact ----------------------------------
 # node1 must not answer for node10, or the anchor is a prefix match.
 # ORDER IS LOAD-BEARING: the local row comes FIRST and the prefix-colliding row
@@ -321,6 +335,26 @@ if [[ "$refuse_msg" == *"fw0:"* && "$refuse_msg" == *"fw1:"* ]]; then
 	pass=$((pass + 1)); printf 'ok   %-32s -> names both nodes\n' REFUSE_NAMES_BOTH_NODES
 else
 	fail=$((fail + 1)); printf 'FAIL %-32s -> refusal did not name both nodes: %q\n' REFUSE_NAMES_BOTH_NODES "$refuse_msg"
+fi
+
+# --- the lib must stay parseable: no apostrophes inside the awk program ---
+# The verdict is one awk program delimited by SINGLE QUOTES. An apostrophe
+# anywhere inside it — including in a comment — ends the program early and the
+# whole lib stops parsing. That happened twice while this was written, both
+# times in prose ("group\x27s", "parseNodeToken\x27s"), and both times every cell
+# below failed at once, which is loud but tells you nothing about where. This
+# names it.
+LIB_FILE="${SCRIPT_DIR}/newflow-ceiling-lib.sh"
+awk_body="$(awk "/^\tawk '\$/{flag=1;next} /^\t' <<</{flag=0} flag" "$LIB_FILE")"
+if [[ -z "${awk_body//[[:space:]]/}" ]]; then
+	fail=$((fail + 1))
+	printf 'FAIL %-32s -> could not extract the awk program from %s; this cell would pass vacuously\n' AWK_BODY_EXTRACTED "$LIB_FILE"
+elif [[ "$awk_body" == *"'"* ]]; then
+	fail=$((fail + 1))
+	printf 'FAIL %-32s -> an apostrophe inside the single-quoted awk program ends it early and breaks the whole lib\n' NO_APOSTROPHE_IN_AWK
+else
+	pass=$((pass + 1))
+	printf 'ok   %-32s -> awk program is apostrophe-free (%d lines)\n' NO_APOSTROPHE_IN_AWK "$(grep -c . <<<"$awk_body")"
 fi
 
 # --- WIRING: the harness must USE the lib, not re-inline the grep ---------

--- a/test/incus/newflow-ceiling-selftest.sh
+++ b/test/incus/newflow-ceiling-selftest.sh
@@ -232,6 +232,16 @@ node1   100      secondary      yes      no       None
 check ROW_BEFORE_ANY_RG_HEADER UNKNOWN 'Node name: node0
 node0   200      primary        yes      no       None
 '
+# ... and the same guard with REAL groups present, so the verdict cannot be
+# reached by the no-groups path instead. Without the in-scope test the stray row
+# is attributed to a group and this reads as an ownership claim.
+check STRAY_ROW_ALONGSIDE_REAL_GROUPS UNKNOWN 'Node name: node0
+node0   200      primary        yes      no       None
+
+Redundancy group: 0 , Failover count: 0
+node0   100      secondary      yes      no       None
+node1   200      primary        yes      no       None
+'
 # A group whose id cannot be read is a group whose ownership is unknown, so the
 # verdict is fail-closed even though every group that DID parse reads primary.
 check MALFORMED_RG_HEADER_FAILS_CLOSED UNKNOWN 'Node name: node0
@@ -245,11 +255,15 @@ node0   200      primary        yes      no       None
 
 # --- node-token anchoring must be exact ----------------------------------
 # node1 must not answer for node10, or the anchor is a prefix match.
+# ORDER IS LOAD-BEARING: the local row comes FIRST and the prefix-colliding row
+# LAST. With node10 first, a prefix match would be overwritten by node1's own
+# later row and the cell would pass against a broken anchor — which is exactly
+# what the first version of this fixture did, and the mutation matrix caught.
 check NODE10_IS_NOT_NODE1 NOT-PRIMARY 'Node name: node1
 
 Redundancy group: 0 , Failover count: 0
-node10  200      primary        yes      no       None
 node1   100      secondary      yes      no       None
+node10  200      primary        yes      no       None
 '
 check NODE10_LOCAL_PRIMARY PRIMARY 'Node name: node10
 

--- a/test/incus/newflow-ceiling-selftest.sh
+++ b/test/incus/newflow-ceiling-selftest.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# Hermetic self-test for test/incus/newflow-ceiling-lib.sh (#6962).
+#
+# No cluster, no incus, no network. Runs in `make test-newflow-ceiling-lib`.
+#
+# THE ROW THAT MATTERS is WRONG_NODE_PEER_IS_PRIMARY: node0's own status, in
+# which node0 is SECONDARY and node1 is PRIMARY. The shipped `grep -qi
+# "primary"` matches node1's row in that text and selects node0 — and prints a
+# node name, so nothing downstream in the harness looks like an error. A
+# fixture where both nodes carry the SAME state cannot distinguish the anchored
+# form from the unanchored one and would pass either way; UNANCHORED_CONTROL
+# below runs the old pattern against the same bytes to keep that difference
+# measured rather than asserted.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./newflow-ceiling-lib.sh
+. "${SCRIPT_DIR}/newflow-ceiling-lib.sh"
+
+pass=0
+fail=0
+
+check() {
+	local name="$1" want="$2" status="$3" got verdict
+	got="$(newflow_cluster_primary_verdict "$status")"
+	verdict="${got%% *}"
+	if [[ "$verdict" == "$want" ]]; then
+		pass=$((pass + 1))
+		printf 'ok   %-32s -> %s\n' "$name" "$verdict"
+	else
+		fail=$((fail + 1))
+		printf 'FAIL %-32s -> want %s got %s (%s)\n' "$name" "$want" "$verdict" "$got"
+	fi
+	# TOTALITY: exactly one verdict line, and it is one of the three words.
+	if [[ "$(grep -c . <<<"$got")" -ne 1 ]]; then
+		fail=$((fail + 1))
+		printf 'FAIL %-32s -> verdict was not exactly one line: %q\n' "$name" "$got"
+	fi
+	case "$verdict" in
+	PRIMARY | NOT-PRIMARY | UNKNOWN) ;;
+	*)
+		fail=$((fail + 1))
+		printf 'FAIL %-32s -> verdict word %q is not one of PRIMARY/NOT-PRIMARY/UNKNOWN\n' "$name" "$verdict"
+		;;
+	esac
+}
+
+# --- ground truth: node1 is primary, node0 is secondary -------------------
+# Both nodes' own renderings of the SAME cluster state. FormatStatus grammar
+# (pkg/cluster/status.go): the local "Node name:" header, then per-RG blocks
+# with the local row, its two readiness lines, then the peer row.
+FW0_STATUS='Monitor Failure codes:
+    CS  Cold Sync monitoring        FL  Fabric Connection monitoring
+    IF  Interface monitoring        IP  IP monitoring
+    CF  Config Sync monitoring
+
+Cluster ID: 1
+Node name: node0
+
+Software version: 0.0.0-dev
+HA protocol version: 3
+
+Redundancy group: 0 , Failover count: 1
+node0   100      secondary      yes      no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node1   200      primary        yes      no       None
+
+Redundancy group: 1 , Failover count: 1
+node0   100      secondary      yes      no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node1   200      primary        yes      no       None
+
+Redundancy group: 2 , Failover count: 1
+node0   100      secondary      yes      no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node1   200      primary        yes      no       None
+'
+FW1_STATUS='Monitor Failure codes:
+    CS  Cold Sync monitoring        FL  Fabric Connection monitoring
+
+Cluster ID: 1
+Node name: node1
+
+Redundancy group: 0 , Failover count: 1
+node1   200      primary        yes      no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node0   100      secondary      yes      no       None
+
+Redundancy group: 1 , Failover count: 1
+node1   200      primary        yes      no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node0   100      secondary      yes      no       None
+
+Redundancy group: 2 , Failover count: 1
+node1   200      primary        yes      no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node0   100      secondary      yes      no       None
+'
+
+check WRONG_NODE_PEER_IS_PRIMARY NOT-PRIMARY "$FW0_STATUS"
+check RIGHT_NODE_OWNS_EVERY_RG   PRIMARY     "$FW1_STATUS"
+
+# --- the negative control: the pattern that shipped, on the same bytes -----
+# This is what makes the two rows above mean something. If node0's own status
+# did NOT match the old pattern, the anchor would be unbound and both cells
+# would pass with or without it.
+if grep -qi "primary" <<<"$FW0_STATUS"; then
+	pass=$((pass + 1))
+	printf 'ok   %-32s -> the shipped `grep -qi "primary"` DOES match the SECONDARY node'"'"'s own status (it is matching the peer row), which is the defect\n' UNANCHORED_CONTROL
+else
+	fail=$((fail + 1))
+	printf 'FAIL %-32s -> the fixture no longer reproduces the defect: `grep -qi "primary"` did not match node0'"'"'s status, so these cells would pass unanchored too and prove nothing\n' UNANCHORED_CONTROL
+fi
+# ... and the anchored verdict must DISAGREE with it on that same input.
+if [[ "$(newflow_cluster_primary_verdict "$FW0_STATUS")" == PRIMARY* ]]; then
+	fail=$((fail + 1))
+	printf 'FAIL %-32s -> anchored verdict agreed with the unanchored grep on node0'"'"'s status; the anchor is not load-bearing\n' ANCHOR_DISAGREES
+else
+	pass=$((pass + 1))
+	printf 'ok   %-32s -> anchored verdict rejects the node the unanchored grep selected\n' ANCHOR_DISAGREES
+fi
+
+# --- partial ownership: the wrong-node error one level in -----------------
+# node0 owns RG0 but not the RGs carrying the measured path (reth0 -> rg1,
+# reth1 -> rg2). Selecting it would measure a node that installs part of the
+# flows, and the run would still produce numbers.
+SPLIT_STATUS='Cluster ID: 1
+Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+node1   100      secondary      yes      no       None
+
+Redundancy group: 1 , Failover count: 1
+node0   100      secondary      yes      no       None
+node1   200      primary        yes      no       None
+
+Redundancy group: 2 , Failover count: 1
+node0   100      secondary      yes      no       None
+node1   200      primary        yes      no       None
+'
+check SPLIT_OWNS_ONLY_RG0 NOT-PRIMARY "$SPLIT_STATUS"
+
+SPLIT_STATUS_FW1='Cluster ID: 1
+Node name: node1
+
+Redundancy group: 0 , Failover count: 0
+node1   100      secondary      yes      no       None
+node0   200      primary        yes      no       None
+
+Redundancy group: 1 , Failover count: 1
+node1   200      primary        yes      no       None
+node0   100      secondary      yes      no       None
+
+Redundancy group: 2 , Failover count: 1
+node1   200      primary        yes      no       None
+node0   100      secondary      yes      no       None
+'
+check SPLIT_OWNS_ONLY_DATA_RGS NOT-PRIMARY "$SPLIT_STATUS_FW1"
+
+# --- single-RG cluster: the ordinary healthy shape ------------------------
+check SINGLE_RG_LOCAL_PRIMARY PRIMARY 'Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+node1   100      secondary      yes      no       None
+'
+check SINGLE_RG_LOCAL_SECONDARY NOT-PRIMARY 'Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node0   100      secondary      yes      no       None
+node1   200      primary        yes      no       None
+'
+
+# --- the instrument could not be read: UNKNOWN, never a selection ---------
+check PROBE_BLIND_EMPTY   UNKNOWN ""
+check PROBE_BLIND_WS      UNKNOWN "   "
+check PROBE_BLIND_NEWLINE UNKNOWN "
+"
+# A node that answered, but not with a cluster status (cli error text, a
+# standalone node, a truncated read).
+check NO_NODE_NAME_HEADER UNKNOWN 'Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+'
+check NO_RG_BLOCKS UNKNOWN 'Cluster ID: 1
+Node name: node0
+
+Software version: 0.0.0-dev
+'
+check ERROR_TEXT_MENTIONING_PRIMARY UNKNOWN 'error: could not read primary state from the cluster manager'
+# RG blocks present, but the node has no row of its own in any of them.
+check NO_LOCAL_ROW_IN_ANY_RG UNKNOWN 'Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node1   200      primary        yes      no       None
+'
+# A local row in RG0 but none in RG1: ownership of the whole path is
+# unconfirmable, so it is not selectable — but the status WAS readable, so this
+# is a NOT-PRIMARY answer rather than a blind instrument.
+check LOCAL_ROW_MISSING_IN_ONE_RG NOT-PRIMARY 'Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+node1   100      secondary      yes      no       None
+
+Redundancy group: 1 , Failover count: 0
+node1   200      primary        yes      no       None
+'
+
+# --- lines that are NOT node rows must not answer for the node ------------
+# #6495 renders "Held secondary: <reason>" above every RG header, and the
+# readiness lines carry free text. Neither may be read as a row. The reason
+# strings here deliberately contain the words the verdict keys on.
+check HELD_AND_READINESS_TEXT_IGNORED PRIMARY 'Node name: node0
+Held secondary: kernel upgrade candidate armed; primary promotion held
+
+Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+  Takeover ready: no (takeover hold: 4s of 10s remaining)
+  Transfer ready: no (peer secondary not ready to become primary)
+node1   100      secondary      yes      no       None
+'
+# A node row before any RG header has no group to belong to and is ignored —
+# the same reset the Go parser does, so a malformed header cannot make the
+# rows after it answer for the previous group.
+check ROW_BEFORE_ANY_RG_HEADER UNKNOWN 'Node name: node0
+node0   200      primary        yes      no       None
+'
+# A group whose id cannot be read is a group whose ownership is unknown, so the
+# verdict is fail-closed even though every group that DID parse reads primary.
+check MALFORMED_RG_HEADER_FAILS_CLOSED UNKNOWN 'Node name: node0
+
+Redundancy group: 0 , Failover count: 0
+node0   200      primary        yes      no       None
+
+Redundancy group: <corrupt> , Failover count: 0
+node0   200      primary        yes      no       None
+'
+
+# --- node-token anchoring must be exact ----------------------------------
+# node1 must not answer for node10, or the anchor is a prefix match.
+check NODE10_IS_NOT_NODE1 NOT-PRIMARY 'Node name: node1
+
+Redundancy group: 0 , Failover count: 0
+node10  200      primary        yes      no       None
+node1   100      secondary      yes      no       None
+'
+check NODE10_LOCAL_PRIMARY PRIMARY 'Node name: node10
+
+Redundancy group: 0 , Failover count: 0
+node10  200      primary        yes      no       None
+node1   100      secondary      yes      no       None
+'
+
+# --- the selection policy: both nodes evaluated, then decided -------------
+checks() {
+	local name="$1" want="$2" n0="$3" v0="$4" n1="$5" v1="$6" got
+	got="$(newflow_select_active_node "$n0" "$v0" "$n1" "$v1")"
+	if [[ "$got" == "$want"* ]]; then
+		pass=$((pass + 1))
+		printf 'ok   %-32s -> %s\n' "$name" "${got%% *}"
+	else
+		fail=$((fail + 1))
+		printf 'FAIL %-32s -> want %s got %s\n' "$name" "$want" "$got"
+	fi
+	if [[ "$(grep -c . <<<"$got")" -ne 1 ]]; then
+		fail=$((fail + 1))
+		printf 'FAIL %-32s -> selection was not exactly one line: %q\n' "$name" "$got"
+	fi
+}
+
+# The ground truth from the fixtures above: fw0 secondary, fw1 primary. The
+# shipped loop selected fw0; the selector must reach fw1.
+V0="$(newflow_cluster_primary_verdict "$FW0_STATUS")"
+V1="$(newflow_cluster_primary_verdict "$FW1_STATUS")"
+checks SELECT_THE_ACTUAL_PRIMARY "SELECT fw1" fw0 "$V0" fw1 "$V1"
+checks SELECT_WHEN_NODE0_PRIMARY "SELECT fw0" \
+	fw0 "PRIMARY node0 is primary for every redundancy group (rg0=primary)" \
+	fw1 "NOT-PRIMARY node1 is not primary for redundancy group(s) rg0 (rg0=secondary)"
+# A split cluster: neither node owns the whole path. The old loop reported
+# "no node reports primary" with no evidence; refusing must name both.
+checks REFUSE_SPLIT_CLUSTER "REFUSE" \
+	fw0 "$(newflow_cluster_primary_verdict "$SPLIT_STATUS")" \
+	fw1 "$(newflow_cluster_primary_verdict "$SPLIT_STATUS_FW1")"
+# Split-brain: BOTH claim every RG. The old loop silently measured fw0.
+checks REFUSE_SPLIT_BRAIN "REFUSE" \
+	fw0 "PRIMARY node0 is primary for every redundancy group (rg0=primary)" \
+	fw1 "PRIMARY node1 is primary for every redundancy group (rg0=primary)"
+# Neither answered at all.
+checks REFUSE_BOTH_UNKNOWN "REFUSE" \
+	fw0 "$(newflow_cluster_primary_verdict "")" \
+	fw1 "$(newflow_cluster_primary_verdict "")"
+# One node down, the other primary: still selectable — a standby that cannot be
+# reached does not stop the owner being measured.
+checks SELECT_WITH_PEER_UNREACHABLE "SELECT fw1" \
+	fw0 "$(newflow_cluster_primary_verdict "")" fw1 "$V1"
+# The REFUSE text must carry both verdicts, or the operator cannot tell a
+# split cluster from an unreachable pair without re-running under the lock.
+refuse_msg="$(newflow_select_active_node fw0 "$V0" fw1 "$V0")"
+if [[ "$refuse_msg" == *"fw0:"* && "$refuse_msg" == *"fw1:"* ]]; then
+	pass=$((pass + 1)); printf 'ok   %-32s -> names both nodes\n' REFUSE_NAMES_BOTH_NODES
+else
+	fail=$((fail + 1)); printf 'FAIL %-32s -> refusal did not name both nodes: %q\n' REFUSE_NAMES_BOTH_NODES "$refuse_msg"
+fi
+
+# --- WIRING: the harness must USE the lib, not re-inline the grep ---------
+# Every cell above passes against a perfect lib that nothing calls. The defect
+# lives in the harness, so bind the harness.
+#
+# Comments are stripped before matching, because this file and the lib both
+# QUOTE the defective pattern in their own prose to explain it — a source scan
+# that reads comments would be satisfied by the explanation of the bug.
+HARNESS="${SCRIPT_DIR}/newflow-ceiling-harness.sh"
+# Materialised ONCE rather than piped per check: under `set -o pipefail`,
+# `sed ... | grep -q X` returns 141 when grep short-circuits and sed takes
+# SIGPIPE, so a MATCH reads as a failed pipeline. This test hit that on its
+# first run and reported the wiring missing while it was present.
+HARNESS_CODE="$(sed -e 's/[[:space:]]#.*$//' -e '/^[[:space:]]*#/d' "$HARNESS")"
+if [[ -z "${HARNESS_CODE//[[:space:]]/}" ]]; then
+	fail=$((fail + 1))
+	printf 'FAIL %-32s -> could not read %s; the wiring cells below would pass vacuously\n' HARNESS_READABLE "$HARNESS"
+else
+	pass=$((pass + 1))
+	printf 'ok   %-32s -> read %s\n' HARNESS_READABLE "$HARNESS"
+fi
+for fn in newflow_cluster_primary_verdict newflow_select_active_node; do
+	if grep -q "$fn" <<<"$HARNESS_CODE"; then
+		pass=$((pass + 1))
+		printf 'ok   %-32s -> harness calls %s\n' "WIRED_${fn}" "$fn"
+	else
+		fail=$((fail + 1))
+		printf 'FAIL %-32s -> the harness does not call %s, so every cell above tests a lib nothing uses (#6962)\n' "WIRED_${fn}" "$fn"
+	fi
+done
+if grep -qE 'grep +-q[a-z]* +"?(primary|secondary)"?' <<<"$HARNESS_CODE"; then
+	fail=$((fail + 1))
+	printf 'FAIL %-32s -> the harness matches primary/secondary with no node token again; that pattern matches the PEER row and selects the wrong node (#6962)\n' NO_UNANCHORED_GREP
+else
+	pass=$((pass + 1))
+	printf 'ok   %-32s -> no unanchored primary/secondary match left in the harness\n' NO_UNANCHORED_GREP
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Closes #6962

## The defect

`show chassis cluster status` prints **both** nodes' rows on whichever node you ask — `pkg/cluster/status.go` `FormatStatus` renders the local row, its two readiness lines, then the peer's. The harness picked the node to measure with:

```bash
for fw in "$FW0" "$FW1"; do
    if incus_cmd exec "$fw" -- cli -c "show chassis cluster status" 2>/dev/null \
        | grep -qi "primary"; then ACTIVE_FW="$fw"; break; fi
done
```

On node0's own output that matches **node1's** row, sets `ACTIVE_FW=$FW0` and breaks. `$FW0` always won, whoever was primary. There is no node token in the pattern at all, so it cannot tell whose row it matched — this is not a `secondary`-contains-`primary` substring artifact.

It **fails to a plausible value, not to an error**: the harness prints `active node = xpf-userspace-fw0` and runs. A secondary allocates nothing from the pool, so the analyzer refuses every cell as INVALID three layers later, and a wasted run under the shared cluster lock reads as a dataplane problem rather than a harness one. That is why "the harness now reports a node" proves nothing — it reported one before.

## The fix

The verdict and the selection move into `test/incus/newflow-ceiling-lib.sh`, anchored on the **local node's own row**: read `Node name: nodeN` (mirroring `parseLocalNodeID` in `pkg/upgrade/cluster_cli.go`), then require *that* node's row. Field 1 must **equal** the local token — equality, not a prefix, so `node1` cannot answer for `node10`, and the `Takeover ready:` / `Transfer ready:` (#103) and `Held secondary:` (#6495) lines, whose free text does contain the words "primary" and "secondary", are not rows.

The verdict is **total** — `PRIMARY` / `NOT-PRIMARY` / `UNKNOWN`, exactly one line, every path — so an unreadable status can never become a selection. `UNKNOWN` is kept apart from `NOT-PRIMARY` deliberately: same decision for the harness, different diagnosis for the operator ("I could not read the instrument" vs "I read it and this node is the standby").

## The residual the issue left open, decided

The old loop `break`ed on the first match, so with multiple RGs the first RG's row won silently. **PRIMARY now means primary for EVERY redundancy group the status reports.**

The measured path spans two of them on this cluster — reth0 (WAN) is `redundancy-group 1`, reth1 (LAN) is `redundancy-group 2`, per `docs/ha-cluster-userspace.conf` — so a node owning only one installs part of the flows and its counters describe half a measurement. That is the same wrong-node error one level in, and just as invisible: the run completes and prints numbers. There is deliberately **no `--rg` selector** — the harness reads one node's counters for the whole path, so "measure the node that owns RG N only" is not a question its output can answer.

Both nodes are now evaluated before deciding, which makes two previously unreachable states nameable:

* **no** node primary for every RG (a split cluster) — previously reported as "no node reports primary for the tested RG" with no evidence;
* **both** claiming to be (split-brain) — previously measured `$FW0` silently.

Every refusal prints both nodes' verdicts, because the cost of a wrong choice is a wasted run under the shared lock and the log has to be enough to tell the cases apart.

## Census — the issue's enumeration is a floor

The issue's sweep (`grep -q[i]? "primary"`) returned one hit. A wider sweep for anything that reads a cluster-status row for primary/secondary:

```
$ git grep -nE '(grep|awk)[^|]*\b(primary|secondary)\b' -- 'test/**/*.sh' 'scripts/**/*.sh'
38 sites
```

**33 carry a node token in the pattern.** Of the 5 that do not:

| site | what it is | verdict |
|---|---|---|
| `cluster-setup.sh:775` | `grep -q "primary\|secondary"` — a liveness wait ("has the cluster manager started emitting a status at all") | correctly node-AGNOSTIC; not a selection |
| `step1-capture.sh:151` | `recheck_primary` — first `primary` line, then `grep -qiE 'fw0|node0'` | anchors the RESULT; a non-row line makes it return non-zero → a spurious `suspect`. **Fail-closed** |
| `step1-capture.sh:185` | awk scoped to the RG0 block, result matched `^(node0|fw0)` | RG-scoped and result-anchored. **Fail-closed** |
| `step1-capture.sh:402-403` | first `primary` line pre/post, compared for drift | not a selection |
| `newflow-ceiling-harness.sh:145` | chooses which node to MEASURE | **the only one that both selects a node and fails open** |

Left the other four alone: no defect to point at, and rewriting a fail-closed capture driver inside this change would be unbound churn. The severity ranking in the issue was right even though its count was a floor.

**Latent hazard recorded while doing the census:** the readiness/held lines carry free text that can contain the words the patterns key on — e.g. `Takeover ready: no (peer secondary not ready to become primary)`. Any future unanchored match over this output can land on one. `HELD_AND_READINESS_TEXT_IGNORED` pins it with reason strings containing both words.

## Test plan

`test/incus/newflow-ceiling-selftest.sh` — 35 cells, hermetic (no incus, no cluster, no network) — wired into `make test-newflow-ceiling-lib` and `scripts/run-selftests.sh`. The harness also joins the shellcheck leg; its one pre-existing SC2034 (`offered` is write-only — the exit status is the liveness check, not the value) is silenced in place with that reason.

The ground truth is **node1 primary / node0 secondary**: the two nodes carry DIFFERENT states, which is the only shape in which the anchoring is observable. `UNANCHORED_CONTROL` runs the shipped `grep -qi "primary"` against the same bytes and `ANCHOR_DISAGREES` requires the new verdict to disagree with it, so "the anchor is the load-bearing difference" is measured rather than asserted.

**Mutation matrix.** Full selftest, no filter, fix committed BEFORE mutating, each cell restored with `git checkout --`, every cell reporting its collected count. Control **35 collected, 0 failed, rc 0**:

| mutation | failed | named failing cell(s) |
|---|---|---|
| harness reverts to the unanchored inline grep | 1 | `NO_UNANCHORED_GREP` |
| local node id never read | 12 | `WRONG_NODE_PEER_IS_PRIMARY`, `RIGHT_NODE_OWNS_EVERY_RG`, … |
| **over-reach**: never report PRIMARY | 6 | `RIGHT_NODE_OWNS_EVERY_RG`, `SELECT_THE_ACTUAL_PRIMARY`, … |
| any-RG instead of every-RG | 7 | `SPLIT_OWNS_ONLY_RG0`, `SPLIT_OWNS_ONLY_DATA_RGS`, … |
| empty status treated as a selection | 4 | `PROBE_BLIND_EMPTY`, `SELECT_WITH_PEER_UNREACHABLE`, … |
| split-brain accepted (first node wins) | 1 | `REFUSE_SPLIT_BRAIN` |
| refusal stops naming both nodes | 1 | `REFUSE_NAMES_BOTH_NODES` |
| node token matched as a PREFIX | 1 | `NODE10_IS_NOT_NODE1` |
| any node row answers for the local node | 10 | `WRONG_NODE_PEER_IS_PRIMARY`, `HELD_AND_READINESS_TEXT_IGNORED`, … |
| unparseable RG header no longer fails closed | 1 | `MALFORMED_RG_HEADER_NO_ROWS_AFTER` |
| stray row attributed to a group | 1 | `STRAY_ROW_ALONGSIDE_REAL_GROUPS` |
| stray-row check removed | 1 | `STRAY_ROW_ALONGSIDE_REAL_GROUPS` |
| missing local row in one RG ignored | 1 | `LOCAL_ROW_MISSING_IN_ONE_RG` |
| apostrophe inside the awk program | 68 | `NO_APOSTROPHE_IN_AWK` |

The over-reach row is what makes the first rows mean something: "never select the wrong node" is otherwise satisfied by selecting nothing. The last row's collected count is 77 rather than 35 because the lib does not parse at all — which is the point of that cell: the failure was already loud both times it happened while this was written, and what was missing was a line saying *which* line did it. `NO_APOSTROPHE_IN_AWK` also fails closed if its extraction returns nothing, so it cannot pass on an empty body.

**Three cells escaped the first run, and they are the part worth reading.**

1. `NODE10_IS_NOT_NODE1` listed the prefix-colliding row (`node10`) **before** the local row (`node1`), so a prefix match wrote "primary" and node1's own later row overwrote it with the correct "secondary". Last-write-wins made a broken anchor pass. Rows swapped so a prefix match now overwrites the right answer with the wrong one.
2. `ROW_BEFORE_ANY_RG_HEADER` has no redundancy groups at all, so the no-groups branch answered before the in-scope test was reached. `STRAY_ROW_ALONGSIDE_REAL_GROUPS` adds the same shape with real groups present — and a local row with no group in scope is now a fail-closed signal in its own right rather than a silently dropped line.
3. The outer `f[1] ~ /^node[0-9]+$/` test was subsumed by the `f[1] == local` equality one line in. Deleting it changed no cell because it could not. **Removed** rather than kept as decoration.

- [x] `bash scripts/run-selftests.sh` → **80 passed, 0 skipped, 0 failed**, post-merge with `origin/master`, `git merge-base --is-ancestor origin/master HEAD` verified.
- [x] `make test-newflow-ceiling-lib` green (analysis unittest + `newflow-gen` cargo + `bash -n` + the new selftest).
- [x] `go build ./... && go test -count=1 ./...` — no Go touched, run as the repo-wide audit.
- [ ] **No cluster smoke owed, and none is possible here.** The change is the harness's own preflight; the harness cannot be run to completion without a committed pool-mode SNAT rule and `newflow-gen` pushed to two hosts (`docs/userspace-newflow-ceiling.md` steps 2-4), and running it would take the shared lock to prove something the fixtures prove hermetically. The one thing a cluster run would add — that the fixture matches real `FormatStatus` output — is bound instead against the grammar's own producer (`pkg/cluster/status.go`) and its Go fixtures (`pkg/upgrade/cluster_cli_test.go`).

## One statement not individually mutation-bound

`cur = ""` in the malformed-`Redundancy group:`-header branch. The verdict for a malformed header is fail-closed `UNKNOWN`, which dominates any misattribution the reset would prevent, so no cell can isolate it. It is kept — it mirrors the reset the Go parser does, and it matters the moment anyone relaxes that `UNKNOWN` — and labelled in the source as defensive rather than proven. Stating it rather than letting a reviewer discover it.
