### PR TITLE
cluster: bind the heartbeat auth rejection reasons to their arms

### DIFF
--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -1290,6 +1290,24 @@ peer liveness (`lastSeen`) or drive election.
     BELOW the floor — keeps the generic wording deliberately: that one really is
     a replay of a retired incarnation.
 
+    **The `heartbeatAuthDecision` arms carry reasons too, and they are bound
+    (#6968).** The epoch override above only helps when `admitAuthed` ran, and
+    it does not run on a bad MAC (`if macOK { nonceFresh, epochReason = ... }`).
+    So a forged or tampered frame's reason comes from `heartbeatAuthDecision`'s
+    OWN `!macOK` arm — and that arm's correctness rests entirely on ARM ORDER:
+    a failed MAC leaves `nonceFresh` at the zero value `false`, so if the
+    `!macOK` arm is removed the frame falls through to `!nonceFresh` and an
+    attacker with the wrong PSK is reported as `stale nonce (replay)`. The
+    frame is refused either way — this is a MISATTRIBUTION, never a fail-open —
+    which is exactly why no admission test could see it. Measured on
+    `63ef1fad6`: `if !macOK` -> `if false` left `go vet` at rc=0 and the whole
+    package GREEN. `TestHeartbeatAuthDecisionReasonNamesTheArm_6968` now
+    asserts the exact reason per arm (and that the arms' strings are pairwise
+    DISTINCT, or the assertions would be vacuous), and
+    `TestForgedHeartbeatIsNotReportedAsReplay_6968` binds the same property
+    through a genuinely forged frame so `macOK` is derived rather than
+    hand-set. **Adding an arm here means adding its reason to that table.**
+
     All five are rendered on all three surfaces
     (`FormatInformation`, `FormatStatistics`, `FormatControlPlaneStatistics`)
     and bound there by `TestEveryEpochCounterIsRendered_6669`, which drives each

--- a/pkg/cluster/heartbeat_auth_test.go
+++ b/pkg/cluster/heartbeat_auth_test.go
@@ -476,3 +476,132 @@ func TestManagerHeartbeatPeerAuthSeen(t *testing.T) {
 		t.Error("#5086: a freshly installed receiver must inherit the armed guard")
 	}
 }
+
+// #6968: the reason a rejected heartbeat carries must NAME THE ARM that
+// refused it, and nothing bound that.
+//
+// THE SHAPE OF THE DEFECT IS MISATTRIBUTION, NOT ADMISSION. A forged or
+// tampered frame is rejected either way — this was never a fail-open — so a
+// test that asserts "rejected" passes identically against the working code and
+// against the broken code. The only observable that separates them is WHICH
+// reason string comes back, and until now no test in this package asserted any
+// of them: `grep -rn "hmac verification failed" pkg/cluster/*_test.go` returned
+// zero hits.
+//
+// WHY THE ARM CAN VANISH SILENTLY. `heartbeatAuthDecision`'s correctness here
+// rests entirely on ARM ORDER. The caller computes
+//
+//	if macOK { nonceFresh, epochReason = r.auth.admitAuthed(...) }
+//
+// so a frame that fails its MAC leaves `nonceFresh` at the zero value FALSE and
+// `epochReason` empty. Delete or disable the `!macOK` arm and the frame falls
+// through to `!nonceFresh`, and a forged frame — a wrong key, a flipped byte, an
+// active on-link attacker — is reported to the operator as `stale nonce
+// (replay)`. The epoch gate's `epochReason` override cannot save it: on a bad
+// MAC `admitAuthed` never runs, so there is no epoch reason to prefer.
+//
+// Measured on origin/master 63ef1fad6: changing `if !macOK` to `if false` left
+// `go vet` at rc=0 and the ENTIRE pkg/cluster suite GREEN. That is the gap this
+// test closes; it reds that mutation by name.
+//
+// The operator cost is the point. "Replay" points at a retired peer incarnation
+// and the anti-replay machinery; a bad MAC points at a key mismatch or an
+// attacker holding the wrong PSK. Sending someone to audit nonces while an
+// on-link forger is active is the failure this reason exists to prevent.
+func TestHeartbeatAuthDecisionReasonNamesTheArm_6968(t *testing.T) {
+	const (
+		reasonBadMAC  = "hmac verification failed"
+		reasonReplay  = "stale nonce (replay)"
+		reasonMissing = "missing auth trailer (enforced: peer previously authenticated)"
+	)
+	// The binding is only as good as the strings being DIFFERENT. If two arms
+	// ever returned the same text, every assertion below would still pass while
+	// the arms became indistinguishable again — the exact property under test.
+	for _, pair := range [][2]string{
+		{reasonBadMAC, reasonReplay},
+		{reasonBadMAC, reasonMissing},
+		{reasonReplay, reasonMissing},
+	} {
+		if pair[0] == pair[1] {
+			t.Fatalf("two arms share the reason %q; the arms are indistinguishable "+
+				"and every assertion in this test is vacuous", pair[0])
+		}
+	}
+
+	cases := []struct {
+		name                                                string
+		keyConfigured, present, macOK, nonceFresh, peerSeen bool
+		wantAccept                                          bool
+		wantReason                                          string
+	}{
+		{"no-key/legacy", false, false, false, false, false, true, ""},
+		{"no-key/authed-frame", false, true, false, false, false, true, ""},
+		{"key/good-hmac-fresh", true, true, true, true, false, true, ""},
+
+		// THE CELL THIS TEST EXISTS FOR. macOK=false forces nonceFresh=false in
+		// the real caller, so both rejecting arms are live at once and only the
+		// ORDER decides the reason. `if !macOK` -> `if false` reds here.
+		{"key/bad-hmac", true, true, false, false, false, false, reasonBadMAC},
+		// ...and its discriminating partner: a frame whose MAC is GOOD and whose
+		// nonce is stale must still say replay. Without this row the test could
+		// be satisfied by returning the bad-MAC reason unconditionally.
+		{"key/good-hmac-replay", true, true, true, false, true, false, reasonReplay},
+
+		{"key/legacy-peer-not-yet-authed", true, false, false, false, false, true, ""},
+		{"key/legacy-after-peer-authed", true, false, false, false, true, false, reasonMissing},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := heartbeatAuthDecision(tc.keyConfigured, tc.present, tc.macOK, tc.nonceFresh, tc.peerSeen)
+			if got != tc.wantAccept {
+				t.Fatalf("accept = %v (reason %q), want %v", got, reason, tc.wantAccept)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q. The frame's admission is unchanged either "+
+					"way — this is the operator-facing CAUSE, and a wrong one sends them "+
+					"hunting the wrong fault (#6968)", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestForgedHeartbeatIsNotReportedAsReplay_6968 binds the same property through
+// a REAL forged frame rather than hand-set booleans.
+//
+// `macOK` here is DERIVED — the frame is signed with an attacker's key and
+// verified against the real one — so this covers the frame -> trailer -> MAC ->
+// reason chain, not just the decision function's truth table. The hand-set
+// version cannot see a regression that makes `verifyHeartbeatMAC` succeed on a
+// forged frame; this one reds on both that and on the arm removal.
+//
+// `nonceFresh` is passed FALSE because that is what the production caller
+// necessarily passes when the MAC fails (`admitAuthed` is called only under
+// `if macOK`). Passing true here would describe a state the receiver cannot
+// produce and would let the bad-MAC arm look load-bearing when it is not.
+func TestForgedHeartbeatIsNotReportedAsReplay_6968(t *testing.T) {
+	realKey := []byte("real-cluster-psk")
+	forged := MarshalHeartbeatAuth(samplePkt(), []byte("attacker-psk"), 9, 1)
+
+	_, _, present := heartbeatAuthTrailer(forged)
+	macOK := present && verifyHeartbeatMAC(forged, realKey)
+	if !present {
+		t.Fatal("forged frame carries no auth trailer — fixture does not reach the arm")
+	}
+	if macOK {
+		t.Fatal("forged frame verified under the real key — HMAC broken")
+	}
+
+	accept, reason := heartbeatAuthDecision(true, present, macOK, false, true)
+	if accept {
+		t.Fatalf("forged heartbeat accepted (reason %q)", reason)
+	}
+	if reason == "stale nonce (replay)" {
+		t.Fatal("a FORGED heartbeat is reported as `stale nonce (replay)`. The frame is " +
+			"still refused, so admission is unaffected — but the operator is pointed at a " +
+			"retired peer incarnation and the anti-replay machinery instead of at a key " +
+			"mismatch or an on-link attacker holding the wrong PSK (#6968)")
+	}
+	if reason != "hmac verification failed" {
+		t.Fatalf("reason = %q, want %q", reason, "hmac verification failed")
+	}
+}


### PR DESCRIPTION
Closes #6968

## First, a correction to the issue

The issue's summary says `heartbeatAuthDecision` **"attributes a forged or tampered heartbeat to `stale nonce (replay)`"**, in the present tense. **That is not true on master.** Verified before writing anything — `heartbeat.go:1160-1166`:

```go
if present {
    if !macOK {
        return false, "hmac verification failed"   // <- reached first
    }
    if !nonceFresh {
        return false, "stale nonce (replay)"
    }
```

The `!macOK` arm precedes `!nonceFresh`, so a forged frame today reports `hmac verification failed`, correctly. The issue's *"Why no test sees it"* section is the accurate part; its summary describes the **post-mutation** behaviour.

So this change is **tests + docs, no production edit**. Claiming a live misattribution and "fixing" correct code would have been wrong.

## What is actually broken

**Nothing keeps the arm there.** Reproduced the issue's mutation on `63ef1fad6`: changing `if !macOK` to `if false` leaves `go vet` at **rc=0** and the **entire `pkg/cluster` suite GREEN**. And `grep -rn "hmac verification failed" pkg/cluster/*_test.go` → **zero hits**.

**Why no existing test can see it.** The defect shape is **misattribution, not admission**. A forged frame is refused either way — never a fail-open — so every assertion of the form *"the frame was rejected"* passes identically against working and broken code. `TestHeartbeatAuthDecision` asserted only that a rejection carries a **non-empty** reason, and both arms do.

**Why the arm can vanish silently.** Correctness rests entirely on **arm ORDER**. The caller computes `nonceFresh` only under `if macOK`:

```go
if macOK { nonceFresh, epochReason = r.auth.admitAuthed(...) }
```

so a failed MAC leaves `nonceFresh` at the zero value `false` and `epochReason` empty. Drop the `!macOK` arm and the frame falls through to `!nonceFresh` — a wrong PSK, a flipped byte, an active on-link forger, all reported as a **replay**. The #6669 `epochReason` override cannot cover it: on a bad MAC `admitAuthed` never runs, so there is no epoch reason to prefer.

The operator cost is the whole point: "replay" sends someone to the anti-replay machinery and retired peer incarnations; a bad MAC means a key mismatch or an attacker.

## The binding

`TestHeartbeatAuthDecisionReasonNamesTheArm_6968` asserts the **exact reason for every row**, not just acceptance. Two design points:

- **The discriminating pair.** A bad MAC must say `hmac verification failed` *and* a good MAC with a stale nonce must say `stale nonce (replay)`. Without the second row the test would be satisfied by returning the bad-MAC reason unconditionally.
- **A distinctness precondition.** It asserts the three arm strings are pairwise **DISTINCT** first. Two arms sharing text would leave every other assertion passing while restoring exactly the indistinguishability under test — see cell **M3**.

`TestForgedHeartbeatIsNotReportedAsReplay_6968` binds the same property through a **real forged frame**, so `macOK` is *derived* from `verifyHeartbeatMAC` rather than hand-set. It covers frame → trailer → MAC → reason, and would also red a regression that made a forged frame verify. It passes `nonceFresh=false` because that is what the production caller necessarily passes on a failed MAC; passing `true` would describe a state the receiver cannot produce and would make the arm look load-bearing when it is not.

## Mutation matrix

Committed before mutating. Gated on a **named failing test** and tests-collected > 0; `vet` reported separately so a build break is a VOID cell, not a red.

| Cell | Mutation | vet | collected | named failing | which |
|---|---|---|---|---|---|
| **C0** | control | 0 | 9 | **0** | — |
| **M1** | `if !macOK` → `if false` (the issue's own) | 0 | 9 | 2 | both |
| **M2** | the two arms **reordered** — the misattribution reached a second way | 0 | 9 | 2 | both |
| **M3** | the two arms given the **same string** | 0 | 9 | 2 | both |
| **M4** | reword the replay arm | 0 | 9 | 1 | table |
| **M5** | reword the downgrade arm | 0 | 9 | 1 | table |

M2 matters most: it produces the exact behaviour the issue *describes*, and reds.

## Validation

`go test -count=1 ./...` → rc=0, 0 FAIL.

**No cluster smoke owed, and that is checkable rather than asserted.** This change touches only `heartbeat_auth_test.go` and `README.md`. Building `cmd/xpfd` from master's `pkg/cluster/` and from this branch's, **from the same directory** (so `-trimpath`-style path differences cannot confound it), gives **byte-identical** binaries — one distinct sha256 across the two. No runtime code moved, so `make test-failover` would be exercising an unchanged binary.

## Scope

This PR closes **#6968 only**. #6967 and #6969 are a separate, coupled design — see the lane report; #6968 is explicitly non-blocking for them (pre-existing #4107 code, a different function, and it touches none of the epoch truth table).

Refs #4107, #6669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqdwwcwWUo7FyCQSCSUh9t