### PR TITLE
test(api): bind three unbound arms of the stale-cert diagnostic (#7043, #7044, #7045)

### DIFF
--- a/docs/log/7043.md
+++ b/docs/log/7043.md
@@ -1,0 +1,88 @@
+# #7043 / #7044 / #7045 — three unbound arms of the stale-cert diagnostic
+
+The hostile review of #6827 ran a 28-cell deletion sweep over that PR's
+`pkg/api` delta: **24 RED, 4 GREEN**. These are three of the four survivors.
+
+In every case the code is **correct**. What was missing is any assertion that
+keeps it correct, so a later edit could have flipped any of the three with the
+whole suite green — in `pkg/api` *and* `pkg/daemon`.
+
+They are one file because they are one function's terminal ladder —
+`WarnStaleMgmtCertForHostName` → `warnCertNoSANs` → `warnStaleHostName` — and
+every cell has to distinguish *"the ladder stopped here"* from *"the ladder ran
+on"*, which is a property of the ladder rather than of any single rung.
+
+## #7043 — the unparseable-certificate arm
+
+`return true` → `return false` was a **total survivor**. The contract is stated
+two lines above the return: re-parsing will fail identically, so the question is
+reported ANSWERED rather than leaving the caller to retry forever.
+
+The fixture uses bytes that cannot begin a DER SEQUENCE (`ff ff ff ff`), not a
+truncated real certificate, so the parse failure is unambiguous and the cell
+cannot pass because some *other* arm returned first.
+
+It also asserts that **no lower-rung warning appears**: everything below
+dereferences a leaf that does not exist, so a warning from below is proof the
+arm did not return — an assertion the boolean alone cannot make.
+
+## #7044 — the no-SANs arm is terminal at the RENAME call site too
+
+Neutralising the early return was a **total survivor**. The property IS bound —
+at the **sibling** call site — and the identical shape here was covered by
+nothing. That is the failure mode worth naming: a guard that exists once and is
+assumed to cover both of its call sites.
+
+`generateSelfSignedCertAt` always mints SANs, so it cannot produce this fixture.
+That is *why* the arm had no fixture. The test mints a leaf directly and
+**asserts `certHasNoSANs` on it before using it** — a fixture that quietly grew
+a SAN would exercise a different arm and still pass.
+
+The behaviour is documented as deliberate: with no SANs at all, the per-identity
+warnings would each report "does not cover X" for a certificate that covers no X
+whatsoever, burying the actual finding under a list of symptoms.
+
+## #7045 — the `hostName == bindHost` suppression conjunct
+
+Dropping it was green in **BOTH polarities** of the observable — the rename path
+goes from zero warnings to one, the load path from one to two, and no cell
+noticed either direction.
+
+The fixture makes `hostName` EQUAL `bindHost` and the certificate cover
+**neither**, so every other early return in `warnStaleHostName` is passed and
+the conjunct is the only thing that can suppress. With the certificate covering
+the host, `certCoversHost` would return first and the conjunct would be
+**dominated** — the cell would be measuring nothing.
+
+## Every cell carries the assertion its own failure mode needs
+
+Not just the one the issue names. This is the part that stops the fix being
+"green in a new way":
+
+| cell | the extra assertion | what it stops |
+|---|---|---|
+| #7043 | no lower-rung warning | an arm that "returns true" by falling through |
+| #7044 | the no-SANs finding IS reported | a fix that emits nothing satisfying the suppression check |
+| #7045 | a DIFFERENT uncovered host name still warns | deleting the whole diagnostic passing the suppression check |
+
+## Mutation matrix
+
+`go test -count=1 -run '7043|7044|7045' -v ./pkg/api/`. **3 collected, 0 build
+errors in every cell.**
+
+| cell | mutation | failed | named failing test |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | unparseable arm `return true` → `false` | 1 | `TestUnparseableCertReportsTheQuestionAnswered_7043` |
+| M2 | no-SANs early return neutralised | 1 | `TestNoSANsIsTerminalAtTheRenameCallSite_7044` |
+| M3 | `\|\| hostName == bindHost` conjunct dropped | 1 | `TestHostNameEqualToBindHostIsSuppressed_7045` |
+| restored | none | 0 | — |
+
+Each mutation reds **exactly one** cell, so none is masking another — which
+matters here because all three arms live in the same call chain and a compound
+mutation could not have shown it.
+
+## The fourth survivor
+
+The sweep found four. The remaining one is not fixed here; #7039, #7041 and
+#7047 track other findings from the same review of that file.

--- a/pkg/api/tls_stale_cert_unbound_arms_7043_test.go
+++ b/pkg/api/tls_stale_cert_unbound_arms_7043_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Three arms of the #5719/#6827 stale-management-cert diagnostic that the
+// hostile review of #6827 found UNBOUND — the code is correct, and a 28-cell
+// deletion sweep over that PR's pkg/api delta left these four green.
+//
+// They are one file because they are one function's terminal ladder
+// (Server.WarnStaleMgmtCertForHostName -> warnCertNoSANs -> warnStaleHostName)
+// and each cell has to distinguish "the ladder stopped here" from "the ladder
+// ran on", which is a property of the ladder, not of any single rung.
+
+// certNoSANs mints a self-signed leaf carrying NO subjectAltName at all — no
+// DNSNames, no IPAddresses. generateSelfSignedCertAt cannot produce this
+// (it always mints SANs), which is exactly why the arm that handles it had no
+// fixture (#7044).
+func certNoSANs(t *testing.T, commonName string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(7044),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse minted certificate: %v", err)
+	}
+	if !certHasNoSANs(leaf) {
+		t.Fatalf("fixture is wrong: the minted certificate carries SANs (dns=%v ip=%v), "+
+			"so it cannot exercise the no-SANs arm", leaf.DNSNames, leaf.IPAddresses)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}
+
+// #7043: an unparseable leaf must report the question ANSWERED (true), not
+// unanswered.
+//
+// `return true` -> `return false` was a total survivor in both pkg/api and
+// pkg/daemon. The contract is stated two lines above the return — "re-parsing it
+// later will fail identically, so report it answered rather than making the
+// caller retry forever" — and a flip turns the caller into a permanent retry
+// loop against a certificate that will never parse.
+func TestUnparseableCertReportsTheQuestionAnswered_7043(t *testing.T) {
+	// Deliberately not a truncated real certificate: bytes that cannot begin a
+	// DER SEQUENCE make the parse failure unambiguous, so the cell cannot pass
+	// because some other arm returned first.
+	garbage := tls.Certificate{Certificate: [][]byte{{0xff, 0xff, 0xff, 0xff}}}
+	s := legServing(garbage, "127.0.0.1:8443")
+
+	var answered bool
+	out := captureWarn(t, func() { answered = s.WarnStaleMgmtCertForHostName("new-fw") })
+
+	if !answered {
+		t.Error("WarnStaleMgmtCertForHostName returned false for a leg serving an UNPARSEABLE " +
+			"certificate; the question was reached and re-parsing will fail identically, so the " +
+			"caller is left retrying forever (#7043)")
+	}
+	// The ladder must STOP here. Anything below dereferences a leaf that does
+	// not exist, so a warning from a lower rung means the arm did not return.
+	if strings.Contains(out, "does not cover") {
+		t.Errorf("a per-identity warning was emitted for an unparseable certificate, so the "+
+			"terminal arm did not return: %s", out)
+	}
+}
+
+// #7044: the no-SANs arm is terminal at the RENAME call site too, not only on
+// the load path.
+//
+// Neutralising the early return was a total survivor: the property IS bound, at
+// the SIBLING call site, and the identical shape here was covered by nothing.
+// The behaviour is documented as deliberate at server.go: with no SANs at all,
+// the per-identity warnings would each report "does not cover X" for a
+// certificate that covers no X whatsoever, burying the actual finding under a
+// list of symptoms.
+func TestNoSANsIsTerminalAtTheRenameCallSite_7044(t *testing.T) {
+	s := legServing(certNoSANs(t, "old-fw"), "127.0.0.1:8443")
+
+	var answered bool
+	out := captureWarn(t, func() { answered = s.WarnStaleMgmtCertForHostName("new-fw") })
+
+	if !answered {
+		t.Error("WarnStaleMgmtCertForHostName returned false for a no-SANs certificate (#7044)")
+	}
+	// POSITIVE CONTROL. Without it a fix that emitted NOTHING would satisfy the
+	// suppression assertion below, and the arm would be "bound" by a cell that
+	// cannot tell silence from correctness.
+	if !strings.Contains(out, "carries NO subjectAltName") {
+		t.Errorf("the no-SANs finding was not reported at all: %s", out)
+	}
+	if strings.Contains(out, "does not cover") {
+		t.Errorf("a per-identity `does not cover` warning was emitted alongside the no-SANs "+
+			"finding, burying it under a list of symptoms — the arm is not terminal here (#7044): %s", out)
+	}
+}
+
+// #7045: the `hostName == bindHost` conjunct in warnStaleHostName.
+//
+// Dropping it was green in BOTH polarities of the observable — the rename path
+// goes from zero warnings to one, and no cell noticed either direction. A
+// suppression conjunct going wrong is precisely how a diagnostic turns into
+// duplicate noise, and duplicate noise is how the real finding gets skimmed
+// past.
+//
+// The fixture makes hostName EQUAL bindHost and the certificate cover neither,
+// so every other early return in warnStaleHostName is passed: the conjunct is
+// the only thing that can suppress the warning. That is what makes the cell
+// sensitive — with the certificate covering the host, `certCoversHost` would
+// return first and the conjunct would be dominated.
+func TestHostNameEqualToBindHostIsSuppressed_7045(t *testing.T) {
+	const shared = "fw.example.net"
+	// Covers something else entirely, so certCoversHost(leaf, shared) is false.
+	cert := mintCert(t, "other-fw.example.net", "10.9.9.9")
+	s := legServing(cert, shared+":8443")
+
+	out := captureWarn(t, func() { s.WarnStaleMgmtCertForHostName(shared) })
+
+	if strings.Contains(out, "does not cover the current host-name") {
+		t.Errorf("the host-name warning fired for a host name EQUAL to the bind host; the same "+
+			"identity is reported twice, once as bind host and once as host name (#7045): %s", out)
+	}
+
+	// The other polarity, so the suppression cannot be "warns about nothing".
+	// A DIFFERENT host name, uncovered, must still warn — otherwise deleting
+	// the whole warning would pass the assertion above.
+	out2 := captureWarn(t, func() { s.WarnStaleMgmtCertForHostName("renamed-fw.example.net") })
+	if !strings.Contains(out2, "does not cover the current host-name") {
+		t.Errorf("a host name DIFFERENT from the bind host and uncovered by the certificate drew "+
+			"no warning, so the suppression above is indistinguishable from the diagnostic being "+
+			"dead: %s", out2)
+	}
+}


### PR DESCRIPTION
The hostile review of #6827 ran a 28-cell deletion sweep over that PR's `pkg/api` delta: **24 RED, 4 GREEN**. These are three of the four survivors.

In every case the code is **correct**. What was missing is any assertion that keeps it correct — so a later edit could have flipped any of the three with the whole suite green, in `pkg/api` *and* `pkg/daemon`.

One file, because they are one function's terminal ladder — `WarnStaleMgmtCertForHostName` → `warnCertNoSANs` → `warnStaleHostName` — and every cell has to distinguish *"the ladder stopped here"* from *"the ladder ran on"*, which is a property of the ladder rather than of any single rung.

## #7043 — the unparseable-certificate arm

`return true` → `return false` was a **total survivor**. The contract is stated two lines above the return: re-parsing will fail identically, so the question is reported ANSWERED rather than leaving the caller retrying forever.

The fixture is bytes that cannot begin a DER SEQUENCE (`ff ff ff ff`), not a truncated real certificate, so the parse failure is unambiguous and the cell cannot pass because some *other* arm returned first. It also asserts **no lower-rung warning appears** — everything below dereferences a leaf that does not exist, so a warning from below proves the arm did not return, which the boolean alone cannot show.

## #7044 — the no-SANs arm is terminal at the RENAME call site too

Neutralising the early return was a **total survivor**. The property IS bound — at the **sibling** call site — and the identical shape here was covered by nothing. That is the failure mode worth naming: a guard that exists once and is assumed to cover both of its call sites.

`generateSelfSignedCertAt` always mints SANs, so it cannot produce this fixture — which is *why* the arm had none. The test mints a leaf directly and **asserts `certHasNoSANs` on it before using it**: a fixture that quietly grew a SAN would exercise a different arm and still pass.

## #7045 — the `hostName == bindHost` suppression conjunct

Dropping it was green in **both polarities** — the rename path goes from zero warnings to one, the load path from one to two, and no cell noticed either direction.

The fixture makes `hostName` EQUAL `bindHost` and the certificate cover **neither**, so every other early return in `warnStaleHostName` is passed and the conjunct is the only thing that can suppress. With the certificate covering the host, `certCoversHost` would return first and the conjunct would be **dominated** — the cell would measure nothing.

## Every cell carries the assertion its own failure mode needs

Not only the one its issue names:

| cell | the extra assertion | what it stops |
|---|---|---|
| #7043 | no lower-rung warning | an arm that "returns true" by falling through |
| #7044 | the no-SANs finding IS reported | a fix that emits nothing satisfying the suppression check |
| #7045 | a DIFFERENT uncovered host name still warns | deleting the whole diagnostic passing the suppression check |

## Mutation matrix

`go test -count=1 -run '7043|7044|7045' -v ./pkg/api/`. **3 collected, 0 build errors in every cell.**

| cell | mutation | failed | named failing test |
|---|---|---|---|
| control | none | 0 | — |
| M1 | unparseable arm `return true` → `false` | 1 | `TestUnparseableCertReportsTheQuestionAnswered_7043` |
| M2 | no-SANs early return neutralised | 1 | `TestNoSANsIsTerminalAtTheRenameCallSite_7044` |
| M3 | `\|\| hostName == bindHost` conjunct dropped | 1 | `TestHostNameEqualToBindHostIsSuppressed_7045` |
| restored | none | 0 | — |

Each mutation reds **exactly one** cell, so none masks another — which matters here because all three arms are in the same call chain and a compound mutation could not have shown it.

## The fourth survivor

Not fixed here. #7039, #7041 and #7047 track other findings from the same review of this file.

---

Test-only change; no production code touched. `./pkg/api/` green. Repo-wide `go test -count=1 ./...` posted as a comment when it finishes.

Docs: `docs/log/7043.md`.

Closes #7043
Closes #7044
Closes #7045
