### PR TITLE
config: stop apply-macro / apply-groups-except compiling as zone members (#7029)

### DIFF
--- a/docs/log/7029.md
+++ b/docs/log/7029.md
@@ -1,0 +1,94 @@
+# #7029 — Junos meta statements compiling as phantom zone members
+
+Junos permits `apply-groups`, `apply-groups-except` and `apply-macro` at **any**
+hierarchy point. `ExpandGroups` removes only `apply-groups`; the other two
+survive expansion as live nodes. In the
+`security zones security-zone <z> interfaces` member slot they were read as
+interface NAMES, compiled as phantom members, and the zone-interface-DEFINED
+gate rejected the commit:
+
+```
+REJECT security zone "Z" references interface "apply-groups-except",
+which is not defined under `interfaces` ...
+```
+
+Fail-LOUD over-rejection, not a silent membership loss — but it refuses a legal
+Junos config, and the operator's only clue names a keyword they never intended
+as an interface.
+
+`zoneInterfaceNonMemberToken` already knew these three keywords. The member walk
+was the one place that did not ask.
+
+## Two things measured that changed the fix
+
+### 1. The guard has to be on the node's OWN name
+
+The first attempt guarded only the child loop. It **changed nothing** — at the
+call site the member nodes come straight from `zoneInterfaceMemberNodes`, so
+`apply-groups-except G;` arrives as `iface` itself, not as a child. The reject
+stayed exactly in place.
+
+Had the probe not been re-run after that edit, the fix would have shipped as a
+no-op with a passing description.
+
+### 2. The second guard was redundant, and was removed rather than described
+
+With the head guard in place, the child-loop guard looked like a second,
+independent check. It is not:
+
+- **Reached?** Yes. Instrumenting it and running a fixture with a meta statement
+  nested under a member (`ge-0/0/0.0 { apply-macro M { … } }`) hits it. Across
+  the rest of the `pkg/config` suite it gets **zero** hits.
+- **Load-bearing?** No. Deleting it, and changing its `continue` to `break`,
+  both leave every cell green — because the recursion calls
+  `zoneInterfaceMembers` on the child and lands right back on the head guard.
+
+So it was a redundant branch dressed up as a guard. Removed. The doc comment now
+says one guard and why the nested case needs no second one, instead of claiming
+two.
+
+The nested fixture is **kept** — the shape must keep compiling however the walk
+is later restructured — but it is documented as a regression test, not as the
+thing that binds a second guard.
+
+## Census, kept as a guard
+
+The issue named one slot. Eight slots read their children as instance NAMES, so
+eight were measured. At `origin/master`:
+
+| slot | `apply-macro` in the name position |
+|---|---|
+| **zone interfaces** | **REJECTED** |
+| security zones (zone-name slot) | accepted |
+| security policies from-zone | accepted |
+| address-book entries | accepted |
+| applications | accepted |
+| interfaces stanza | accepted |
+| firewall filters | accepted |
+| routing-instances | accepted |
+
+Exactly one. That asymmetry is also what proves the table is not blind: a census
+in which nothing ever fails is indistinguishable from a census that cannot see.
+
+## Mutation matrix
+
+`go test -count=1 -run 7029 -v ./pkg/config/`. **14 collected, 0 build errors in
+every cell.**
+
+| cell | mutation | failed | named failing tests |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | walk reverted to master | 7 | all three |
+| M2 | head guard returns the node's own name instead of nil | 6 | the member table + the census |
+| M3 | predicate narrowed to `apply-groups` only | 7 | all three |
+| M4 | predicate always false | 7 | all three |
+| restored | none | 0 | — |
+
+> **Method note.** The first M3 was a **VOID cell**: the edit matched a `case`
+> line that appears in *both* `zoneInterfaceApplyMetaKeyword` and its sibling
+> `zoneInterfaceNonMemberToken`, and `rindex` selected the sibling. It reported
+> 0 failed — indistinguishable from a genuine escape — and would have been
+> written up as "the predicate is unbound". Re-run with the edit anchored inside
+> the target function, it reds 7. *Which site was mutated* is a separate
+> question from *did it red*, and only the first one is answered by the
+> harness's own output.

--- a/pkg/config/apply_meta_in_named_slot_7029_test.go
+++ b/pkg/config/apply_meta_in_named_slot_7029_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7029: Junos permits `apply-groups`, `apply-groups-except` and `apply-macro`
+// at ANY point in the hierarchy. ExpandGroups removes only `apply-groups` — the
+// other two survive expansion as live nodes — so in a slot whose children are
+// read as NAMES they compiled as phantom instances.
+//
+// In the `security zones security-zone <z> interfaces` member slot that made
+// the zone-interface-DEFINED gate reject the commit:
+//
+//	REJECT security zone "Z" references interface "apply-groups-except",
+//	which is not defined under `interfaces` ...
+//
+// Fail-LOUD over-rejection rather than a silent membership loss — but it
+// refuses a legal Junos config, and the operator's only clue names a keyword
+// they did not intend as an interface.
+func TestApplyMetaInZoneInterfaceMemberSlotCompiles_7029(t *testing.T) {
+	for _, meta := range []string{
+		"apply-groups-except G;",
+		"apply-macro M { key value; }",
+		// Nested body, since apply-macro's contents are arbitrary and the walk
+		// must not descend into them looking for members either.
+		"apply-macro M { ge-0/0/9.0 something; }",
+	} {
+		t.Run(meta, func(t *testing.T) {
+			src := `
+interfaces { ge-0/0/0 { unit 0 { family inet { address 10.0.0.1/24; } } } }
+security { zones { security-zone Z { interfaces {
+` + meta + `
+  ge-0/0/0.0;
+} } } }
+`
+			tree, errs := NewParser(src).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse: %v", errs)
+			}
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig REJECTED a legal Junos config carrying %q in the member "+
+					"slot: %v", meta, err)
+			}
+			zone := cfg.Security.Zones["Z"]
+			if zone == nil {
+				t.Fatal("zone Z did not compile")
+			}
+			// POSITIVE CONTROL. Skipping the meta statement must not skip the
+			// real member beside it — a walk that returned early on the first
+			// meta node would satisfy the "no rejection" assertion above while
+			// emptying the zone, which is a security-boundary loss.
+			want := []string{"ge-0/0/0.0"}
+			if len(zone.Interfaces) != 1 || zone.Interfaces[0] != want[0] {
+				t.Errorf("zone Z Interfaces = %v, want %v — the real member must survive beside "+
+					"the meta statement", zone.Interfaces, want)
+			}
+			// And the meta keyword itself must not have become a member under
+			// any spelling.
+			for _, name := range zone.Interfaces {
+				if strings.HasPrefix(name, "apply-") {
+					t.Errorf("zone Z carries %q as an interface member (#7029)", name)
+				}
+			}
+		})
+	}
+}
+
+// The CENSUS, kept as a guard rather than reported once and discarded.
+//
+// The issue named one slot. Every slot below reads its children as instance
+// NAMES, so every one could carry the same defect; measured at
+// `origin/master`, exactly ONE did — which is what makes this table a real
+// negative rather than an untested assumption.
+//
+// It is also the proof that the table is not blind: run it against master's
+// compiler_security_zones.go and the zone-interfaces row REJECTS while the
+// other seven accept. A census in which nothing ever fails is indistinguishable
+// from a census that cannot see.
+func TestApplyMetaIsAcceptedInEveryNamedInstanceSlot_7029(t *testing.T) {
+	for name, src := range map[string]string{
+		"zone interfaces": `
+interfaces { ge-0/0/0 { unit 0 { family inet { address 10.0.0.1/24; } } } }
+security { zones { security-zone Z { interfaces { apply-macro M { k v; } ge-0/0/0.0; } } } }
+`,
+		"security zones (zone-name slot)": `
+security { zones { apply-macro M { k v; } security-zone Z { } } }
+`,
+		"security policies from-zone": `
+security { zones { security-zone A { } security-zone B { } }
+  policies { apply-macro M { k v; }
+    from-zone A to-zone B { policy P { match { source-address any; destination-address any; application any; } then { permit; } } } } }
+`,
+		"address-book entries": `
+security { zones { security-zone A { address-book { apply-macro M { k v; } address H 10.0.0.1/32; } } } }
+`,
+		"applications": `
+applications { apply-macro M { k v; } application APP { protocol tcp; destination-port 80; } }
+`,
+		"interfaces stanza": `
+interfaces { apply-macro M { k v; } ge-0/0/0 { unit 0 { family inet { address 10.0.0.1/24; } } } }
+`,
+		"firewall filters": `
+firewall { family inet { filter F { apply-macro M { k v; } term T { then accept; } } } }
+`,
+		"routing-instances": `
+routing-instances { apply-macro M { k v; } RI { instance-type virtual-router; } }
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			tree, errs := NewParser(src).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse: %v", errs)
+			}
+			if _, err := CompileConfig(tree); err != nil {
+				t.Errorf("`apply-macro` in the %s slot rejects the commit; Junos permits it at any "+
+					"hierarchy point and ExpandGroups does not remove it (#7029): %v", name, err)
+			}
+		})
+	}
+}
+
+// A meta statement nested UNDER a member, which reaches a different guard.
+//
+// A meta statement reaches the guard by two different routes, and this fixture
+// is the second: at the top of the stanza it arrives as the member NODE, and
+// nested under a real member it arrives as a CHILD and comes back to the same
+// guard through the recursion.
+//
+// The distinction was measured rather than assumed. A second check in the child
+// loop was written first — "two guards" — then instrumented: it IS reached by
+// this fixture, and removing it changes no outcome, because the recursion lands
+// on the head guard anyway. It was a redundant branch dressed up as a guard and
+// was removed. This test stays: the nested shape must keep compiling however
+// the walk is later restructured.
+func TestApplyMetaNestedUnderAMemberCompiles_7029(t *testing.T) {
+	src := `
+interfaces { ge-0/0/0 { unit 0 { family inet { address 10.0.0.1/24; } } } }
+security { zones { security-zone Z { interfaces {
+  ge-0/0/0.0 { apply-macro M { key value; } }
+} } } }
+`
+	tree, errs := NewParser(src).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig REJECTED a member carrying a nested apply-macro: %v", err)
+	}
+	zone := cfg.Security.Zones["Z"]
+	if zone == nil {
+		t.Fatal("zone Z did not compile")
+	}
+	// The member must survive AND the macro must not have become a second one.
+	if len(zone.Interfaces) != 1 || zone.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("zone Z Interfaces = %v, want [ge-0/0/0.0] — a nested meta statement must be "+
+			"skipped without taking its parent member with it (#7029)", zone.Interfaces)
+	}
+}

--- a/pkg/config/compiler_security_zones.go
+++ b/pkg/config/compiler_security_zones.go
@@ -391,6 +391,13 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 // member node's own KEYS instead (zoneInterfaceMemberKeys), which separates the
 // two shapes (#6391).
 func zoneInterfaceMembers(iface *Node) []string {
+	// #7029: the node itself may BE a meta statement. At the call site the
+	// member nodes come straight from zoneInterfaceMemberNodes, so
+	// `apply-groups-except G;` arrives here as `iface`, not as a child — which
+	// is why guarding only the child loop below left the reject in place.
+	if zoneInterfaceApplyMetaKeyword(iface.Name()) {
+		return nil
+	}
 	names, hasBody := zoneInterfaceKeysBeforeBody(iface)
 	if hasBody {
 		// A body keyword landed on this node's OWN Keys, which means the
@@ -407,9 +414,43 @@ func zoneInterfaceMembers(iface *Node) []string {
 		if zoneInterfaceBodyKeywords[child.Name()] {
 			continue
 		}
+		// #7029: Junos permits apply-groups / apply-groups-except /
+		// apply-macro at ANY point in the hierarchy, and ExpandGroups removes
+		// only apply-groups -- the other two survive expansion as live nodes.
+		// In the member slot they were read as interface NAMES, compiled as
+		// phantom members, and the zone-interface-DEFINED gate then rejected
+		// the commit:
+		//
+		//   REJECT security zone "Z" references interface
+		//   "apply-groups-except", which is not defined under `interfaces`
+		//
+		// Fail-LOUD over-rejection, not a silent membership loss, but it
+		// refuses a legal Junos config. zoneInterfaceNonMemberToken already
+		// knew these three; this walk was the one place that did not ask it.
+		if zoneInterfaceApplyMetaKeyword(child.Name()) {
+			continue
+		}
 		names = append(names, zoneInterfaceMembers(child)...)
 	}
 	return names
+}
+
+// zoneInterfaceApplyMetaKeyword reports whether tok is one of the three Junos
+// meta statements that may appear at any hierarchy point and are never an
+// interface name (#7029).
+//
+// Deliberately NOT zoneInterfaceNonMemberToken, which is a superset: that one
+// also covers the host-inbound body keywords, and the member walk already
+// handles those through zoneInterfaceBodyKeywords with different semantics (a
+// body keyword on the node's OWN Keys terminates the walk; a meta keyword is
+// simply skipped). Widening the walk to the superset would conflate the two and
+// change what a packed body does.
+func zoneInterfaceApplyMetaKeyword(tok string) bool {
+	switch tok {
+	case "apply-groups", "apply-groups-except", "apply-macro":
+		return true
+	}
+	return false
 }
 
 // zoneInterfaceBodyKeywords is the set of tokens that may legally appear UNDER a


### PR DESCRIPTION
Junos permits `apply-groups`, `apply-groups-except` and `apply-macro` at **any** hierarchy point. `ExpandGroups` removes only `apply-groups`; the other two survive expansion as live nodes. In the `security zones security-zone <z> interfaces` member slot they were read as interface NAMES, compiled as phantom members, and the zone-interface-DEFINED gate rejected the commit:

```
REJECT security zone "Z" references interface "apply-groups-except",
which is not defined under `interfaces` ...
```

Fail-LOUD over-rejection, not a silent membership loss — but it refuses a legal Junos config, and the operator's only clue names a keyword they never intended as an interface. `zoneInterfaceNonMemberToken` already knew these three; the member walk was the one place that did not ask.

## Two measurements that changed the fix

### The guard has to be on the node's OWN name

The first attempt guarded only the child loop and **changed nothing**. At the call site the member nodes come straight from `zoneInterfaceMemberNodes`, so `apply-groups-except G;` arrives as `iface` itself, not as a child — the reject stayed exactly in place. Re-running the probe after the edit is what caught it; otherwise this ships as a no-op with a passing description.

### The apparent second guard was redundant, and is removed rather than described

With the head guard in place the child-loop check looked like an independent second guard. Measured:

- **Reached?** Yes — instrumenting it and running a meta statement nested under a member (`ge-0/0/0.0 { apply-macro M { … } }`) hits it. Zero hits across the rest of `pkg/config`.
- **Load-bearing?** No — deleting it, and turning its `continue` into a `break`, both leave every cell green, because the recursion calls `zoneInterfaceMembers` on the child and lands back on the head guard.

So it was a redundant branch dressed up as a guard. Removed; the doc comment now says *one* guard and why the nested case needs no second, instead of claiming two. **A redundant branch is worse than none, because the comment above it makes a claim the code does not carry.**

The nested fixture is **kept** as a regression test — the shape must keep compiling however the walk is restructured — but documented as that, not as the thing binding a second guard.

## Census, kept as a guard

The issue named one slot. Eight slots read their children as instance NAMES, so eight were measured at `origin/master`:

| slot | `apply-macro` in the name position |
|---|---|
| **zone interfaces** | **REJECTED** |
| security zones (zone-name slot) | accepted |
| security policies from-zone | accepted |
| address-book entries | accepted |
| applications | accepted |
| interfaces stanza | accepted |
| firewall filters | accepted |
| routing-instances | accepted |

Exactly one. That asymmetry is also what proves the table is not blind: **a census in which nothing ever fails is indistinguishable from a census that cannot see.**

## Mutation matrix

`go test -count=1 -run 7029 -v ./pkg/config/`. **14 collected, 0 build errors in every cell.**

| cell | mutation | failed | named failing tests |
|---|---|---|---|
| control | none | 0 | — |
| M1 | walk reverted to master | 7 | all three |
| M2 | head guard returns the node's own name instead of nil | 6 | the member table + the census |
| M3 | predicate narrowed to `apply-groups` only | 7 | all three |
| M4 | predicate always false | 7 | all three |
| restored | none | 0 | — |

> **Method note.** The first M3 was a **VOID cell**. The edit matched a `case` line present in *both* `zoneInterfaceApplyMetaKeyword` and its sibling `zoneInterfaceNonMemberToken`, and `rindex` selected the sibling. It reported **0 failed** — indistinguishable from a genuine escape — and would have been written up as "the predicate is unbound". Anchored inside the target function, it reds 7. *Which site was mutated* is a separate question from *did it red*, and the harness's own output only answers the second.

---

`./pkg/config/` green. Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

Docs: `docs/log/7029.md`.

Closes #7029
