### PR TITLE
userspace: give applyHelperStatusLocked a map-free seam

### DIFF
--- a/pkg/dataplane/userspace/helper_status_apply.go
+++ b/pkg/dataplane/userspace/helper_status_apply.go
@@ -445,8 +445,8 @@ func (m *Manager) applyRuntimeModeLocked(ctrl *userspaceCtrlValue) {
 // pre-#6429 behaviour.
 func (m *Manager) applyPrimaryBindingRowsLocked(
 	status *ProcessStatus,
-	ctrlMap *ebpf.Map,
-	bindingsMap *ebpf.Map,
+	ctrlMap ctrlMapUpdater,
+	bindingsMap ctrlMapUpdater,
 	ctrl userspaceCtrlValue,
 	deadWorkers map[uint32]bool,
 	newBindingIndices []uint32,
@@ -515,8 +515,8 @@ func (m *Manager) applyPrimaryBindingRowsLocked(
 // applyPrimaryBindingRowsLocked.
 func (m *Manager) applyAliasBindingRowsLocked(
 	status *ProcessStatus,
-	ctrlMap *ebpf.Map,
-	bindingsMap *ebpf.Map,
+	ctrlMap ctrlMapUpdater,
+	bindingsMap ctrlMapUpdater,
 	ctrl userspaceCtrlValue,
 	deadWorkers map[uint32]bool,
 	newBindingIndices []uint32,

--- a/pkg/dataplane/userspace/helper_status_ctrl_callsite_6994_test.go
+++ b/pkg/dataplane/userspace/helper_status_ctrl_callsite_6994_test.go
@@ -1,0 +1,172 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// #6994: bind applyHelperStatusLocked's ctrl-gate CALL SITE, not the predicate.
+//
+// WHAT WAS UNBOUND, measured rather than inferred. On the pre-#6994 head,
+// deleting `m.resolveCtrlEnableLocked(status, &ctrl)` from
+// applyHelperStatusLocked left BOTH pkg/dataplane/userspace and pkg/daemon
+// fully green. The reason is structural: the function opened by resolving
+// userspace_ctrl and userspace_bindings straight off m.bpfShim and returning
+// "userspace_ctrl map not loaded" when either was absent, so on an
+// unprivileged machine — every machine CI runs on — every test stopped on line
+// one and the entire body behind it was reached by nothing.
+//
+// WHY THE #6871 PREDICATE TABLE IS NOT THIS. #6871 round 9 extracted
+// ctrlMustStayDisabledLocked precisely so the clause could be tabled without
+// privileges, and that binding is real and load-bearing: dropping
+// `|| m.linkCycleInFlight()` from it reds
+// TestCtrlMustStayDisabledDuringLinkCycle_6871 (verified by mutation on this
+// branch). What a predicate table cannot see is production no longer
+// CONSULTING the predicate. Those are different properties and they need
+// different cells — which is the whole point of this file.
+//
+// WHY BOTH CELLS ARE REQUIRED, and why either alone certifies the bug it is
+// aimed at:
+//
+//   - The link-cycle cell alone asserts "ctrl ends DISABLED during a cycle".
+//     `ctrl` is initialised as `userspaceCtrlValue{Enabled: 0, ...}`, so
+//     deleting the resolve call leaves it at 0 and that cell PASSES. It cannot
+//     see the severance it would be assumed to cover.
+//   - The enable cell alone asserts "ctrl ends ENABLED for a ready helper".
+//     Removing `|| m.linkCycleInFlight()` from the predicate does not change
+//     that outcome, so it PASSES too.
+//
+// Only the pair discriminates: the enable cell is what reds on a severed call
+// site, and the link-cycle cell is what reds on a weakened gate. A single cell
+// varying only one of the two axes would sample the passing point of the other.
+
+// fakeBindingsMap is the userspace_bindings half of the #6994 seam. It is
+// deliberately permissive about the value type — applyPrimaryBindingRowsLocked
+// writes a binding row, not a ctrl value, so fakeCtrlMap's typed assertion does
+// not fit — and records nothing beyond call counts, because the assertions here
+// are about the CTRL map's contents.
+type fakeBindingsMap struct {
+	lookups int
+	updates int
+}
+
+func (f *fakeBindingsMap) Lookup(_, _ interface{}) error { f.lookups++; return ebpf.ErrKeyNotExist }
+func (f *fakeBindingsMap) Update(_, _ interface{}, _ ebpf.MapUpdateFlags) error {
+	f.updates++
+	return nil
+}
+
+// readyHelperStatus is a helper status that satisfies every readiness gate
+// resolveCtrlEnableLocked consults on its arming branch: one registered, armed
+// and bound binding (probeBindingsReady && allBindingsBound) and a non-zero
+// neighbour generation (neighborSyncReady). Without all three the arming branch
+// falls through to `ctrl.Enabled = 0` and the enable cell below would be
+// vacuous — passing for the wrong reason, which is the failure mode this whole
+// file exists to avoid.
+func readyHelperStatus() *ProcessStatus {
+	return &ProcessStatus{
+		Enabled: true,
+		Workers: 1,
+		Bindings: []BindingStatus{{
+			Slot: 0, QueueID: 0, WorkerID: 0,
+			Interface: "ge-0-0-1", Ifindex: 7,
+			Registered: true, Armed: true, Ready: true, Bound: true,
+			RXPackets: 1000,
+		}},
+		NeighborGeneration: 1,
+	}
+}
+
+// seamedManager returns a Manager whose two applyHelperStatusLocked map handles
+// and classifier-map writes are routed through test doubles, so the function's
+// body runs unprivileged. It returns the ctrl fake so a cell can read back what
+// production actually WROTE, rather than asserting on in-memory manager state
+// that a severed map write would leave untouched.
+func seamedManager(t *testing.T) (*Manager, *fakeCtrlMap) {
+	t.Helper()
+	m := New()
+	ctrl := &fakeCtrlMap{}
+	m.helperStatusCtrlMapHook = ctrl
+	m.helperStatusBindingsMapHook = &fakeBindingsMap{}
+	m.syncClassifierMapsHook = func(*ConfigSnapshot) error { return nil }
+	// Liveness already proven: advanceXSKLivenessLocked then takes its
+	// restore-the-shim arm instead of starting a 10 s probe, which keeps the
+	// enable cell deterministic and independent of wall-clock.
+	m.xskLivenessProven = true
+	// Precondition. A cell that reads Enabled==0 out of a map that was never
+	// written proves nothing, and a cell that reads Enabled==1 out of a
+	// pre-populated one proves less. Assert the fixture starts blank.
+	if ctrl.haveStored {
+		t.Fatal("fixture invalid: the ctrl map already holds a value before any apply")
+	}
+	return m, ctrl
+}
+
+// The ready-helper path must end with ctrl ENABLED in the map.
+//
+// RED on revert: delete `m.resolveCtrlEnableLocked(status, &ctrl)` from
+// applyHelperStatusLocked and this fails — `ctrl.Enabled` stays at the literal
+// 0 it is constructed with, the `if ctrl.Enabled == 1` write never runs, and
+// the ctrl map is never written at all. Measured on the pre-#6994 head: that
+// same deletion left the entire package green.
+func TestApplyHelperStatusEnablesCtrlForAReadyHelper6994(t *testing.T) {
+	m, ctrl := seamedManager(t)
+
+	if err := m.applyHelperStatusLocked(readyHelperStatus()); err != nil {
+		t.Fatalf("applyHelperStatusLocked: %v", err)
+	}
+
+	if !ctrl.haveStored {
+		t.Fatal("applyHelperStatusLocked wrote NOTHING to the userspace_ctrl map for a " +
+			"ready helper. The ctrl-enable resolution is not reached: the shim never " +
+			"starts redirecting to XSK and all transit stays fail-closed, with no test " +
+			"outside this one able to see it (#6994)")
+	}
+	if ctrl.stored.Enabled != 1 {
+		t.Fatalf("ctrl.Enabled = %d after applying a ready helper status, want 1. "+
+			"applyHelperStatusLocked is not consulting resolveCtrlEnableLocked, so the "+
+			"gate is stuck at the value the struct literal initialises (#6994)",
+			ctrl.stored.Enabled)
+	}
+	if !m.ctrlWasEnabled {
+		t.Fatal("m.ctrlWasEnabled is false after a ctrl-enabling apply: the map write " +
+			"and the manager's derived state disagree, so the next disable would not " +
+			"stamp ctrlDisabledAt (#6994)")
+	}
+}
+
+// The same ready helper, with a link cycle in flight, must end DISABLED.
+//
+// RED on revert: drop `|| m.linkCycleInFlight()` from
+// ctrlMustStayDisabledLocked and this fails — the identical status now arms the
+// gate mid-cycle. That is the #6871 hazard: UpdateRGActive reaches
+// applyHelperStatusLocked off the daemon's applySem, so the status tick's own
+// lease skip does not cover it, and re-enabling here points the XDP shim at XSK
+// queues the cycle is about to destroy.
+func TestApplyHelperStatusKeepsCtrlDisabledDuringLinkCycle6994(t *testing.T) {
+	fakeLinkCycleClock(t)
+	m, ctrl := seamedManager(t)
+	t.Cleanup(m.releaseLinkCycleLease)
+	m.acquireLinkCycleLease()
+	if !m.linkCycleInFlight() {
+		t.Fatal("fixture invalid: the link-cycle lease is not held, so this cell would " +
+			"be asserting the ungated path and would pass for the wrong reason")
+	}
+
+	if err := m.applyHelperStatusLocked(readyHelperStatus()); err != nil {
+		t.Fatalf("applyHelperStatusLocked: %v", err)
+	}
+
+	if ctrl.haveStored && ctrl.stored.Enabled != 0 {
+		t.Fatalf("ctrl.Enabled = %d with a link cycle in flight, want 0. The gate that "+
+			"holds ctrl at 0 for the duration of a RETH MAC link cycle is not reached "+
+			"from applyHelperStatusLocked, so the shim redirects into XSK sockets whose "+
+			"queues the cycle is tearing down (#6871/#6994)",
+			ctrl.stored.Enabled)
+	}
+	if m.ctrlWasEnabled {
+		t.Fatal("m.ctrlWasEnabled is true after an apply that ran during a link cycle: " +
+			"the enable half of the ctrl branch executed despite the gate (#6871/#6994)")
+	}
+}

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -306,6 +306,16 @@ type Manager struct {
 	// readback faults without a privileged BPF map (#5486). Production leaves
 	// it nil.
 	disableCtrlMapHook ctrlMapUpdater
+	// helperStatusCtrlMapHook / helperStatusBindingsMapHook, when non-nil,
+	// replace the two bpfShim maps applyHelperStatusLocked operates on, so its
+	// ctrl-gate decision is reachable without a privileged BPF map (#6994).
+	// Production leaves both nil. This is the SAME map-free seam
+	// disableCtrlMapHook establishes for the disable path (#5486); #6994 exists
+	// because applyHelperStatusLocked lacked it, which made its whole body —
+	// including the #6871 link-cycle gate — unreachable to every unprivileged
+	// test and therefore bound by nothing CI runs.
+	helperStatusCtrlMapHook     ctrlMapUpdater
+	helperStatusBindingsMapHook ctrlMapUpdater
 	// syncClassifierMapsHook, when non-nil, replaces the ingress/local/
 	// interface-NAT classifier map writes in unit tests (#7468). Nil in
 	// production.

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -268,7 +268,7 @@ func (m *Manager) setupUserspaceCPUMapLocked() bool {
 	return true
 }
 
-func (m *Manager) failClosedUserspaceCtrlLocked(ctrlMap *ebpf.Map, ctrl userspaceCtrlValue, cause error) error {
+func (m *Manager) failClosedUserspaceCtrlLocked(ctrlMap ctrlMapUpdater, ctrl userspaceCtrlValue, cause error) error {
 	if ctrl.Enabled != 1 {
 		return cause
 	}
@@ -303,9 +303,9 @@ func (m *Manager) syncUserspaceClassifierMapsLocked(snapshot *ConfigSnapshot) er
 	return m.syncInterfaceNATAddressMapsLocked(snapshot)
 }
 
-type userspaceCtrlLookupHook func(*ebpf.Map, uint32, *userspaceCtrlValue) error
+type userspaceCtrlLookupHook func(ctrlMapUpdater, uint32, *userspaceCtrlValue) error
 
-func (m *Manager) lookupUserspaceCtrlForFailClosed(ctrlMap *ebpf.Map, key uint32, ctrl *userspaceCtrlValue) error {
+func (m *Manager) lookupUserspaceCtrlForFailClosed(ctrlMap ctrlMapUpdater, key uint32, ctrl *userspaceCtrlValue) error {
 	if m.lookupUserspaceCtrlForFailClosedHook != nil {
 		return m.lookupUserspaceCtrlForFailClosedHook(ctrlMap, key, ctrl)
 	}
@@ -348,7 +348,7 @@ func (m *Manager) failClosedUserspaceCtrlMapLocked(snapshot *ConfigSnapshot, cau
 }
 
 func (m *Manager) blindFailClosedUserspaceCtrlLocked(
-	ctrlMap *ebpf.Map,
+	ctrlMap ctrlMapUpdater,
 	snapshot *ConfigSnapshot,
 	cause error,
 	lookupErr error,
@@ -432,12 +432,48 @@ func (m *Manager) ctrlMustStayDisabledLocked(statusEnabled bool) bool {
 // path), so it must not block or allocate beyond what the steps below already
 // do. #6429 split the per-domain steps into helper_status_apply.go; the order
 // of the steps, and what each early return skips, is unchanged.
+// helperStatusMapsLocked resolves the two shim maps applyHelperStatusLocked
+// operates on, through a map-free seam (#6994).
+//
+// WHY THIS EXISTS. applyHelperStatusLocked used to open by calling
+// m.bpfShim.Map twice and returning "userspace_ctrl map not loaded" when either
+// was absent. On an unprivileged machine — which is every machine CI runs on —
+// the shim holds no maps, so EVERY test stopped on line one and the entire body
+// behind it was bound by nothing. Measured on the pre-#6994 head: deleting
+// `m.resolveCtrlEnableLocked(status, &ctrl)` outright left both
+// pkg/dataplane/userspace and pkg/daemon fully green, which is the ctrl gate —
+// #6871's link-cycle clause included — not being reached by any test at all.
+//
+// #6871 round 9 extracted ctrlMustStayDisabledLocked so the PREDICATE could be
+// tabled unprivileged, and that binding is real: dropping
+// `|| m.linkCycleInFlight()` from it reds
+// TestCtrlMustStayDisabledDuringLinkCycle_6871. What it could not bind is
+// production still CONSULTING it. That is this seam's job, and the reason a
+// predicate table is not a substitute for it.
+//
+// Nil handling matches ctrlMapForDisableLocked: a missing map returns an
+// untyped nil, never a non-nil interface wrapping a nil *ebpf.Map, so the
+// callers' `== nil` checks behave as they did when the values were pointers.
+func (m *Manager) helperStatusMapsLocked() (ctrlMapUpdater, ctrlMapUpdater) {
+	var ctrlMap, bindingsMap ctrlMapUpdater
+	if m.helperStatusCtrlMapHook != nil {
+		ctrlMap = m.helperStatusCtrlMapHook
+	} else if cm := m.bpfShim.Map(mapNameUserspaceCtrl); cm != nil {
+		ctrlMap = cm
+	}
+	if m.helperStatusBindingsMapHook != nil {
+		bindingsMap = m.helperStatusBindingsMapHook
+	} else if bm := m.bpfShim.Map(mapNameUserspaceBindings); bm != nil {
+		bindingsMap = bm
+	}
+	return ctrlMap, bindingsMap
+}
+
 func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
-	ctrlMap := m.bpfShim.Map(mapNameUserspaceCtrl)
+	ctrlMap, bindingsMap := m.helperStatusMapsLocked()
 	if ctrlMap == nil {
 		return errors.New("userspace_ctrl map not loaded")
 	}
-	bindingsMap := m.bpfShim.Map(mapNameUserspaceBindings)
 	if bindingsMap == nil {
 		return errors.New("userspace_bindings map not loaded")
 	}
@@ -492,13 +528,16 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 		return err
 	}
 	m.lastBindingIndices = m.clearStaleBindingRowsLocked(bindingsMap, newBindingIndices, newBindingIndexSet)
-	if err := m.syncIngressIfaceMapLocked(m.lastSnapshot); err != nil {
-		return m.failClosedUserspaceCtrlLocked(ctrlMap, ctrl, err)
-	}
-	if err := m.syncLocalAddressMapsLocked(m.lastSnapshot); err != nil {
-		return m.failClosedUserspaceCtrlLocked(ctrlMap, ctrl, err)
-	}
-	if err := m.syncInterfaceNATAddressMapsLocked(m.lastSnapshot); err != nil {
+	// #6994: one call through the shared classifier-sync helper instead of the
+	// three inline calls this used to make. Behaviour-identical — that helper
+	// runs the SAME three syncs in the SAME order and returns the first error,
+	// and all three inline arms wrapped that error in the identical
+	// failClosedUserspaceCtrlLocked — while bringing this path under the #7468
+	// syncClassifierMapsHook seam. Without it the ingress-iface sync errors
+	// "userspace_ingress_ifaces map not loaded" on any unprivileged machine and
+	// applyHelperStatusLocked fail-closes before ever writing the ctrl gate, so
+	// the map-free seam above would still leave the ctrl branch untestable.
+	if err := m.syncUserspaceClassifierMapsLocked(m.lastSnapshot); err != nil {
 		return m.failClosedUserspaceCtrlLocked(ctrlMap, ctrl, err)
 	}
 	// Sync userspace-forwarded packet counters into BPF counter maps so
@@ -530,7 +569,7 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 // the XDP shim would keep steering transit to a slot no longer backed by a
 // live worker. A successful clear removes the row from the inventory (it is
 // not in newBindingIndexSet, so it is not carried forward).
-func (m *Manager) clearStaleBindingRowsLocked(bindingsMap *ebpf.Map, newBindingIndices []uint32, newBindingIndexSet map[uint32]struct{}) []uint32 {
+func (m *Manager) clearStaleBindingRowsLocked(bindingsMap ctrlMapUpdater, newBindingIndices []uint32, newBindingIndexSet map[uint32]struct{}) []uint32 {
 	var zeroBinding userspaceBindingValue
 	for _, idx := range m.lastBindingIndices {
 		if _, keep := newBindingIndexSet[idx]; keep {

--- a/pkg/dataplane/userspace/maps_sync_cap_test.go
+++ b/pkg/dataplane/userspace/maps_sync_cap_test.go
@@ -410,7 +410,7 @@ func TestBlindFailClosedUserspaceCtrlAfterLookupFailure(t *testing.T) {
 			}
 
 			lookupErr := errors.New("transient ctrl lookup failed")
-			m.lookupUserspaceCtrlForFailClosedHook = func(_ *ebpf.Map, _ uint32, _ *userspaceCtrlValue) error {
+			m.lookupUserspaceCtrlForFailClosedHook = func(_ ctrlMapUpdater, _ uint32, _ *userspaceCtrlValue) error {
 				return lookupErr
 			}
 

--- a/pkg/dataplane/userspace/process_linkcycle.go
+++ b/pkg/dataplane/userspace/process_linkcycle.go
@@ -10,9 +10,16 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-// ctrlMapUpdater is the subset of *ebpf.Map used to flip the ctrl.enabled
-// gate. *ebpf.Map satisfies it directly; tests substitute a fake to inject
-// Lookup/Update/readback faults without a privileged BPF map (#5486).
+// ctrlMapUpdater is the subset of *ebpf.Map the manager uses on the
+// userspace_ctrl and userspace_bindings maps. *ebpf.Map satisfies it directly;
+// tests substitute a fake to inject Lookup/Update/readback faults without a
+// privileged BPF map (#5486).
+//
+// #6994 widened its ROLE, not its method set: `Lookup` + `Update` is already
+// everything applyHelperStatusLocked and its five helpers call on either map
+// (measured: 4 ctrlMap.Lookup, 7 ctrlMap.Update, 2 bindingsMap.Lookup,
+// 6 bindingsMap.Update across the non-test tree), so routing that chain through
+// this interface needed no new method and no behavioural change.
 type ctrlMapUpdater interface {
 	Lookup(key, valueOut interface{}) error
 	Update(key, value interface{}, flags ebpf.MapUpdateFlags) error


### PR DESCRIPTION
Closes #6994

## The gap, measured

`applyHelperStatusLocked` opened by resolving `userspace_ctrl` and
`userspace_bindings` straight off `m.bpfShim`, returning `"userspace_ctrl map
not loaded"` when either was absent. On an unprivileged machine — every machine
CI runs on — the shim holds no maps, so **every test stopped on line one** and
the entire body behind it was reached by nothing.

Measured on the pre-change head, not inferred: deleting
`m.resolveCtrlEnableLocked(status, &ctrl)` outright left **both**
`pkg/dataplane/userspace` and `pkg/daemon` fully green.

## Why the #6871 predicate table is not this

#6871 round 9 extracted `ctrlMustStayDisabledLocked` so the *predicate* could be
tabled unprivileged, and I re-verified that binding rather than assuming it:
dropping `|| m.linkCycleInFlight()` reds
`TestCtrlMustStayDisabledDuringLinkCycle_6871/enabled/no_rg/link_cycle`. That is
real and load-bearing. What a predicate table cannot see is production no longer
**consulting** the predicate. Different property, different cell.

## The change

The seam is the one `ctrlMapForDisableLocked`/`disableCtrlMapHook` already
establishes for the disable path (#5486), applied to the status path.
`helperStatusMapsLocked` resolves both handles through two new test-only hooks
and returns an **untyped** nil for a missing map, so the callers' `== nil`
checks behave exactly as they did when the values were pointers.

Widening the chain needed **no new method and no behavioural change**: `Lookup`
+ `Update` is already everything the function and its five helpers call on
either map — measured across the non-test tree as 4 `ctrlMap.Lookup`, 7
`ctrlMap.Update`, 2 `bindingsMap.Lookup`, 6 `bindingsMap.Update` — which is
exactly the existing `ctrlMapUpdater` interface. Seven signatures move from
`*ebpf.Map` to it.

One behaviour-preserving fold was required to make the seam actually bite: the
three inline classifier-map syncs now go through
`syncUserspaceClassifierMapsLocked`, which runs the same three in the same order
and returns the first error, and which all three inline arms already wrapped in
the identical `failClosedUserspaceCtrlLocked`. Without it the ingress-iface sync
errors `"userspace_ingress_ifaces map not loaded"` unprivileged and the function
fail-closes before ever writing the ctrl gate.

## The cells are a PAIR, and each alone certifies the other's bug

This is the part worth reviewing. `ctrl` is constructed as
`userspaceCtrlValue{Enabled: 0, ...}`, so:

- the **link-cycle** cell alone ("ctrl ends disabled during a cycle") **passes**
  with the resolve call severed — the value it asserts is the literal's own
  initialiser;
- the **enable** cell alone ("ctrl ends enabled for a ready helper") **passes**
  with the link-cycle disjunct removed — that mutation does not change the
  ready-helper outcome.

Only together do they discriminate a severed call site from a weakened gate. A
single cell varying one axis would sample the passing point of the other.

## Mutation matrix — full package suites, no `-run` filter

| cell | rc | pkgs reported | named failing | which |
|---|---|---|---|---|
| control (committed head) | 0 | 4 | **0** | — |
| MA: sever `m.resolveCtrlEnableLocked(status, &ctrl)` | 1 | 4 | **1** | `TestApplyHelperStatusEnablesCtrlForAReadyHelper6994` |
| MB: drop `\|\| m.linkCycleInFlight()` | 1 | 4 | **2** | `TestApplyHelperStatusKeepsCtrlDisabledDuringLinkCycle6994` + the pre-existing `TestCtrlMustStayDisabledDuringLinkCycle_6871` |

Each mutation reds a **named** test, and each cell **localises**: MA leaves the
link-cycle cell green and MB leaves the enable cell green, which is the paired
evidence the doc comment claims rather than merely asserts. Worktree restored to
0 dirty files after the matrix.

## Validation

- `go vet ./pkg/dataplane/userspace/...` and `gofmt -l` clean.
- Full repo suite: `go test -count=1 ./...` → **FULL_RC=0**, 68 packages ok, zero
  `FAIL` lines.
- Both new cells confirmed to **RUN**, not merely to pass a filter: `-v` shows
  two `=== RUN` lines. (A `-run` filter matching nothing exits 0 and prints
  `ok`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
