### PR TITLE
test: make the rollback-exhaustion check a regression backstop, not a calibration (#7062)

### DIFF
--- a/docs/log/7062.md
+++ b/docs/log/7062.md
@@ -1,0 +1,89 @@
+# #7062 — a contention calibration wearing the shape of a property assertion
+
+```
+thread '...v8_release_unused_v8_concurrent_preserves_ledger_invariant'
+  panicked at shared_cos_lease_tests.rs:2395:
+assertion `left == right` failed: no tag-checked-rollback exhaustion expected under this contention
+  left: 1
+ right: 0
+```
+
+Hit once during a full `cargo test -- --test-threads=1` run while several other
+build jobs saturated the machine.
+
+## What it was asserting
+
+`v8_rollback_retry_exceeded() == 0` — that across **4 threads × 3 000 rounds =
+12 000 operations**, no tag-checked rollback exhausted its retries. That is a
+statement about how much scheduler contention the test's own load produces, not
+about the lease.
+
+The two assertions immediately above it are the real properties, and they are
+contention-independent:
+
+```rust
+assert!(sum <= class_granted as u64, "... (over-admission)");
+assert!(class_granted as u64 <= 2_500, "... must never exceed the epoch cap 2500");
+```
+
+Both held in the failing run. One exhaustion out of 12 000 operations broke
+nothing.
+
+## Why deleting it was not the fix
+
+The counter has three other call sites, and all three assert only that it
+**starts** at zero:
+
+```
+shared_cos_lease_tests.rs:109   v8_legacy_lease_does_not_advertise_v8_mode
+shared_cos_lease_tests.rs:349   v8_telemetry_rollback_metric_starts_zero
+shared_cos_lease_tests.rs:359   v8_legacy_lease_telemetry_returns_zero
+```
+
+So this is the only check that exhaustion does not happen **in practice**.
+Removing it would trade a flake for a coverage hole — the same trade #6989
+declined.
+
+## The shape that works: order of magnitude, not calibration
+
+Host load produces a *handful* of exhaustions out of 12 000. A regression that
+made the retry budget structurally too small produces one on a *large fraction*
+of them, because every operation hits the same ceiling.
+
+`ROUNDS` (3 000 — a quarter of the operations) sits far above the first and far
+below the second. No amount of CPU contention reaches it; no structural
+regression avoids it.
+
+The failure text carries the instruction that makes it durable:
+
+> a handful under host load is expected and harmless — the ledger invariants
+> above are the properties. This many means the retry budget is structurally too
+> small, not that the box was busy: **do not raise the bound**.
+
+Raising a bound is the natural response to a red, and it is the wrong one here
+precisely because the bound is not measuring contention.
+
+## Validation
+
+`cargo test --manifest-path userspace-dp/Cargo.toml --release --bins
+v8_release_unused_v8_concurrent -- --test-threads=1` → **1 passed**, on a box
+concurrently running four other agent lanes and two release builds. That is the
+contention that produced the original red, so the pass is a measurement under
+the reported conditions rather than on an idle machine.
+
+## Family
+
+This is the last of the contention-sensitive assertions in this file. The
+sibling guards were closed separately:
+
+- **#6991 / #7001** — `v8_epoch_seqlock_snapshot_never_tears_tag_grace`'s
+  vacuity guard, fixed by #7789 with a paired 16/25 → 0/25 verification under
+  2-CPU confinement.
+- **#7088 / #7089** — `cold_path_hist` and wg `framed_handshake`, both rewritten
+  by #7650 from fixed-iteration budgets to loop-until-observed.
+
+The distinction between those and this one is worth keeping: they were
+**progress guards** whose satisfaction depended on winning scheduler time, and
+the fix is to wait on the observable. This one is a **calibration** — it was
+never waiting for anything, it was asserting an outcome that load perturbs — and
+the fix is to bound it where load cannot reach.

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -2392,10 +2392,39 @@ fn v8_release_unused_v8_concurrent_preserves_ledger_invariant() {
         class_granted as u64 <= 2_500,
         "class total {class_granted} must never exceed the epoch cap 2500"
     );
-    assert_eq!(
-        lease.v8_rollback_retry_exceeded(),
-        0,
-        "no tag-checked-rollback exhaustion expected under this contention"
+    // #7062: a SYSTEMIC-regression backstop, not a contention reading.
+    //
+    // This was `== 0`: no tag-checked-rollback may exhaust its retries under
+    // the contention this test happens to generate. That is a statement about
+    // the machine, not about the lease. It red once during a full
+    // `--test-threads=1` run while several other build jobs saturated the box,
+    // with `left: 1, right: 0` — one exhaustion across 4 threads x 3 000 rounds
+    // = 12 000 operations, while the two ledger invariants asserted immediately
+    // above (which ARE the properties, and are contention-independent) held.
+    //
+    // The bound distinguishes the two causes by ORDER OF MAGNITUDE rather than
+    // by calibration. Load produces a handful of exhaustions out of 12 000. A
+    // regression that made the retry budget structurally too small produces one
+    // on a large fraction of them, because every operation would hit the same
+    // ceiling. ROUNDS (3 000, a quarter of the operations) sits far above the
+    // former and far below the latter, so no amount of CPU contention reaches
+    // it and a real regression cannot avoid it.
+    //
+    // If this ever reds, do NOT raise it. It is not measuring contention, so a
+    // higher number cannot make it correct — a value near this bound means
+    // rollback is exhausting on a quarter of all operations, which is the
+    // condition it exists to catch. The counter's zero-at-rest contract is
+    // bound separately and deterministically by
+    // v8_telemetry_rollback_metric_starts_zero.
+    let exhausted = lease.v8_rollback_retry_exceeded();
+    assert!(
+        exhausted < ROUNDS,
+        "tag-checked-rollback exhausted {exhausted} times across {} operations \
+         (4 threads x {ROUNDS} rounds). A handful under host load is expected \
+         and harmless — the ledger invariants above are the properties. This \
+         many means the retry budget is structurally too small, not that the \
+         box was busy: do not raise the bound (#7062)",
+        4 * ROUNDS
     );
     assert_eq!(
         sum, class_granted as u64,


### PR DESCRIPTION
```
assertion `left == right` failed: no tag-checked-rollback exhaustion expected under this contention
  left: 1
 right: 0
```

Hit once during a full `cargo test -- --test-threads=1` run while several other build jobs saturated the machine.

## What it was asserting

`v8_rollback_retry_exceeded() == 0` — that across **4 threads × 3 000 rounds = 12 000 operations**, no tag-checked rollback exhausted its retries. That is a statement about how much scheduler contention the test's own load produces, not about the lease.

The two assertions immediately above it are the real properties, and they are contention-independent:

```rust
assert!(sum <= class_granted as u64, "... (over-admission)");
assert!(class_granted as u64 <= 2_500, "... must never exceed the epoch cap 2500");
```

**Both held in the failing run.** One exhaustion out of 12 000 operations broke nothing.

## Why deleting it was not the fix

The counter's three other call sites assert only that it **starts** at zero (`v8_telemetry_rollback_metric_starts_zero`, `v8_legacy_lease_telemetry_returns_zero`, and one unrelated). So this is the only check that exhaustion does not happen *in practice* — removing it trades a flake for a coverage hole, the trade #6989 declined.

## The shape that works: order of magnitude, not calibration

Host load produces a *handful* of exhaustions out of 12 000. A regression that made the retry budget structurally too small produces one on a *large fraction* of them, because every operation hits the same ceiling.

`ROUNDS` (3 000 — a quarter of the operations) sits far above the first and far below the second. No amount of CPU contention reaches it; no structural regression avoids it.

The failure text carries the instruction that makes it durable:

> a handful under host load is expected and harmless — the ledger invariants above are the properties. This many means the retry budget is structurally too small, not that the box was busy: **do not raise the bound**.

Raising a bound is the natural response to a red, and it is the wrong one here precisely because the bound is not measuring contention.

## Validation

`cargo test --release --bins v8_release_unused_v8_concurrent -- --test-threads=1` → **1 passed**, on a box concurrently running four other agent lanes and two release builds. That is the contention that produced the original red, so the pass is a measurement under the reported conditions rather than on an idle machine.

Full `make test-rust` posted as a comment when it finishes.

## Family, and the distinction worth keeping

This is the last contention-sensitive assertion in the file. The siblings were closed separately today:

- **#6991 / #7001** — the seqlock vacuity guard, fixed by #7789 with a paired **16/25 → 0/25** verification under 2-CPU confinement.
- **#7088 / #7089** — `cold_path_hist` and wg `framed_handshake`, rewritten by #7650 from fixed-iteration budgets to loop-until-observed.

Those were **progress guards** whose satisfaction depended on winning scheduler time, and the fix is to wait on the observable. This one is a **calibration** — it was never waiting for anything, it asserted an outcome that load perturbs — and the fix is to bound it where load cannot reach. Same family, different mechanism, different repair.

Docs: `docs/log/7062.md`.

Closes #7062
