### PR TITLE
test(daemon): guard three pieces of shared state the -race leg trips on (#7075, #7825)

### DIFF
--- a/docs/log/7075.md
+++ b/docs/log/7075.md
@@ -1,0 +1,90 @@
+# #7075 + #7825 — three unsynchronised accesses that red the `-race` leg deterministically
+
+`go test -race ./pkg/daemon/` fails at master on shared state in **test
+infrastructure**, not in the daemon. Three distinct pairs, all the same shape.
+
+That is worse than a flake. A deterministic red in a gate trains reviewers to
+wave the leg through, and the next real race arrives looking exactly like this
+one. `pkg/daemon -race` is one of the gates this project uses to clear changes
+to the apply path — the one I ran on #7822 today, which is how these surfaced.
+
+## All three are "published on one side only"
+
+The mutex is held where the value is written and not where it is read. A mutex
+held on one side of a publish establishes no happens-before for a reader that
+does not take it.
+
+That is the same shape as **#7012** (`d.mgmt` published under `staleCertMu` on
+the write side only), and the fix here is the same one that worked there: make
+the unguarded form **unrepresentable**, rather than guarding the accesses known
+today. Guarding four readers leaves the fifth free to omit the lock; removing
+the pointer leaves nothing to omit.
+
+### 1. `installConntrackDeleteStub` (#7825)
+
+```go
+var mu sync.Mutex
+conntrackDeleteFilters = func(...) (uint, error) {
+    mu.Lock(); calls++; mu.Unlock()   // synchronised
+    return 0, err
+}
+return &calls                          // ... and the reader gets a raw *int
+```
+
+The mutex is captured by the closure and never handed out, so **every read is
+unsynchronised** while the reassert loop the test starts is still writing.
+
+Now returns `func() int`. There is no pointer to dereference.
+
+### 2. `capturingHandler` (#7075)
+
+Installed as the **global** slog default, so anything still logging in the
+process writes through it — including goroutines the test never started and does
+not join, such as a leaked configstore `persistRetryLoop`. It appended to a
+caller-owned `*[]captureRecord` with no synchronisation at all.
+
+The consequence worth naming: **the test it failed was whichever one happened to
+be running**, not the one that leaked the goroutine. That is why this was hard
+to attribute.
+
+The mutex now lives inside the handler, and records come back through
+`records()`, which returns a **copy**. Handing out the live slice would move the
+race from the append to the caller's `range` loop, since the handler keeps
+appending for as long as it is the default.
+
+### 3. The RA probe seam — found by the gate, named by neither issue
+
+`TestReassertRechecksTheGateInsideTheSemaphore6793` assigned
+`d.raHasDeadSendersFn` **after** `<-started`, while the goroutine was already
+inside `reassertDeadRASendersOnce` → `raHasDeadSenders()` reading it.
+
+The interesting part: the `healthy` bool *was* correctly guarded by `probeMu`.
+The unguarded state was the **seam assignment one level up** — the thing the
+careful mutex was protecting a value inside of. Guarding the value and leaving
+the publication unguarded is the same error as #1 and #2, one indirection out.
+
+Fixed by installing the seam before the goroutine starts, which costs the test
+nothing: the closure returns `!healthy`, `healthy` starts false, so the gate
+reads exactly as it did before the flip. The property under test — the tick
+re-checking the gate *inside* the semaphore and seeing the rebuilt sender — is
+untouched.
+
+## Measurement
+
+Same five tests, `go test -count=1 -race -v ./pkg/daemon/`:
+
+| tree | rc | DATA RACE | named failures |
+|---|---|---|---|
+| pristine `origin/master` | 1 | 2 | `TestRetryLoopTicks6802`, `TestReassertRechecksTheGateInsideTheSemaphore6793` |
+| after #7825 + #7075 fixes | 1 | 1 | `TestReassertRechecksTheGateInsideTheSemaphore6793` |
+| after the RA seam fix | **0** | **0** | — |
+
+The middle row is why the third fix is in this change: fixing the two the issues
+named left the leg red, and a leg that is still red is not a gate. It also shows
+the two issues' enumeration was a **floor** — one test carried two independent
+races, and finding the second required running the leg rather than reading the
+issues.
+
+The pre-existing side was measured at pristine `origin/master` in a clean
+worktree **before** any of this was written, so "not introduced here" is a
+measurement rather than an inference.

--- a/pkg/daemon/host_inbound_addressless_3698_test.go
+++ b/pkg/daemon/host_inbound_addressless_3698_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"sync"
 )
 
 // captureRecord is one slog record captured by capturingHandler.
@@ -15,7 +16,44 @@ type captureRecord struct {
 	attrs map[string]string
 }
 
-type capturingHandler struct{ recs *[]captureRecord }
+// capturingHandler collects slog records for assertion.
+//
+// #7075: it is installed as the GLOBAL slog default, so anything still logging
+// in this process writes through it — including goroutines the test did not
+// start and does not join, such as a leaked configstore persistRetryLoop. The
+// previous shape appended to a caller-owned `*[]captureRecord` with no
+// synchronisation at all, so `go test -race ./pkg/daemon/` reported a DATA RACE
+// between two Handle calls, and the test it failed was whichever one happened
+// to be running — not the one that leaked the goroutine.
+//
+// The mutex lives INSIDE the handler and the records are read back through
+// records(), so a caller cannot hold the slice directly and forget the lock.
+// That is the difference between fixing this instance and making the shape
+// unrepresentable: the previous API handed out the address of the slice, which
+// is an invitation to read it unguarded, and every caller accepted.
+type capturingHandler struct{ sink *captureSink }
+
+// captureSink owns the records and the mutex that guards them.
+type captureSink struct {
+	mu   sync.Mutex
+	recs []captureRecord
+}
+
+// newCaptureSink returns a sink ready to be installed in a capturingHandler.
+func newCaptureSink() *captureSink { return &captureSink{} }
+
+// records returns a COPY of what has been captured so far, under the lock.
+//
+// A copy rather than the slice itself: the handler keeps appending for as long
+// as it is the slog default, so handing out the live slice would move the race
+// from the append to the caller's range loop.
+func (s *captureSink) records() []captureRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]captureRecord, len(s.recs))
+	copy(out, s.recs)
+	return out
+}
 
 func (h capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
 func (h capturingHandler) Handle(_ context.Context, r slog.Record) error {
@@ -24,7 +62,9 @@ func (h capturingHandler) Handle(_ context.Context, r slog.Record) error {
 		attrs[a.Key] = a.Value.String()
 		return true
 	})
-	*h.recs = append(*h.recs, captureRecord{level: r.Level, msg: r.Message, attrs: attrs})
+	h.sink.mu.Lock()
+	h.sink.recs = append(h.sink.recs, captureRecord{level: r.Level, msg: r.Message, attrs: attrs})
+	h.sink.mu.Unlock()
 	return nil
 }
 func (h capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
@@ -57,16 +97,16 @@ func addresslessDaemonCfg(withWANAddr bool) *config.Config {
 // the daemon-side observability: an addressless enforcing zone logs a WARN once
 // on ENTRY (not every apply), and an INFO on RECOVERY when it gains an address.
 func TestLogHostInboundAddresslessTransitions(t *testing.T) {
-	var recs []captureRecord
+	sink := newCaptureSink()
 	prev := slog.Default()
-	slog.SetDefault(slog.New(capturingHandler{recs: &recs}))
+	slog.SetDefault(slog.New(capturingHandler{sink: sink}))
 	defer slog.SetDefault(prev)
 
 	d := &Daemon{}
 
 	warnsFor := func(zone string) int {
 		n := 0
-		for _, r := range recs {
+		for _, r := range sink.records() {
 			if r.level == slog.LevelWarn && r.attrs["zone"] == zone {
 				n++
 			}
@@ -75,7 +115,7 @@ func TestLogHostInboundAddresslessTransitions(t *testing.T) {
 	}
 	infosFor := func(zone string) int {
 		n := 0
-		for _, r := range recs {
+		for _, r := range sink.records() {
 			if r.level == slog.LevelInfo && r.attrs["zone"] == zone {
 				n++
 			}

--- a/pkg/daemon/host_inbound_ambiguous_3718_test.go
+++ b/pkg/daemon/host_inbound_ambiguous_3718_test.go
@@ -38,16 +38,16 @@ func ambiguousDaemonCfg(differ bool) *config.Config {
 // on ENTRY (not every apply), and an INFO on RECOVERY once the ambiguity is
 // resolved. An identical-service duplicate must never warn.
 func TestLogHostInboundAmbiguousTransitions(t *testing.T) {
-	var recs []captureRecord
+	sink := newCaptureSink()
 	prev := slog.Default()
-	slog.SetDefault(slog.New(capturingHandler{recs: &recs}))
+	slog.SetDefault(slog.New(capturingHandler{sink: sink}))
 	defer slog.SetDefault(prev)
 
 	d := &Daemon{}
 
 	warnsFor := func(addr string) int {
 		n := 0
-		for _, r := range recs {
+		for _, r := range sink.records() {
 			if r.level == slog.LevelWarn && r.attrs["address"] == addr {
 				n++
 			}
@@ -56,7 +56,7 @@ func TestLogHostInboundAmbiguousTransitions(t *testing.T) {
 	}
 	infos := func() int {
 		n := 0
-		for _, r := range recs {
+		for _, r := range sink.records() {
 			if r.level == slog.LevelInfo && r.msg == "host-inbound address ambiguity resolved — the address no longer has an order-dependent host-inbound verdict" {
 				n++
 			}

--- a/pkg/daemon/host_inbound_conntrack_retry_6802_test.go
+++ b/pkg/daemon/host_inbound_conntrack_retry_6802_test.go
@@ -33,11 +33,29 @@ import (
 )
 
 // installConntrackDeleteStub replaces the delete seam and records every call.
-func installConntrackDeleteStub(t *testing.T, err error) *int {
+// It returns an ACCESSOR, not a pointer to the counter.
+//
+// #7825: it used to take a mutex around the increment and then return
+// `&calls` — a raw *int whose mutex was captured by the closure and never
+// handed out. So the write was synchronised and every READ was not, while the
+// reassert loop the test starts was still writing. `go test -race
+// ./pkg/daemon/` reported a DATA RACE between the loop's increment and the
+// test's own `*calls` read, deterministically, in two tests.
+//
+// A mutex held on one side of a publish establishes no happens-before for a
+// reader that does not take it — the same shape as #7012 (`d.mgmt` published
+// under staleCertMu on the write side only), which was fixed by making the
+// unguarded form unrepresentable rather than by guarding the four readers then
+// known.
+//
+// Returning `func() int` does that here: there is no pointer to dereference, so
+// a caller cannot read the counter without going through the lock, and a future
+// call site cannot reintroduce the bug by omission.
+func installConntrackDeleteStub(t *testing.T, err error) func() int {
 	t.Helper()
 	orig := conntrackDeleteFilters
-	calls := 0
 	var mu sync.Mutex
+	calls := 0
 	conntrackDeleteFilters = func(netlink.InetFamily, ...netlink.CustomConntrackFilter) (uint, error) {
 		mu.Lock()
 		calls++
@@ -45,7 +63,11 @@ func installConntrackDeleteStub(t *testing.T, err error) *int {
 		return 0, err
 	}
 	t.Cleanup(func() { conntrackDeleteFilters = orig })
-	return &calls
+	return func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls
+	}
 }
 
 func flushReq6802() hostInboundConntrackFlushRequest {
@@ -89,10 +111,10 @@ func TestFlushReportsItsOutcome6802(t *testing.T) {
 		// Both families must still be attempted: their stale entries are
 		// independent, and abandoning v6 because v4 failed would leave half the
 		// revocation undone for a reason unrelated to v6.
-		if *calls != 2 {
+		if calls() != 2 {
 			t.Fatalf("conntrack delete attempted %d times, want 2 (one per "+
 				"address family) — a failure in one family must not abandon the "+
-				"other", *calls)
+				"other", calls())
 		}
 	})
 
@@ -145,11 +167,11 @@ func TestRetryReDrivesTheOwedRequest6802(t *testing.T) {
 		calls := installConntrackDeleteStub(t, errors.New("still failing"))
 		d := &Daemon{applySem: semaphore.NewWeighted(1)}
 		d.noteHostInboundConntrackFlush(flushReq6802(), false)
-		before := *calls
+		before := calls()
 
 		d.retryHostInboundConntrackFlushOnce(context.Background())
 
-		if *calls <= before {
+		if calls() <= before {
 			t.Fatal("the retry owner did not re-drive the owed revocation — " +
 				"no ticker under pkg/daemon re-runs the flush, so without this " +
 				"the only re-attempt is the next externally-triggered apply (#6802)")
@@ -166,9 +188,9 @@ func TestRetryReDrivesTheOwedRequest6802(t *testing.T) {
 
 		d.retryHostInboundConntrackFlushOnce(context.Background())
 
-		if *calls != 0 {
+		if calls() != 0 {
 			t.Fatalf("the retry owner dumped conntrack %d times with NO debt "+
-				"owed — the always-on loop must be free on a healthy node", *calls)
+				"owed — the always-on loop must be free on a healthy node", calls())
 		}
 	})
 
@@ -203,7 +225,7 @@ func TestRetryRechecksTheDebtInsideTheSemaphore6802(t *testing.T) {
 	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
 		t.Fatalf("Acquire: %v", err)
 	}
-	before := *calls
+	before := calls()
 
 	started := make(chan struct{})
 	done := make(chan struct{})
@@ -219,10 +241,10 @@ func TestRetryRechecksTheDebtInsideTheSemaphore6802(t *testing.T) {
 	d.applySem.Release(1)
 	<-done
 
-	if *calls != before {
+	if calls() != before {
 		t.Fatalf("the retry dumped conntrack %d extra times after the commit it "+
 			"queued behind had already cleared the debt — re-checking INSIDE the "+
-			"semaphore is what prevents that (#6802)", *calls-before)
+			"semaphore is what prevents that (#6802)", calls()-before)
 	}
 }
 
@@ -243,7 +265,7 @@ func TestRetryLoopTicks6802(t *testing.T) {
 	go func() { d.hostInboundConntrackReassertLoop(ctx); close(loopDone) }()
 
 	deadline := time.Now().Add(5 * time.Second)
-	for *calls == 0 {
+	for calls() == 0 {
 		if time.Now().After(deadline) {
 			cancel()
 			<-loopDone

--- a/pkg/daemon/ra_dead_sender_retry_6793_test.go
+++ b/pkg/daemon/ra_dead_sender_retry_6793_test.go
@@ -261,6 +261,28 @@ func TestReassertRechecksTheGateInsideTheSemaphore6793(t *testing.T) {
 		t.Fatalf("Acquire: %v", err)
 	}
 
+	// #7075: the probe seam is installed BEFORE the goroutine starts.
+	//
+	// It used to be assigned after `<-started`, while the goroutine was already
+	// inside reassertDeadRASendersOnce -> raHasDeadSenders(), which reads
+	// `d.raHasDeadSendersFn`. The `healthy` bool was correctly guarded by
+	// probeMu; the unguarded shared state was the SEAM ASSIGNMENT itself, one
+	// level up, and `go test -race ./pkg/daemon/` reported it deterministically.
+	//
+	// Installing it first costs the test nothing. The closure returns
+	// `!healthy`, and `healthy` starts false, so the gate reads exactly as it
+	// did before the flip. What the test is about — the tick re-checking the
+	// gate INSIDE the semaphore and seeing the rebuilt sender — is unchanged:
+	// the goroutine still blocks on applySem, `healthy` still flips under
+	// probeMu before the release, and the re-check still happens after it.
+	var probeMu sync.Mutex
+	healthy := false
+	d.raHasDeadSendersFn = func() bool {
+		probeMu.Lock()
+		defer probeMu.Unlock()
+		return !healthy
+	}
+
 	started := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
@@ -272,13 +294,6 @@ func TestReassertRechecksTheGateInsideTheSemaphore6793(t *testing.T) {
 
 	// The tick is now blocked on the semaphore (or about to be). Simulate the
 	// commit having rebuilt the sender, then let the tick through.
-	var probeMu sync.Mutex
-	healthy := false
-	d.raHasDeadSendersFn = func() bool {
-		probeMu.Lock()
-		defer probeMu.Unlock()
-		return !healthy
-	}
 	probeMu.Lock()
 	healthy = true
 	probeMu.Unlock()

--- a/pkg/daemon/webmgmt_bind_ifname_5714_test.go
+++ b/pkg/daemon/webmgmt_bind_ifname_5714_test.go
@@ -85,9 +85,9 @@ func TestWebMgmtBindUnresolvableLogsLoudError_5714(t *testing.T) {
 		return nil, fmt.Errorf("no such kernel interface: %s", kernelName)
 	}
 
-	var recs []captureRecord
+	sink := newCaptureSink()
 	prevLog := slog.Default()
-	slog.SetDefault(slog.New(capturingHandler{recs: &recs}))
+	slog.SetDefault(slog.New(capturingHandler{sink: sink}))
 	defer slog.SetDefault(prevLog)
 
 	d := &Daemon{}
@@ -95,7 +95,7 @@ func TestWebMgmtBindUnresolvableLogsLoudError_5714(t *testing.T) {
 	d.resolveAPIBinds(&apiCfg, webmgmtIfnameCfg("ge-0/0/9.0"))
 
 	var loud bool
-	for _, r := range recs {
+	for _, r := range sink.records() {
 		if r.level == slog.LevelError && r.attrs["interface"] == "ge-0/0/9.0" {
 			loud = true
 			break
@@ -103,7 +103,7 @@ func TestWebMgmtBindUnresolvableLogsLoudError_5714(t *testing.T) {
 	}
 	if !loud {
 		t.Fatalf("unresolvable web-mgmt interface must log a LOUD ERROR naming the interface, "+
-			"not a silent fallback; got records: %+v", recs)
+			"not a silent fallback; got records: %+v", sink.records())
 	}
 	// Fallback is retained (loopback), so the mgmt API still serves locally —
 	// on the canonical web-mgmt port (#5715), since `web-management http` is


### PR DESCRIPTION
`go test -race ./pkg/daemon/` fails at master on shared state in **test infrastructure**, not in the daemon. Three distinct pairs, all the same shape.

That is worse than a flake. A deterministic red in a gate trains reviewers to wave the leg through, and the next real race arrives looking exactly like this one. `pkg/daemon -race` is one of the gates this project uses to clear changes to the apply path — it is the one I ran on #7822 today, which is how these surfaced.

## All three are "published on one side only"

The mutex is held where the value is written and not where it is read. **A mutex held on one side of a publish establishes no happens-before for a reader that does not take it.**

Same shape as **#7012** (`d.mgmt` published under `staleCertMu` on the write side only), and the fix is the one that worked there: make the unguarded form **unrepresentable** rather than guarding the accesses known today. Guarding four readers leaves the fifth free to omit the lock; removing the pointer leaves nothing to omit.

### 1. `installConntrackDeleteStub` — #7825

```go
var mu sync.Mutex
conntrackDeleteFilters = func(...) (uint, error) {
    mu.Lock(); calls++; mu.Unlock()   // synchronised
    return 0, err
}
return &calls                          // ...and the reader gets a raw *int
```

The mutex is captured by the closure and never handed out, so **every read is unsynchronised** while the reassert loop the test starts is still writing. Now returns `func() int` — there is no pointer to dereference.

### 2. `capturingHandler` — #7075

Installed as the **global** slog default, so anything still logging writes through it, including goroutines the test never started and does not join (a leaked configstore `persistRetryLoop`). It appended to a caller-owned `*[]captureRecord` with no synchronisation at all.

The consequence worth naming: **the test it failed was whichever one happened to be running**, not the one that leaked the goroutine. That is why it was hard to attribute.

The mutex now lives inside the handler and records come back through `records()`, which returns a **copy** — handing out the live slice would move the race from the append to the caller's `range` loop, since the handler keeps appending for as long as it is the default.

### 3. The RA probe seam — found by the gate, named by neither issue

`TestReassertRechecksTheGateInsideTheSemaphore6793` assigned `d.raHasDeadSendersFn` **after** `<-started`, while the goroutine was already inside `raHasDeadSenders()` reading it.

The interesting part: the `healthy` bool **was** correctly guarded by `probeMu`. The unguarded state was the **seam assignment one level up** — the thing the careful mutex was protecting a value *inside* of. Guarding the value and leaving the publication unguarded is the same error as #1 and #2, one indirection out.

Fixed by installing the seam before the goroutine starts. That costs the test nothing: the closure returns `!healthy` and `healthy` starts false, so the gate reads exactly as it did before the flip, and the property under test — the tick re-checking the gate *inside* the semaphore and seeing the rebuilt sender — is untouched.

## Measurement

Same five tests, `go test -count=1 -race -v ./pkg/daemon/`:

| tree | rc | DATA RACE | named failures |
|---|---|---|---|
| pristine `origin/master` | 1 | 2 | `TestRetryLoopTicks6802`, `TestReassertRechecksTheGateInsideTheSemaphore6793` |
| after the #7825 + #7075 fixes | 1 | **1** | `TestReassertRechecksTheGateInsideTheSemaphore6793` |
| after the RA seam fix | **0** | **0** | — |

**The middle row is why the third fix is in this change.** Fixing the two the issues named left the leg red, and a leg that is still red is not a gate. It also shows the two issues' enumeration was a **floor**: one test carried two independent races, and finding the second required running the leg rather than reading the issues.

Whole-package confirmation on this branch: `go test -count=1 -race ./pkg/daemon/` → **rc=0, 0 DATA RACE, 0 failures**.

The pre-existing side was measured at pristine `origin/master` in a clean worktree **before** any of this was written — including a dedicated re-run of the RA test at master, which reproduces its race — so "not introduced here" is a measurement, not an inference.

Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched, no production code changed.

Docs: `docs/log/7075.md`.

Closes #7075
Closes #7825
