### PR TITLE
userspace-dp: mirror transit sessions into the BPF conntrack map (#6965)

### DIFF
--- a/docs/log/6965.md
+++ b/docs/log/6965.md
@@ -185,6 +185,42 @@ code: #4983's contract is the `{parent ifindex, VLAN}` PAIR (11 / 50), resolved
 to a unit on the Go side. A count-only test would have passed and the false
 contract would have gone in as documentation.
 
+## On-cluster before/after — the measurement, not the argument
+
+Run on the loss userspace cluster (`loss:xpf-userspace-fw0/fw1`) under the
+shared lock. Identical traffic both times, driven from
+`loss:cluster-userspace-host` (10.0.61.102): `iperf3 -c 172.16.80.200 -p 5201
+-t 25 -P 2` plus three pings, then `show security flow session` on **node0, the
+ACTIVE node that is forwarding those flows**.
+
+| build | node0 (ACTIVE, forwarding) | node1 (BACKUP) |
+|---|---|---|
+| master `4f2361829` | **Total sessions: 0** | 4 rows, all `lan -> wan` |
+| this branch | **Total sessions: 4**, all `lan -> wan` transit | 4 rows |
+
+The zero is the defect, and the pair of columns is what proves it is not a
+traffic problem: **node1 can see node0's transit sessions and node0 cannot.**
+The standby's rows are there because the GO side writes peer-synced sessions
+into the same map directly
+(`Manager.SetClusterSyncedSessionV4` -> `maps_session.go`), which is the
+"two writers" the architecture docs describe. So the flows demonstrably existed
+in node0's helper table — it synced them to its peer — while node0's own
+operator surface reported nothing.
+
+After the fix, node0 shows the flows with the identity intact:
+
+```
+Session ID: 1125899906842669, Policy name: unattributed/0, HA State: Active, ...
+  In: 10.0.61.102/47494 --> 172.16.80.200/5201;tcp, If: reth1, Zone: lan, Pkts: 0, Bytes: 0,
+  Out: 172.16.80.200/5201 --> 172.16.80.8/0;tcp, If: wan, Zone: wan, Pkts: 50159, Bytes: 3511138,
+```
+
+Zones (`lan` -> `wan`), interface names (`reth1` / `wan`) and live volume all
+render. **This is the check that had to be a transit session**: a fixture whose
+only flow is host-inbound would have printed rows on both builds. None of the
+four flows here is host-inbound, a missing-neighbor seed, or a reverse
+companion, so none of them could have carried a row at master.
+
 ## Mutation matrix
 
 Full binary, `--test-threads=1`, **no `-run` filter**, per-cell
@@ -221,9 +257,38 @@ precondition guard that is satisfied only by winning scheduler time. Filed as
 - `go build ./...` clean; full `go test ./... -count=1`.
 - Mutation cells N1-N3 above.
 - Microbenchmark as tabulated (3 runs per cell, 200,000 ops each).
-- **Cluster smoke owed and NOT run here**: this changes what the HA mirror
-  sweep sees, so `make cluster-deploy` + `make test-failover` is the validation
-  lane that applies. Stated rather than claimed.
+- **Cluster smoke RUN** on the loss userspace cluster under the shared lock:
+  `make cluster-deploy` (both nodes sha256-verified against the local build) +
+  `./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` (deploy wipes CoS) +
+  `make test-failover` -> **16 passed, 1 failed**.
+
+  Every HA assertion passed: crash failover (sysrq reboot of the primary),
+  rejoin as secondary with no auto-preempt, manual failover back, session sync
+  (19 sessions synced to the peer within 5s), and IPv4 + IPv6 transit before and
+  after each transition. That is the set this change could plausibly disturb,
+  since it widens what the HA mirror sweep sees.
+
+  The one failure is a **fixture collision, not a regression**, and it is
+  attributed with a like-for-like measurement rather than dismissed:
+
+  ```
+  FAIL  iperf3 throughput too low: 0.0937 Gbps (expected >= 1.0 Gbps)
+  ```
+
+  `test-failover.sh` runs iperf3 on the DEFAULT port 5201 against
+  `MIN_THROUGHPUT=1.0` Gbps, and `cos-iperf-config.set` — which the deploy
+  protocol REQUIRES re-applying — maps destination-port 5201 to forwarding-class
+  `iperf-100m`. Same box, same minute, same build:
+
+  | port | forwarding class | throughput | retransmits |
+  |---|---|---|---|
+  | 5201 | `iperf-100m` | 97.1 Mbit/s | 104 |
+  | 5211 | `iperf-uncapped` | **22.3 Gbit/s** | **0** |
+
+  97.1 Mbit/s is the 100 Mb/s shaper working. 22.3 Gbit/s at zero retransmits is
+  a healthy dataplane on this branch, in the band the engineering-style
+  validation table expects. Following the documented protocol makes this gate
+  fail every time; filed as **#7847**.
 
 ## Documentation updated in the same change
 

--- a/docs/log/6965.md
+++ b/docs/log/6965.md
@@ -153,7 +153,9 @@ nothing keys on the id.
 
 The sweep-volume question is **not** resolved here and does not ride in this
 PR: whether the 15s mirror sweep should skip what the delta stream already
-covers is a behaviour choice for the HA path, and it is filed separately.
+covers is a behaviour choice for the HA path, filed as **#7842** with the three
+options and the counters that would settle it (`stats.SessionsSent`,
+`stats.Errors`, sampled at a realistic connection rate — not reasoned about).
 
 ## Tests
 

--- a/docs/log/6965.md
+++ b/docs/log/6965.md
@@ -1,0 +1,247 @@
+# 6965 — transit sessions are invisible to `show security flow session`
+
+## The defect
+
+`show security flow session` enumerates the BPF conntrack map
+(`pkg/dataplane/maps_session.go`'s `Manager.IterateSessions` over
+`m.maps["sessions"]`). Ordinary **transit** sessions were never published there
+— not with a zeroed identity, **no row at all** — so for the dominant traffic
+population the command, and every filter built on it, showed nothing.
+
+Two maps, not one pin under two names:
+
+| | pin | key | value | max_entries |
+|---|---|---|---|---|
+| steering | `/sys/fs/bpf/xpf/userspace_sessions` | `UserspaceSessionMapKey`, 40 B | `u8` action | 262,144 (shim ELF) |
+| conntrack mirror | `/sys/fs/bpf/xpf/sessions` | `BpfSessionKeyV4`, 16 B | `BpfSessionValueV4`, 144 B | 10,000,000 (Go, `loader_userspace_shim.go`) |
+
+The transit forward install called `publish_live_session_entry` (steering) and
+`publish_shared_session` (shared/HA), never `publish_bpf_conntrack_entry`. Only
+three sites in `poll_descriptor` reached the mirror: the host-inbound
+`LocalMiss` install, the `MissingNeighborSeed` install, and the
+reverse-companion repair — whose row is `is_reverse != 0` and is discarded by
+every `show`/`clear` call site before it filters. Dates to `fab9230c5`.
+
+This is the shape #6656 reports: 4.6M rx packets, 33 sessions.
+
+## Which end moves — the decision, and the rivals
+
+### Chosen: publish at the transit forward install
+
+One `publish_bpf_conntrack_entry` at the site labelled *"#4800: the single
+place a locally learned transit forward flow is installed"*, mirroring the
+neighbor-seed site argument for argument.
+
+**Cost, measured rather than argued.** A standalone microbenchmark
+(`/var/tmp/wt6965/ctbench.c`, run under `sudo` because `bpf(BPF_MAP_CREATE)`
+needs CAP_BPF) creates maps of the exact production shape and times
+`bpf_map_update_elem`, 200,000 ops per cell, on this box at load average ~20/16
+cores:
+
+| map under test | insert-new | update-existing |
+|---|---|---|
+| conntrack (16 B key, 144 B value, 10,000,000 entries, `NO_PREALLOC`) | 1185 / 1385 / 1230 ns | 1131 / 1159 / 1037 ns |
+| steering (40 B key, 1 B value, 262,144 entries, prealloc) | 1136 / 1177 / 979 ns | 1136 / 1222 / 1009 ns |
+
+**The number that decides it is the RATIO, not the absolute.** A conntrack
+update is per-call indistinguishable from a steering update — the 144-byte
+value and the 10M-entry `NO_PREALLOC` table cost nothing measurable over the
+1-byte value in a preallocated one, because the syscall dominates. The transit
+install already performs several of these (`publish_live_session_entry` writes
+1-4 keys; `publish_dnat_table_entry` adds 1), so this is one more of what the
+path already does: **+14% to +33% of its BPF-syscall work**, ~1.1-1.4 us per
+new connection.
+
+**Capacity is not a constraint, with a number.** The mirror holds 10,000,000
+entries against a helper ceiling of `DEFAULT_MAX_SESSIONS` = 131,072 per worker
+(6 workers on the loss cluster → 786,432 worst case). The issue listed
+"what happens at conntrack-map capacity once the mirror becomes near-complete"
+as an open decision; it is answered by a factor of 12.
+
+### Rejected: make the operator surface read the real source
+
+The real source is the helper's in-memory `SessionTable`. There is **no session
+list/snapshot RPC on the control socket** — `userspace-dp/src/protocol/control.rs`
+carries status, config, neighbor, fabric and delta messages, and nothing that
+enumerates sessions. Building one means adding a bulk, operator-triggered
+consumer to a socket that `CLAUDE.md` names explicitly:
+
+> The userspace helper control socket is shared by status poll (1/s), HA sync,
+> session installs, snapshot sync, and forwarding sync. High-frequency callers
+> MUST be throttled. Adding a new control socket request at >1/s will starve
+> session installs during bulk sync.
+
+A `show security flow session` is not >1/s, but a chunked dump of up to ~786K
+sessions occupies that socket for the duration, against session installs. And
+the surface change is not one command: `IterateSessions` and its siblings feed
+the CLI, gRPC (`server_sessions.go`, `server_show_flow.go`), REST
+(`pkg/api/sessions.go`), Prometheus (`metrics_sessions.go`), `natshow`, the
+conntrack GC, and the cluster sync paths. Rejected on cost and blast radius,
+not on principle.
+
+### Rejected: populate the mirror from the existing paced refresh walk
+
+Genuinely attractive, and worth recording because it costs **zero** syscalls on
+the packet path. `refresh_bpf_conntrack_last_seen` (#5287) already walks live
+forward sessions on a budgeted slice (100ms cadence, 10s window), already does
+a `bpf_map_lookup_elem` per entry, and already skips when the row is absent —
+so the walk visits every transit session today and pays the lookup. Publishing
+on that miss would populate the mirror for free at install time.
+
+Rejected on **operator semantics**: the row would appear up to one refresh
+cycle late (~6.4s at the default cap, longer above it), so a session would not
+be visible immediately after it is established and a flow shorter than the
+cycle might never appear at all. Junos shows a session as soon as it exists.
+Trading a correct answer for a cheaper one is the wrong trade when the cost is
+one syscall on a path that already makes several — engineering-style's
+"correctness first, performance second".
+
+The `BPF_EXIST` flag on that walk (*"avoid recreating deleted entries"*) would
+also have had to become `BPF_ANY`, which changes what happens when Go deletes a
+row for a session the helper still holds. Not a blocker, but a second decision
+riding along.
+
+## Forward only
+
+The reverse companion installed two dozen lines later in the same arm gets no
+row. Every consumer skips it before it filters — `val.IsReverse != 0` precedes
+the filter in `pkg/cli/cli_show_flow.go`, `pkg/grpcapi/server_sessions.go`,
+`pkg/api/sessions.go` and the `natshow` sources — so a reverse row costs a
+syscall per connection for something that can never surface a flow, and the
+forward row already carries BOTH directions' counters (#2501). The issue listed
+this as open decision 1; `transit_reverse_companion_gets_no_conntrack_row_6965`
+pins the answer, and cell N2 shows the over-reach reds.
+
+## Consequences that are NOT display-only — stated, because they were nearly missed
+
+`show security flow session` was not the only reader. Two are worth naming:
+
+**1. `SessionCount` / Prometheus / `/status` start telling the truth.**
+`maps_session.go`'s `SessionCount` counts `IsReverse == 0` rows, i.e. it
+counted host-inbound + neighbor-seed + Go-installed peer-synced rows and never
+transit. `pkg/api/metrics_sessions.go` feeds `xpf_sessions_active` /
+`_established` from the same walk. Those gauges will **step up sharply** on
+upgrade. That is the fix for #6656, not a regression — but an operator with an
+alert threshold on `xpf_sessions_active` will see it fire, and that belongs in
+release notes rather than being discovered.
+
+**2. The HA incremental sweep now covers transit — a widening, not a break.**
+`pkg/cluster/sync_conn_sweep.go`'s `syncSweep` walks the mirror
+(`ForEachV4`/`ForEachV6`), skips `IsReverse != 0`, and queues every row with
+`Created >= lastSweepTime` to the peer. It is NOT disabled under the userspace
+dataplane — `Manager.SessionSyncSweepProfile` only slows it to 15s/60s, with
+the comment *"userspace forwarding already streams authoritative open/close
+deltas. Keep a periodic refresh for long-lived flows."* So:
+
+- Transit sessions are **already** synced to the peer, by the delta stream
+  (`daemon_ha_userspace_stream.go` → `queueUserspaceSessionDeltas`).
+- After this change the 15s sweep **also** queues them, so newly created
+  transit sessions are sent twice.
+- The duplicate is an idempotent upsert on the receiver, so it is a **volume**
+  question, not a correctness one — and duplication already existed for the
+  host-inbound and neighbor-seed populations, which the sweep and the delta
+  stream both covered. What changes is the size of the duplicated set.
+- Read the other way, it is a repair: the mirror-walk backstop was
+  *structurally blind* to the population an HA firewall actually protects, and
+  now is not.
+
+`docs/session-sync-architecture.md` predicted this in as many words — *"if
+#6965 is ever closed, the transit population lands in the mirror with
+helper-minted ids and this two-writer surface widens sharply"* — and its safety
+argument is unchanged: #6311 gave every session id a node discriminator bit, and
+nothing keys on the id.
+
+The sweep-volume question is **not** resolved here and does not ride in this
+PR: whether the 15s mirror sweep should skip what the delta stream already
+covers is a behaviour choice for the HA path, and it is filed separately.
+
+## Tests
+
+The trap this had to avoid: **a check that `show security flow session` prints
+rows proves nothing.** It printed rows before the fix — host-inbound and
+neighbor-seed sessions were always mirrored — so a fixture whose only session is
+host-inbound is mutation-insensitive here. The subject must be a TRANSIT
+session.
+
+`tests_session_ingress_identity.rs` already had exactly that fixture from
+#4983: `run_ingress_identity_flow`, a permitted lan → wan SYN driven through
+the real `poll_binding_process_descriptor`, `ForwardCandidate` with a resolved
+neighbor, which reaches none of the three pre-existing publish sites.
+
+The unit driver passes `-1` for both conntrack fds, so nothing is written to
+any map and there is nothing to read back. That is the correct scope: the
+defect IS a missing call site, so the property is the CALL and its ARGUMENTS.
+A test-only recorder captures each `publish_bpf_conntrack_entry` with
+`is_reverse`, the ingress pair, both zones, `app_id` and `session_id`. The value
+SHAPE those arguments produce is a different property, already owned by
+`bpf_map_tests.rs` (`build_conntrack_value_v4/v6`), and is deliberately not
+restated — the two together are the chain.
+
+**Asserting arguments rather than a count paid for itself immediately.** The
+first draft asserted the resolved LOGICAL ifindex (13) and reddened on correct
+code: #4983's contract is the `{parent ifindex, VLAN}` PAIR (11 / 50), resolved
+to a unit on the Go side. A count-only test would have passed and the false
+contract would have gone in as documentation.
+
+## Mutation matrix
+
+Full binary, `--test-threads=1`, **no `-run` filter**, per-cell
+`CARGO_TARGET_DIR` under `/var/tmp`. RED requires a **named** failure with
+**tests-collected > 0**; `rc != 0` with no named test is a build break.
+
+| cell | mutation | result | collected | named failure(s) |
+|---|---|---|---|---|
+| **N1** | remove the new transit `publish_bpf_conntrack_entry` (revert #6965) | **RED** | 4723 | `transit_forward_install_publishes_a_conntrack_row_6965` — and ONLY that one |
+| **N2** | also publish the reverse companion (the over-reach) | **RED** | 4723 | `transit_reverse_companion_gets_no_conntrack_row_6965`, `transit_forward_install_publishes_a_conntrack_row_6965` |
+| **N3** | pass `session_id: 0` instead of resolving it (#5213) | **RED** | 4723 | `transit_forward_install_publishes_a_conntrack_row_6965` |
+
+**N1 is the proof obligation and the localising pair at once.** It reds the
+transit test and leaves `local_miss_install_still_publishes_a_conntrack_row_6965`
+GREEN — which is what says the transit assertion is about the transit call and
+not about the recorder working. A cell that reddened both would have proved
+only that the instrument exists.
+
+## Incidental sighting, filed separately
+
+Cell N3's run also reddened
+`filter::policer::tests::concurrent_refill_under_contention_neither_over_nor_under_grants_6307`
+with *"no op observed another thread's clock advance: the threads ran serially
+and the refill race was never exercised"*. No causal path from an N3 mutation
+that changes a `session_id` argument. 0-of-30 isolated on the same binary; 1
+sighting under full-suite load. It is the **#6989 class** — a non-vacuity
+precondition guard that is satisfied only by winning scheduler time. Filed as
+**#7841** rather than folded in.
+
+## Validation
+
+- `cargo test --manifest-path userspace-dp/Cargo.toml --release --bins --
+  --test-threads=1`: 4723 collected, **4721 passed / 0 failed / 2 ignored**.
+- `go build ./...` clean; full `go test ./... -count=1`.
+- Mutation cells N1-N3 above.
+- Microbenchmark as tabulated (3 runs per cell, 200,000 ops each).
+- **Cluster smoke owed and NOT run here**: this changes what the HA mirror
+  sweep sees, so `make cluster-deploy` + `make test-failover` is the validation
+  lane that applies. Stated rather than claimed.
+
+## Documentation updated in the same change
+
+Nine places asserted "three sites" or "a transit session has no conntrack row
+at all". Every one is a claim this change falsifies, so every one moves with it:
+
+| file | what it claimed |
+|---|---|
+| `userspace-dp/src/session/README.md` | the three-site count, the "transit does NOT publish there" paragraph, and the operator-visibility scope |
+| `userspace-dp/src/session/entry.rs` | the `SCOPE (#6965)` doc block on `ingress_ifindex` |
+| `userspace-dp/src/afxdp/tests_session_ingress_identity.rs` | the file header's "they do not, and cannot, assert…" scope note |
+| `pkg/dataplane/types.go` (×2, v4 and v6) | "a transit session has NO row in this map at all" |
+| `pkg/dataplane/maps_session.go` | what `IterateSessions` enumerates |
+| `docs/session-sync-architecture.md` (×2) | the #6031 mirror-blindness rationale and the predicted widening |
+| `docs/sync-protocol.md` | the table-truth window-source rationale |
+| `pkg/cluster/sync.go` | `BulkSnapshotSource`'s "structurally absent from that walk" |
+| `pkg/daemon/daemon_ha_userspace_export.go` | the same claim on the export side |
+
+The #6031 rationale is **amended, not deleted**. The mirror stops being blind to
+transit, but it is still a best-effort copy of a table the helper owns — a
+publish that fails under map pressure is counted, not retried — so it is not
+table-truth however complete it becomes, and the table-truth window source
+stays.

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -407,14 +407,26 @@ framed VERBATIM — see "Why the window is not framed from the BPF mirror" below
 
 `BulkSync()`'s `ForEachV4/V6` walk reads the pinned `sessions` / `sessions_v6`
 BPF **conntrack** maps. Under the userspace dataplane those maps are a
-best-effort **display mirror**, not the authoritative session set. The Rust
-helper publishes a conntrack row (`publish_bpf_conntrack_entry`) from only three
-sites in `afxdp/poll_descriptor`: the host-inbound (LocalMiss) install, the
-missing-neighbor seed, and the reverse-companion repair. The ordinary **transit**
-forward install — the site labelled "#4800: the single place a locally learned
-transit forward flow is installed" — writes only the shim steering map
-(`publish_live_session_entry`) and the shared session tables. **A transit session
-therefore has no conntrack row at all**, and the store walk cannot see it.
+best-effort **display mirror**, not the authoritative session set.
+
+When #6031 was written the gap was total: the Rust helper published a conntrack
+row (`publish_bpf_conntrack_entry`) from only three sites in
+`afxdp/poll_descriptor` — the host-inbound (LocalMiss) install, the
+missing-neighbor seed, and the reverse-companion repair — and the ordinary
+**transit** forward install, the site labelled "#4800: the single place a
+locally learned transit forward flow is installed", wrote only the shim
+steering map (`publish_live_session_entry`) and the shared session tables. **A
+transit session therefore had no conntrack row at all**, and the store walk
+could not see it.
+
+**#6965 added the transit publish, so that particular blindness is gone — and
+#6031's conclusion is unchanged anyway.** The mirror is still a DISPLAY mirror
+rather than table-truth, for a reason that has nothing to do with which sites
+publish: the helper owns session lifetime in its own `SessionTable`, the mirror
+is written best-effort (a publish that fails under map pressure is counted, not
+retried), and the Go GC has `SkipSweep` set precisely because the map is not
+authoritative. Framing the window from it would still be framing it from a
+copy. The table-truth window source stays.
 
 The standby's copy of that same session IS in its mirror, because the Go receive
 path writes it (`userspace.Manager.SetClusterSyncedSessionV4` →
@@ -998,10 +1010,18 @@ guard. The blast radius is display-only.
 
 **What it does NOT close**, so the claim is not over-stated: synthesized reverse
 companions still carry `session_id: 0` (they are not displayed — the CLI skips
-reverse rows), and #6965 means an ordinary TRANSIT session has no conntrack row
-at all, so the population this improves is the peer-synced, host-inbound and
-neighbor-seed sets. If #6965 is ever closed, the transit population lands in the
-mirror with helper-minted ids and this two-writer surface widens sharply.
+reverse rows), and until #6965 an ordinary TRANSIT session had no conntrack row
+at all, so the population this improved was the peer-synced, host-inbound and
+neighbor-seed sets.
+
+**#6965 IS now closed, and this is the widening it predicted.** The transit
+population lands in the mirror with helper-minted ids, so the two-writer
+surface described above now covers the dominant population rather than a
+minority of it. The safety argument is unchanged and is what makes the widening
+tolerable: #6311 gave every id a node discriminator bit, so an adopted peer id
+cannot collide with a locally minted one, and nothing keys on the id — a sweep
+of every non-test `SessionID` reference finds no map key, index, dedup or
+generation guard. The blast radius stays display-only, at a larger scale.
 
 ## Sync Readiness and Bulk Priming
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -1110,10 +1110,14 @@ framed unconditionally, so an override can never re-send empty markers.
 #### Table-truth window source (#6031)
 
 The window's session SOURCE is no longer the shim `sessions`/`sessions_v6` BPF
-maps. Under the userspace dataplane those are a best-effort **display mirror**:
-the helper publishes a conntrack row only on the host-inbound install, the
-missing-neighbor seed, and the reverse-companion repair, so a **transit** session
-— which is what an HA firewall is actually protecting — has no row there at all.
+maps. Under the userspace dataplane those are a best-effort **display mirror**.
+When this was written the helper published a conntrack row only on the
+host-inbound install, the missing-neighbor seed, and the reverse-companion
+repair, so a **transit** session — which is what an HA firewall is actually
+protecting — had no row there at all. #6965 added the transit publish, but the
+reason for moving the window source stands without it: the mirror is a
+best-effort copy of a table the helper owns, so it is not table-truth however
+complete it becomes.
 Combined with the authoritative reconcile above (absent from the window ⇒
 DELETED), framing the window from that mirror deleted the standby's live
 peer-owned transit sessions on every cold prime, survivor re-drive, and forced

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -684,10 +684,14 @@ type SessionSync struct {
 	//
 	// BulkSync's ForEachV4/V6 walk reads the `sessions`/`sessions_v6` BPF
 	// conntrack maps, which under the userspace dataplane are a best-effort
-	// DISPLAY mirror, not the authoritative session set: the Rust helper's
-	// transit forward install publishes only the shim steering map and its
-	// shared session tables, never publish_bpf_conntrack_entry, so a TRANSIT
-	// session is structurally absent from that walk. Since #5085 made the
+	// DISPLAY mirror, not the authoritative session set. Until #6965 the Rust
+	// helper's transit forward install published only the shim steering map and
+	// its shared session tables, never publish_bpf_conntrack_entry, so a TRANSIT
+	// session was structurally absent from that walk; it is published now, but
+	// the mirror is still a best-effort copy of a table the helper OWNS — a
+	// publish that fails under map pressure is counted, not retried — so this
+	// source stays non-authoritative however complete it becomes. Since #5085
+	// made the
 	// receiver reconcile authoritatively against the delimited window, framing
 	// it from the mirror DELETES exactly the live peer-owned transit sessions
 	// the standby needs at failover. A table-truth source closes that.

--- a/pkg/daemon/daemon_ha_userspace_export.go
+++ b/pkg/daemon/daemon_ha_userspace_export.go
@@ -65,12 +65,15 @@ func (d *Daemon) exportUserspaceOwnerRGSessionsWithConfig(
 //
 // This is the table-truth counterpart to cluster.SessionSync.BulkSync's walk of
 // the `sessions`/`sessions_v6` BPF conntrack maps. Those maps are a best-effort
-// DISPLAY mirror: the Rust helper publishes a conntrack row only on the
-// host-inbound install, the missing-neighbor seed, and the reverse-companion
-// repair. The ordinary TRANSIT forward install — "the single place a locally
+// DISPLAY mirror. Until #6965 the Rust helper published a conntrack row only on
+// the host-inbound install, the missing-neighbor seed, and the reverse-companion
+// repair, and the ordinary TRANSIT forward install — "the single place a locally
 // learned transit forward flow is installed", userspace-dp
-// afxdp/poll_descriptor — writes only the shim steering map and the shared
-// session tables, so a transit session is STRUCTURALLY absent from that walk.
+// afxdp/poll_descriptor — wrote only the shim steering map and the shared
+// session tables, so a transit session was STRUCTURALLY absent from that walk.
+// #6965 added the transit publish; the mirror is nonetheless a best-effort copy
+// of a table the helper OWNS, so it is not table-truth however complete it is,
+// and this export stays the authoritative source.
 // Since #5085 the receiver reconciles authoritatively against the delimited
 // window and DELETES every eligible session missing from it, so a mirror-framed
 // cold prime wipes exactly the live peer-owned transit sessions the standby

--- a/pkg/dataplane/maps_session.go
+++ b/pkg/dataplane/maps_session.go
@@ -36,7 +36,10 @@ func IsKeyNotFound(err error) bool {
 // fn receives the key and value; return false to stop iteration.
 //
 // When the userspace dataplane is active, this map contains mirrored
-// sessions written by the Rust helper's publish_bpf_conntrack_entry.
+// sessions written by the Rust helper's publish_bpf_conntrack_entry —
+// since #6965 that includes ordinary TRANSIT sessions, which previously
+// had no row here at all and were therefore invisible to every caller
+// of this function.
 // The helper periodically refreshes LastSeen (~10s) so callers see
 // reasonably accurate idle times.  Session lifetime is owned by the
 // helper, not Go GC (GC.SkipSweep is set).  See #333.

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -84,20 +84,21 @@ type SessionValue struct {
 	// carry the peer's node-local ifindex. Both are listed among the
 	// legitimate zeros below.
 	//
-	// Of the frame-driven stamps, only some reach THIS map, which is what
-	// IterateSessions — and therefore `show`/`clear security flow session` —
-	// enumerates. The helper's publish_bpf_conntrack_entry is called from only
-	// three sites in afxdp/poll_descriptor: the host-inbound (LocalMiss)
-	// install, the missing-neighbor-seed install, and the reverse-companion
-	// repair (whose row is IsReverse != 0 and is skipped before filtering).
-	// The ordinary TRANSIT forward install does NOT publish here — it writes
-	// the shim's separate steering table via publish_live_session_entry — so a
-	// transit session has NO row in this map at all, and an interface filter
-	// cannot select it either way. That gap predates #4983 (it dates to the
-	// commit that first added the conntrack mirror) and is tracked as #6965;
-	// until it is closed, this field is operator-visible for the host-inbound
+	// The frame-driven stamps reach THIS map, which is what IterateSessions —
+	// and therefore `show`/`clear security flow session` — enumerates. The
+	// helper's publish_bpf_conntrack_entry is called from four sites in
+	// afxdp/poll_descriptor: the TRANSIT forward install (#6965), the
+	// host-inbound (LocalMiss) install, the missing-neighbor-seed install, and
+	// the reverse-companion repair (whose row is IsReverse != 0 and is skipped
+	// before filtering). Before #6965 the transit install did NOT publish here
+	// — it wrote only the shim's separate steering table via
+	// publish_live_session_entry — so a transit session had NO row in this map
+	// at all, and an interface filter could not select it either way. That gap
+	// predated #4983 (it dated to the commit that first added the conntrack
+	// mirror). This field is now operator-visible for the transit, host-inbound
 	// and missing-neighbor-seed populations plus peer-synced sessions the Go
-	// side installs directly.
+	// side installs directly. What it carries is the {parent ifindex, VLAN}
+	// PAIR; the unit is resolved on this side.
 	//
 	// 0 means "no ingress identity carried" and is NEVER a valid ifindex. These
 	// populations legitimately carry 0 and MUST keep working:
@@ -390,20 +391,21 @@ type SessionValueV6 struct {
 	// carry the peer's node-local ifindex. Both are listed among the
 	// legitimate zeros below.
 	//
-	// Of the frame-driven stamps, only some reach THIS map, which is what
-	// IterateSessions — and therefore `show`/`clear security flow session` —
-	// enumerates. The helper's publish_bpf_conntrack_entry is called from only
-	// three sites in afxdp/poll_descriptor: the host-inbound (LocalMiss)
-	// install, the missing-neighbor-seed install, and the reverse-companion
-	// repair (whose row is IsReverse != 0 and is skipped before filtering).
-	// The ordinary TRANSIT forward install does NOT publish here — it writes
-	// the shim's separate steering table via publish_live_session_entry — so a
-	// transit session has NO row in this map at all, and an interface filter
-	// cannot select it either way. That gap predates #4983 (it dates to the
-	// commit that first added the conntrack mirror) and is tracked as #6965;
-	// until it is closed, this field is operator-visible for the host-inbound
+	// The frame-driven stamps reach THIS map, which is what IterateSessions —
+	// and therefore `show`/`clear security flow session` — enumerates. The
+	// helper's publish_bpf_conntrack_entry is called from four sites in
+	// afxdp/poll_descriptor: the TRANSIT forward install (#6965), the
+	// host-inbound (LocalMiss) install, the missing-neighbor-seed install, and
+	// the reverse-companion repair (whose row is IsReverse != 0 and is skipped
+	// before filtering). Before #6965 the transit install did NOT publish here
+	// — it wrote only the shim's separate steering table via
+	// publish_live_session_entry — so a transit session had NO row in this map
+	// at all, and an interface filter could not select it either way. That gap
+	// predated #4983 (it dated to the commit that first added the conntrack
+	// mirror). This field is now operator-visible for the transit, host-inbound
 	// and missing-neighbor-seed populations plus peer-synced sessions the Go
-	// side installs directly.
+	// side installs directly. What it carries is the {parent ifindex, VLAN}
+	// PAIR; the unit is resolved on this side.
 	//
 	// 0 means "no ingress identity carried" and is NEVER a valid ifindex. These
 	// populations legitimately carry 0 and MUST keep working:

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -372,6 +372,74 @@ const SESS_STATE_ESTABLISHED: u8 = 4;
 ///
 /// `conntrack_v4_fd` / `conntrack_v6_fd`: FDs for the pinned `sessions` / `sessions_v6`
 /// BPF HASH maps. Pass -1 if unavailable (will be a no-op).
+/// #6965 fail-on-revert instrumentation: every `publish_bpf_conntrack_entry`
+/// call, recorded with enough of its arguments to say WHICH population it came
+/// from.
+///
+/// A bare counter would not do the job here. The test driver
+/// (`tests_support::txn_run_descriptor`) passes `-1` for both conntrack fds, so
+/// no row is ever written in a unit test and there is nothing in a map to read
+/// back. What the #6965 defect actually IS, though, is a MISSING CALL SITE —
+/// the transit forward install never called this function at all — so the
+/// property to bind is the call and its arguments, not the map write. The value
+/// SHAPE this function produces from those arguments is a different property
+/// and is already owned by `bpf_map_tests.rs`
+/// (`build_conntrack_value_v4`/`_v6`); this recorder deliberately does not
+/// restate it.
+///
+/// Recording the ingress identity and `is_reverse` rather than counting is what
+/// makes the transit assertion non-vacuous: a count of 1 is also what you get
+/// from a publish of the WRONG row, and the three pre-existing call sites all
+/// publish rows this fixture must not be satisfied by.
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ConntrackPublishRecord {
+    pub(super) is_reverse: bool,
+    pub(super) ingress_ifindex: u32,
+    pub(super) ingress_vlan_id: u16,
+    pub(super) ingress_zone: u16,
+    pub(super) egress_zone: u16,
+    pub(super) app_id: u16,
+    pub(super) session_id: u64,
+}
+
+#[cfg(test)]
+pub(super) static CONNTRACK_PUBLISHES: std::sync::Mutex<Vec<ConntrackPublishRecord>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// #6965: the ONE mutex that serializes tests SAMPLING `CONNTRACK_PUBLISHES`.
+///
+/// Module scope for the same reason as `checksum::DNAT_COUNTER_GUARD` (#6872):
+/// a `static` declared inside a test function body is unnameable from any other
+/// function, so two tests each declaring one lock private mutexes and exclude
+/// nobody. This does NOT mutually exclude the writer below — that is production
+/// code on the install path and must not take a lock — it serializes the
+/// samplers against each other, which is the shape that breaks.
+#[cfg(test)]
+pub(super) static CONNTRACK_PUBLISH_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// #6965: clear the recorder and return the guard, so a sampling test cannot
+/// forget either half.
+#[cfg(test)]
+pub(super) fn take_conntrack_publish_guard() -> std::sync::MutexGuard<'static, ()> {
+    let guard = CONNTRACK_PUBLISH_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    CONNTRACK_PUBLISHES
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+    guard
+}
+
+#[cfg(test)]
+pub(super) fn conntrack_publishes() -> Vec<ConntrackPublishRecord> {
+    CONNTRACK_PUBLISHES
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
 pub(super) fn publish_bpf_conntrack_entry(
     conntrack_v4_fd: c_int,
     conntrack_v6_fd: c_int,
@@ -395,6 +463,25 @@ pub(super) fn publish_bpf_conntrack_entry(
     // unknown (no live entry) — the Go render then keeps the legacy ordinal.
     session_id: u64,
 ) {
+    // #6965: record the call BEFORE the `fd >= 0` gate below. The gate is what
+    // makes this a no-op under a unit test's `-1` fds, and the property the
+    // #6965 tests bind is that the call SITE exists on the transit install
+    // path — which is fd-independent.
+    #[cfg(test)]
+    {
+        CONNTRACK_PUBLISHES
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(ConntrackPublishRecord {
+                is_reverse: metadata.is_reverse,
+                ingress_ifindex: metadata.ingress_ifindex,
+                ingress_vlan_id: metadata.ingress_vlan_id,
+                ingress_zone: metadata.ingress_zone,
+                egress_zone: metadata.egress_zone,
+                app_id,
+                session_id,
+            });
+    }
     // #919: zones are now u16 in SessionMetadata; the round-trip
     // name→id lookup the old code did is gone.
     let ingress_zone_id = metadata.ingress_zone;

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2683,6 +2683,71 @@ pub(super) fn poll_binding_process_descriptor(
                                             .live
                                             .new_flow_installs
                                             .fetch_add(1, Ordering::Relaxed);
+                                        // #6965: mirror the TRANSIT forward
+                                        // session into the kernel-visible
+                                        // conntrack map. Until this call
+                                        // existed, `publish_bpf_conntrack_entry`
+                                        // was reached only from the host-inbound
+                                        // LocalMiss install, the
+                                        // MissingNeighborSeed install and the
+                                        // reverse-companion repair — so the
+                                        // DOMINANT population, ordinary transit
+                                        // flows, had NO row in the map that
+                                        // `show security flow session`
+                                        // enumerates. Not a row with a zeroed
+                                        // identity: no row at all, which is why
+                                        // #6656 saw 33 sessions on a node
+                                        // carrying 4.6M rx packets.
+                                        //
+                                        // FORWARD ONLY. The reverse companion
+                                        // installed below deliberately gets no
+                                        // row: every `show`/`clear` call site
+                                        // skips `IsReverse != 0` before
+                                        // filtering, so a reverse row costs a
+                                        // syscall per connection and can never
+                                        // surface a flow. The forward row
+                                        // already carries BOTH directions'
+                                        // counters (#2501).
+                                        //
+                                        // Cost: one `bpf_map_update_elem` on
+                                        // the new-flow path, which already
+                                        // performs several (the steering
+                                        // publish above is 1-4, `dnat_table`
+                                        // below is 1). Measured at ~1.1-1.4us,
+                                        // indistinguishable per-call from the
+                                        // steering writes it joins — see
+                                        // docs/log/6965.md.
+                                        //
+                                        // #2008 M5 / #3321 / #3416: directional
+                                        // app resolution off the POST-DNAT
+                                        // destination, identical to the
+                                        // neighbor-seed site.
+                                        let ct_app_id = worker_ctx
+                                            .forwarding
+                                            .app_catalog
+                                            .lookup_admitted(
+                                                flow.forward_key.protocol,
+                                                flow.forward_key.src_port,
+                                                flow.forward_key.dst_port,
+                                                forward_entry.metadata.is_reverse,
+                                                decision.nat.rewrite_dst_port,
+                                            );
+                                        // #5213: the stable id of the session
+                                        // just installed, so the mirrored row
+                                        // reports the SAME id RT_FLOW emits.
+                                        let ct_session_id =
+                                            sessions.session_id_for(&flow.forward_key);
+                                        publish_bpf_conntrack_entry(
+                                            conntrack_v4_fd,
+                                            conntrack_v6_fd,
+                                            &flow.forward_key,
+                                            decision,
+                                            &forward_entry.metadata,
+                                            &worker_ctx.forwarding.zone_name_to_id,
+                                            worker_ctx.forwarding.alg_disable_flags,
+                                            ct_app_id,
+                                            ct_session_id,
+                                        );
                                         publish_shared_session(
                                             worker_ctx.shared_sessions,
                                             worker_ctx.shared_nat_sessions,

--- a/userspace-dp/src/afxdp/tests_session_ingress_identity.rs
+++ b/userspace-dp/src/afxdp/tests_session_ingress_identity.rs
@@ -37,17 +37,23 @@
 //   - the MISSING-NEIGHBOR seed (`build_missing_neighbor_session_metadata`);
 //   - and the REVERSE companion, whose 0 is asserted as an over-reach guard.
 //
-// SCOPE, stated plainly because it is easy to over-read: these tests bind what
-// the poll body STAMPS onto the installed session. They do not, and cannot,
-// assert that a TRANSIT session's identity reaches the operator-visible BPF
-// conntrack map — the transit install does not publish there at all (it calls
-// `publish_live_session_entry`, which writes shim steering KEYS into a
-// different map, plus `publish_shared_session`). Only the LocalMiss and
-// missing-neighbor-seed installs call `publish_bpf_conntrack_entry`, and their
-// tests below DO drive that call. The transit gap predates #4983 — it dates to
-// `fab9230c5`, the commit that first added the conntrack mirror and wired only
-// those sites — and is tracked as #6965. Read these tests as "the stamp is
-// correct", not "the operator can see it for every session".
+// SCOPE. The #4983 tests here bind what the poll body STAMPS onto the installed
+// session. Whether that stamp reaches the operator-visible BPF conntrack map is
+// a SEPARATE property, and it used to be one this file could not assert for a
+// transit flow: the transit install did not publish to the mirror at all (it
+// called only `publish_live_session_entry`, which writes shim steering KEYS
+// into a different map, plus `publish_shared_session`), so there was no call to
+// omit. That gap predated #4983 — it dated to `fab9230c5`, the commit that
+// first added the conntrack mirror and wired only the LocalMiss,
+// missing-neighbor-seed and reverse-companion sites — and it was #6965.
+//
+// #6965 is closed, and the `*_6965` tests below bind the second property for
+// the transit population: the install PUBLISHES a mirror row, it is the
+// FORWARD one only, and it carries the {parent ifindex, VLAN} pair, the zones
+// and the stable session id. They assert the publish call's ARGUMENTS rather
+// than a count, because a count of 1 is also what a publish of the WRONG row
+// produces. Read the two families together as "the stamp is correct" AND "the
+// operator can see it".
 //
 // Sibling `#[path]` test module loaded from afxdp/mod.rs, mirroring the #4840
 // split; helpers come from afxdp/tests_support.rs.

--- a/userspace-dp/src/afxdp/tests_session_ingress_identity.rs
+++ b/userspace-dp/src/afxdp/tests_session_ingress_identity.rs
@@ -228,6 +228,157 @@ fn split_forward_reverse(sessions: &SessionTable) -> (Vec<SessionMetadata>, Vec<
     (forward, reverse)
 }
 
+/// #6965 PRODUCER fail-on-revert: a TRANSIT forward install must publish a row
+/// into the BPF conntrack map — the map `show security flow session`
+/// enumerates.
+///
+/// This is the assertion the header of this file used to say could not be
+/// written, because the transit install had no conntrack publication to omit.
+/// It has one now, and this is the test that keeps it.
+///
+/// **The trap this fixture is built to avoid.** A test that merely proves
+/// `show security flow session` prints rows proves nothing here: it printed
+/// rows BEFORE #6965, because the host-inbound and missing-neighbor-seed
+/// installs were always mirrored. The subject has to be a TRANSIT session
+/// specifically, and `run_ingress_identity_flow` is exactly that — a permitted
+/// lan -> wan SYN, `ForwardingDisposition::ForwardCandidate`, resolved
+/// neighbor, so it reaches NONE of the three pre-existing publish sites. A
+/// record therefore can only have come from the new call.
+///
+/// **What it binds and what it does not.** The unit-test driver passes `-1`
+/// for both conntrack fds (`tests_support::txn_run_descriptor`), so no row is
+/// written to any map and there is nothing to read back. That is the right
+/// scope: the #6965 defect IS a missing call site, so the property is the CALL
+/// and the arguments it carries. The value SHAPE those arguments produce is a
+/// separate property already owned by `bpf_map_tests.rs`
+/// (`build_conntrack_value_v4/v6` copying `metadata.ingress_*` onto the row),
+/// and this test deliberately does not restate it — the two together are the
+/// chain.
+///
+/// Asserting the ARGUMENTS rather than a count is what keeps it non-vacuous: a
+/// count of 1 is also what a publish of the WRONG row produces.
+#[test]
+fn transit_forward_install_publishes_a_conntrack_row_6965() {
+    let _guard = crate::afxdp::bpf_map::take_conntrack_publish_guard();
+    let sessions = run_ingress_identity_flow();
+    assert_eq!(
+        sessions.len(),
+        2,
+        "fixture liveness: the transit forward + reverse companion must both \
+         install, or the publish assertions below are about nothing"
+    );
+    let published = crate::afxdp::bpf_map::conntrack_publishes();
+    assert_eq!(
+        published.len(),
+        1,
+        "a transit forward install must publish EXACTLY ONE conntrack row \
+         (got {published:?}). Zero means the #6965 gap is back: the session is \
+         installed and forwarding, but `show security flow session` enumerates \
+         the conntrack map and there is no row for it — not a row with a zeroed \
+         identity, no row at all"
+    );
+    let row = published[0];
+    assert!(
+        !row.is_reverse,
+        "the published row must be the FORWARD one; every show/clear call site \
+         skips `IsReverse != 0` before filtering, so a reverse row costs a \
+         syscall per connection and can never surface a flow"
+    );
+    // The recorded identity is the {PARENT ifindex, VLAN} PAIR, not a
+    // pre-resolved logical unit. That is #4983's contract, not an accident:
+    // `poll_descriptor` stamps `meta.ingress_ifindex` (the binding the frame
+    // was received on) and the 802.1Q tag, and the Go side resolves the pair
+    // through the same `{parent, VLAN}` map the EGRESS side uses
+    // (`pkg/cli/session_filter.go` `resolveIngressIfaces`). An earlier draft of
+    // this test asserted the LOGICAL ifindex 13 and reddened on correct code —
+    // recorded here so the next reader does not "fix" it in that direction.
+    // `poll_descriptor_transit_install_stamps_ingress_binding_4983` above pins
+    // the same pair on the in-memory entry; this pins that the MIRROR carries
+    // it, which is the half #6965 was missing.
+    assert_eq!(
+        row.ingress_ifindex, INGRESS_PARENT_IFINDEX as u32,
+        "the mirrored row must carry the ifindex of the binding the SYN \
+         arrived on — reverting the stamp to 0 makes the Go filter fall back \
+         to the zone for every transit session, which is the approximation \
+         #4983 removed"
+    );
+    assert_eq!(
+        row.ingress_vlan_id, INGRESS_VLAN_ID,
+        "…and its VLAN: the parent alone is SHARED with the egress unit \
+         reth0.80 and resolves to zone wan on its own, so only the pair names \
+         the interface the flow arrived on"
+    );
+    assert_eq!(
+        row.ingress_zone, TEST_LAN_ZONE_ID,
+        "ingress zone lan"
+    );
+    assert_eq!(
+        row.egress_zone, TEST_WAN_ZONE_ID,
+        "egress zone wan"
+    );
+    assert_ne!(
+        row.session_id, 0,
+        "#5213: the mirrored row must carry the STABLE session id resolved \
+         from the just-installed live entry, so `show security flow session` \
+         reports the same id RT_FLOW emits. A 0 here means the id was resolved \
+         before the install, or from the wrong key"
+    );
+}
+
+/// #6965 over-reach guard: the reverse companion must NOT get a conntrack row.
+///
+/// Paired with the test above, this is what makes "exactly one" a decision
+/// rather than an accident. Publishing the reverse companion is the obvious
+/// over-correction — it is installed two dozen lines later, in the same arm,
+/// with the same fds in scope — and it would cost a `bpf_map_update_elem` per
+/// connection for a row that every `show`/`clear` call site discards before it
+/// filters (`val.IsReverse != 0` precedes the filter at
+/// `pkg/cli/cli_show_flow.go`, `pkg/grpcapi/server_sessions.go`,
+/// `pkg/api/sessions.go`, and the natshow sources). The forward row already
+/// carries BOTH directions' counters (#2501), so nothing is lost.
+#[test]
+fn transit_reverse_companion_gets_no_conntrack_row_6965() {
+    let _guard = crate::afxdp::bpf_map::take_conntrack_publish_guard();
+    let sessions = run_ingress_identity_flow();
+    let (forward, reverse) = split_forward_reverse(&sessions);
+    assert_eq!(
+        (forward.len(), reverse.len()),
+        (1, 1),
+        "fixture liveness: the flow must install one forward and one reverse \
+         entry, or 'no reverse row was published' is true for free"
+    );
+    let published = crate::afxdp::bpf_map::conntrack_publishes();
+    assert!(
+        published.iter().all(|r| !r.is_reverse),
+        "no reverse-companion conntrack row may be published on the install \
+         path (got {published:?})"
+    );
+}
+
+/// #6965 recorder control: the pre-existing HOST-INBOUND publish site is still
+/// seen by the same recorder.
+///
+/// Without this, `transit_forward_install_publishes_a_conntrack_row_6965`
+/// could not distinguish "the transit publish landed" from "the recorder
+/// works". Reverting ONLY the transit call leaves this test green and reds the
+/// transit one, which is the pair that localises the change.
+#[test]
+fn local_miss_install_still_publishes_a_conntrack_row_6965() {
+    let _guard = crate::afxdp::bpf_map::take_conntrack_publish_guard();
+    let sessions = run_local_miss_identity_flow();
+    assert!(
+        sessions.len() >= 1,
+        "fixture liveness: the host-inbound miss must install a session"
+    );
+    let published = crate::afxdp::bpf_map::conntrack_publishes();
+    assert!(
+        published.iter().any(|r| !r.is_reverse),
+        "the host-inbound LocalMiss install has published a forward conntrack \
+         row since fab9230c5; if this is empty the recorder is broken and the \
+         transit assertion above proves nothing (got {published:?})"
+    );
+}
+
 /// #4983 PRODUCER fail-on-revert (transit forward install). The FORWARD
 /// session the poll installs must carry the {ifindex, VLAN} of the binding
 /// the SYN actually arrived on — parent 11, VLAN 50 — not 0, not the parent

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -1041,12 +1041,20 @@ plane reads them as `dataplane.SessionValue.IngressIfindex` /
 the helper's in-memory `SessionEntry`, and that is a different question from
 what `show security flow session` can see. That command enumerates the BPF
 conntrack map (`pkg/dataplane/maps_session.go`'s `Manager.IterateSessions`
-over `m.maps["sessions"]`), and inside the HELPER only three install sites ever
-write it: `publish_bpf_conntrack_entry`'s callers in `afxdp/poll_descriptor` —
-the host-inbound `LocalMiss` install, the `MissingNeighborSeed` install, and the
-reverse-companion repair on the session-hit path (that third row is
-`is_reverse != 0`, which every `show`/`clear` call site skips before filtering,
-so it never surfaces a flow on its own).
+over `m.maps["sessions"]`), and inside the HELPER **four** install sites write
+it: `publish_bpf_conntrack_entry`'s callers in `afxdp/poll_descriptor` — the
+TRANSIT forward install (#6965), the host-inbound `LocalMiss` install, the
+`MissingNeighborSeed` install, and the reverse-companion repair on the
+session-hit path (that fourth row is `is_reverse != 0`, which every
+`show`/`clear` call site skips before filtering, so it never surfaces a flow on
+its own).
+
+**The transit site is #6965 and it is the one that matters for volume.** Until
+it existed the mirror carried only the host-inbound and neighbor-seed
+populations, so for the DOMINANT population — ordinary transit flows — `show
+security flow session` showed nothing at all. Not a row with a zeroed identity:
+no row. #6656 records the shape that produced, a node carrying 4.6M rx packets
+while showing 33 sessions.
 
 "Inside the helper" is load-bearing, because the map has a writer OUTSIDE it
 (#6928 review). Every HA peer-synced row reaches the same `sessions` /
@@ -1054,27 +1062,42 @@ so it never surfaces a flow on its own).
 `Manager.SetClusterSyncedSessionV4`/`V6` (`pkg/dataplane/userspace/manager_sessions.go`)
 call `bpfShim.SetSessionV4`/`V6`, which is `maps_session.go`'s
 `m.maps["sessions"].Update`. That is the "for peer-synced sessions the Go side
-installs directly" case named below; the three-site count is a claim about the
-Rust helper's publication sites, never about the map's writers. The ordinary TRANSIT forward
-install does NOT publish there: it calls `publish_live_session_entry`, which
-writes the shim's steering table (`session_map_fd`, a 40-byte key with a
-one-byte action value — a different map from the 144-byte conntrack value),
-plus `publish_shared_session` for the shared/HA maps.
+installs directly" case named below; the four-site count is a claim about the
+Rust helper's publication sites, never about the map's writers.
+
+The transit forward install publishes the mirror row IN ADDITION to the shim's
+steering table, not instead of it. The two are different maps and always were:
+`publish_live_session_entry` writes `session_map_fd`, a 40-byte key with a
+one-byte action value, and the mirror carries the 144-byte conntrack value.
+`publish_shared_session` for the shared/HA maps is unchanged.
+
+FORWARD ONLY, deliberately. The reverse companion installed in the same arm
+gets no mirror row: every `show`/`clear` call site skips `IsReverse != 0`
+before filtering, so a reverse row would cost a `bpf_map_update_elem` per
+connection for something that can never surface a flow, and the forward row
+already carries BOTH directions' counters (#2501). Pinned by
+`transit_reverse_companion_gets_no_conntrack_row_6965`.
 
 So the identity is stamped on every forward session installed from a RECEIVED
 FRAME — the three frame-driven install sites, the only ones with an observed
 binding to copy. (The two forward installs that carry `0`, host-outbound GRE
 and the HA peer import, are not exceptions: neither has an observed local
 ingress. Both are enumerated under "`0` means no ingress identity carried"
-below.) Of those stamps, the identity reaches the operator
-surface only for the host-inbound and missing-neighbor-seed populations, and
-for peer-synced sessions the Go side installs directly. Transit sessions are
-absent from that map entirely — not carrying a zeroed identity, but having no
-row at all — so `show`/`clear ... interface <name>` cannot select them either
-way. That gap is PRE-EXISTING (it dates to `fab9230c5`, the commit that first
-added the conntrack mirror and wired only these three sites) and is tracked as
-**#6965**; #4983 neither introduced nor widened it. Closing #6965 is what makes
-this datum operator-visible for the dominant population.
+below.) Since #6965 the identity reaches the operator
+surface for the TRANSIT population too, alongside the host-inbound and
+missing-neighbor-seed ones and the peer-synced sessions the Go side installs
+directly. Before it, transit sessions were absent from that map entirely — not
+carrying a zeroed identity, but having no row at all — so `show`/`clear ...
+interface <name>` could not select them either way. That gap dated to
+`fab9230c5`, the commit that first added the conntrack mirror and wired only
+three sites; #4983 neither introduced nor widened it.
+
+What the mirror carries is the {PARENT ifindex, VLAN} PAIR, not a pre-resolved
+logical unit — the Go side resolves the pair through the same map the egress
+side uses. Both halves are pinned end to end:
+`poll_descriptor_transit_install_stamps_ingress_binding_4983` on the in-memory
+entry and `transit_forward_install_publishes_a_conntrack_row_6965` on the
+mirrored row.
 
 Before this the session carried only its ingress ZONE, so
 `show security flow session interface <name>` and the matching `clear` had to

--- a/userspace-dp/src/session/entry.rs
+++ b/userspace-dp/src/session/entry.rs
@@ -42,15 +42,15 @@ pub(crate) struct SessionMetadata {
     /// `clear ... interface <name>` tore down sibling-interface sessions —
     /// see `session/README.md` "Which surfaces this applies to".
     ///
-    /// SCOPE (#6965): "for the sessions that are mirrored" is load-bearing.
-    /// `publish_bpf_conntrack_entry` is called from only three sites in
-    /// `afxdp/poll_descriptor` — the host-inbound (LocalMiss) install, the
-    /// missing-neighbor-seed install, and the reverse-companion repair. The
-    /// ordinary TRANSIT forward install does NOT publish there (it writes the
-    /// shim's separate steering table via `publish_live_session_entry`), so a
-    /// transit session has no conntrack row at all and this stamp, though
-    /// correct on the in-memory entry, is not operator-visible for it. The gap
-    /// predates #4983 and is tracked as #6965.
+    /// SCOPE (#6965, CLOSED): `publish_bpf_conntrack_entry` is called from four
+    /// sites in `afxdp/poll_descriptor` — the TRANSIT forward install, the
+    /// host-inbound (LocalMiss) install, the missing-neighbor-seed install, and
+    /// the reverse-companion repair. The transit site is #6965; before it,
+    /// "for the sessions that are mirrored" excluded the dominant population
+    /// outright — a transit session had no conntrack row at all, so this stamp,
+    /// though correct on the in-memory entry, was not operator-visible for it.
+    /// The gap predated #4983. What reaches the mirror is the {parent ifindex,
+    /// VLAN} PAIR stamped below, resolved to a unit on the Go side.
     ///
     /// `0` means "no ingress identity carried" and is NEVER a valid ifindex.
     /// These populations legitimately carry `0`:


### PR DESCRIPTION
Closes #6965

`show security flow session` enumerates the BPF conntrack map, and ordinary
**transit** sessions were never published there — not with a zeroed identity,
**no row at all**. For the dominant traffic population the command, and every
filter built on it, showed nothing, because the session was not in the table
being read. #6656 records the shape: 4.6M rx packets, 33 sessions.

Two maps, not one pin under two names:

| | pin | key | value | max_entries |
|---|---|---|---|---|
| steering | `userspace_sessions` | `UserspaceSessionMapKey`, 40 B | `u8` action | 262,144 |
| conntrack mirror | `sessions` | `BpfSessionKeyV4`, 16 B | `BpfSessionValueV4`, 144 B | **10,000,000** |

The transit forward install called `publish_live_session_entry` (steering) and
`publish_shared_session` (shared/HA), never `publish_bpf_conntrack_entry`. Only
three sites reached the mirror — host-inbound `LocalMiss`, `MissingNeighborSeed`,
and the reverse-companion repair whose row is `is_reverse != 0` and is discarded
before filtering. Dates to `fab9230c5`.

## Which end moves, and why — with the numbers

### Chosen: publish at the transit forward install

**Cost, measured not asserted.** A standalone microbenchmark builds maps of the
exact production shape and times `bpf_map_update_elem`, 200k ops per cell, 3
runs, on this box at load ~20/16 cores:

| map | insert-new | update-existing |
|---|---|---|
| conntrack (16 B key, **144 B** value, **10M** entries, `NO_PREALLOC`) | 1185 / 1385 / 1230 ns | 1131 / 1159 / 1037 ns |
| steering (40 B key, 1 B value, 262k, prealloc) | 1136 / 1177 / 979 ns | 1136 / 1222 / 1009 ns |

**The decisive number is the ratio, not the absolute.** A conntrack update is
per-call *indistinguishable* from a steering update — the fat value and the 10M
`NO_PREALLOC` table cost nothing measurable, because the syscall dominates. The
install already performs several (`publish_live_session_entry` writes 1-4 keys,
`publish_dnat_table_entry` adds 1), so this is one more of what the path already
does: **+14% to +33%** of its BPF-syscall work, ~1.1-1.4 µs per new connection.

**Capacity, the issue's open decision 2, answered by a factor of 12**: the
mirror holds 10,000,000 entries against a helper ceiling of
`DEFAULT_MAX_SESSIONS` = 131,072 per worker (786,432 worst case at 6 workers).

### Rejected: make the operator surface read the real source

The real source is the helper's in-memory `SessionTable`, and **there is no
session-list RPC on the control socket** — `protocol/control.rs` carries status,
config, neighbor, fabric and delta messages, nothing that enumerates sessions.
Adding one puts a bulk consumer on a socket `CLAUDE.md` names explicitly:

> The userspace helper control socket is shared by status poll (1/s), HA sync,
> session installs, snapshot sync, and forwarding sync… Adding a new control
> socket request at >1/s will starve session installs during bulk sync.

A `show` is not >1/s, but a chunked dump of ~786K sessions holds that socket
against session installs for its duration. And it is not one command:
`IterateSessions` and siblings feed CLI, gRPC, REST, Prometheus, `natshow`, the
conntrack GC and the cluster sync paths. Rejected on cost and blast radius.

### Rejected: populate from the existing paced refresh walk

Recorded because it is genuinely attractive and costs **zero** packet-path
syscalls. `refresh_bpf_conntrack_last_seen` (#5287) already walks live forward
sessions on a budgeted slice, already does a lookup per entry, and already skips
on miss — so it visits every transit session today and pays the lookup.
Publishing on that miss would populate the mirror for free.

Rejected on **operator semantics**: the row would appear up to one refresh cycle
late (~6.4s at the default cap), so a session would not be visible immediately
after it is established and a flow shorter than the cycle might never appear.
Junos shows a session as soon as it exists. It would also have forced
`BPF_EXIST` → `BPF_ANY` on that walk, whose comment is *"avoid recreating
deleted entries"* — a second decision riding along.

## Forward only (the issue's open decision 1)

The reverse companion installed in the same arm gets no row. `val.IsReverse != 0`
precedes the filter in `pkg/cli/cli_show_flow.go`,
`pkg/grpcapi/server_sessions.go`, `pkg/api/sessions.go` and the `natshow`
sources, so a reverse row costs a syscall per connection for something that can
never surface a flow — and the forward row already carries both directions'
counters (#2501). Pinned by a guard; cell N2 shows the over-reach reds.

## Two consequences that are NOT display-only

Stated because they were nearly missed.

**1. Session-count gauges start telling the truth.** `SessionCount` counts
`IsReverse == 0` rows and therefore counted host-inbound + neighbor-seed +
peer-synced and never transit; `pkg/api/metrics_sessions.go` feeds
`xpf_sessions_active` / `_established` from the same walk. Those **step up
sharply on upgrade**. That is the #6656 fix, not a regression — but an operator
with an alert threshold on `xpf_sessions_active` will see it fire, and that
belongs in release notes rather than being discovered.

**2. The HA incremental sweep now covers transit.**
`pkg/cluster/sync_conn_sweep.go` walks the mirror and queues every row with
`Created >= lastSweepTime` to the peer. It is **not** disabled under the
userspace dataplane — `SessionSyncSweepProfile` only slows it to 15s/60s.
Transit sessions are *already* synced by the authoritative delta stream
(`daemon_ha_userspace_stream.go`), so after this change newly created transit
sessions are sent **twice**. The receiver's install is an idempotent upsert, so
it is a **volume** question, not a correctness one — and duplication already
existed for the host-inbound and neighbor-seed populations; what changes is the
size of the duplicated set. Read the other way it is a repair: the backstop was
structurally blind to the population an HA firewall actually protects.

`docs/session-sync-architecture.md` predicted this in as many words — *"if #6965
is ever closed, the transit population lands in the mirror with helper-minted
ids and this two-writer surface widens sharply"* — and its safety argument holds
(#6311's node discriminator bit; nothing keys on the id).

**The sweep-volume choice does not ride in this PR.** Filed as **#7842** with
three options and the two counters that would settle it (`stats.SessionsSent`,
`stats.Errors` at a realistic connection rate — measured, not reasoned about).

## Tests — and the trap they are built to avoid

**A check that `show security flow session` prints rows proves nothing here.**
It printed rows before this change; host-inbound and neighbor-seed sessions were
always mirrored. A fixture whose only session is host-inbound is
mutation-insensitive. The subject has to be a TRANSIT session.

`tests_session_ingress_identity.rs` already had exactly that from #4983:
`run_ingress_identity_flow`, a permitted lan → wan SYN driven through the real
`poll_binding_process_descriptor`, `ForwardCandidate` with a resolved neighbor,
reaching **none** of the three pre-existing publish sites.

The unit driver passes `-1` for both conntrack fds, so nothing is written and
there is nothing to read back. That is the correct scope: the defect IS a
missing call site, so the property is the CALL and its ARGUMENTS. A test-only
recorder captures each publish with `is_reverse`, the ingress pair, both zones,
`app_id` and `session_id`. The value SHAPE those arguments produce is a separate
property already owned by `bpf_map_tests.rs` (`build_conntrack_value_v4/v6`) and
is deliberately not restated — the two together are the chain.

**Asserting arguments rather than a count paid for itself immediately.** The
first draft asserted the resolved LOGICAL ifindex (13) and **reddened on correct
code**: #4983's contract is the `{parent ifindex, VLAN}` PAIR (11 / 50), resolved
to a unit on the Go side. A count-only test would have passed and shipped that
false contract as documentation. The correction is recorded at the assertion so
the next reader does not "fix" it back.

## Mutation matrix

Full binary, `--test-threads=1`, **no `-run` filter**, per-cell
`CARGO_TARGET_DIR` under `/var/tmp`. RED requires a **named** failure with
**tests-collected > 0**.

| cell | mutation | result | collected | named failure(s) |
|---|---|---|---|---|
| **N1** | remove the new transit publish (revert #6965) | **RED** | 4723 | `transit_forward_install_publishes_a_conntrack_row_6965` — **and only that one** |
| **N2** | also publish the reverse companion (the over-reach) | **RED** | 4723 | `transit_reverse_companion_gets_no_conntrack_row_6965` + the forward test |
| **N3** | pass `session_id: 0` instead of resolving it (#5213) | **RED** | 4723 | `transit_forward_install_publishes_a_conntrack_row_6965` |

**N1 is the proof obligation and the localising pair at once**: it reds the
transit test and leaves `local_miss_install_still_publishes_a_conntrack_row_6965`
GREEN. That green is what says the transit assertion is about the transit call
and not about the recorder working — a cell reddening both would have proved
only that the instrument exists.

## Incidental sighting, filed separately

N3's run also reddened
`filter::policer::tests::concurrent_refill_under_contention_neither_over_nor_under_grants_6307`
(*"the threads ran serially and the refill race was never exercised"*). No causal
path from a `session_id` argument. 0-of-30 isolated, 1 under full-suite load —
the **#6989 class**, a non-vacuity guard satisfied only by winning scheduler
time. Filed as **#7841**.

## Docs — nine claims moved with the code

Every place asserting "three sites" or "a transit session has no conntrack row
at all": `session/README.md`, `session/entry.rs`, the test-file scope header,
`pkg/dataplane/types.go` (×2), `pkg/dataplane/maps_session.go`,
`docs/session-sync-architecture.md` (×2), `docs/sync-protocol.md`,
`pkg/cluster/sync.go`, `pkg/daemon/daemon_ha_userspace_export.go`.

The #6031 rationale is **amended, not deleted**: the mirror stops being blind to
transit, but it is still a best-effort copy of a table the helper owns — a
publish that fails under map pressure is counted, not retried — so it is not
table-truth however complete it becomes, and the table-truth window source stays.

## Validation

- `cargo test --manifest-path userspace-dp/Cargo.toml --release --bins --
  --test-threads=1`: 4723 collected, **4721 passed / 0 failed / 2 ignored**.
- `go build ./...` clean; full `go test ./... -count=1` **rc=0**.
- Mutation cells N1-N3 above; microbenchmark as tabulated.
- **Cluster smoke in flight** (`make cluster-deploy` + `make test-failover` on
  the loss userspace cluster, under the shared lock). This changes what the HA
  mirror sweep sees, so that lane applies; results posted to this PR when it
  completes rather than claimed in advance.

Full record, including the rejected rivals and the raw numbers, in
`docs/log/6965.md`.