### PR TITLE
userspace-dp: bind the worker-loop publish-tick refreshes and the zone-traffic publication

### DIFF
--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1230,6 +1230,22 @@ impl Coordinator {
         self.forwarding.zone_id_to_name.insert(zone, name.to_string());
     }
 
+    /// #6983: the zone-TRAFFIC twin of `seed_flood_counter_for_test`, opened
+    /// for the same reason and on the same seam. `server::tests` cannot reach
+    /// into `crate::afxdp` to record and flush a zone tally itself, so binding
+    /// the status publication from the caller's side needs a seeder here.
+    #[cfg(test)]
+    pub(crate) fn seed_zone_traffic_counter_for_test(&mut self, zone: u16, name: &str, bytes: u64) {
+        use crate::afxdp::zone_counters::{
+            flush_recorded_zone_counters, record_zone_traffic, ZoneCounterSlotMap,
+        };
+        let map = ZoneCounterSlotMap::build(&[zone], &self.forwarding.zone_counter_store);
+        record_zone_traffic(&map, zone, 0, bytes);
+        flush_recorded_zone_counters(&self.forwarding.zone_counter_store, &map);
+        self.forwarding.zone_counter_slot_map = std::sync::Arc::new(map);
+        self.forwarding.zone_id_to_name.insert(zone, name.to_string());
+    }
+
     /// Current in-memory FIB generation (the value flow-cache lookups
     /// validate against). Read by the `bump_fib_generation` control handler
     /// to build a rollback-rejection error and by tests.

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -491,14 +491,20 @@ pub(crate) fn worker_loop(
                 refresh_worker_cos_queue_lease_runtime_counters(&mut wr_counters, &bindings);
                 // #4800: per-worker transit new-flow install count.
                 //
-                // NOT REACHABILITY-BOUND (#6971). The callee is covered by
-                // `refresh_worker_new_flow_install_counters_sums_across_bindings`,
-                // but nothing drives `worker_loop` in any test, so deleting
-                // THIS LINE leaves the whole suite green while the wire field
-                // pins at 0 and both #4800 cross-worker analyzer gates
-                // (`active_workers < 3`, `max_worker_share > 0.60`) silently
-                // stop discriminating. The `refresh_worker_cos_queue_lease_*`
-                // call above it has the same gap; one harness binds both.
+                // REACHABILITY-BOUND SINCE #6971, structurally. Nothing drives
+                // `worker_loop` in any test, so deleting THIS LINE used to leave
+                // the whole suite green while the wire field pinned at 0 and both
+                // #4800 cross-worker analyzer gates (`active_workers < 3`,
+                // `max_worker_share > 0.60`) silently stopped discriminating. The
+                // `refresh_worker_cos_queue_lease_*` call above it had the same
+                // gap. Both are now pinned by
+                // `worker_loop_refreshes_publish_tick_counters_6971`
+                // (server/tests.rs), which also asserts they sit INSIDE this
+                // publish-tick block rather than merely existing — a source pin,
+                // because `worker_loop` takes five heavyweight parameters and is
+                // spawned only from coordinator bringup against real AF_XDP
+                // sockets, so no test can drive it and inventing a seam would
+                // just move the unbound boundary up one level.
                 refresh_worker_new_flow_install_counters(&mut wr_counters, &bindings);
                 wr_counters.session_table_entries = sessions.len() as u64;
                 wr_counters.max_sessions = sessions.max_sessions() as u64;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1786,6 +1786,141 @@ mod tests {
         );
     }
 
+    /// #6971: the CoS lease / wheel refresh's own ARITHMETIC, which nothing
+    /// covered — `refresh_worker_cos_queue_lease_runtime_counters` had zero
+    /// references in the tree outside its definition and its one production
+    /// call site. Its sibling `refresh_worker_new_flow_install_counters` had
+    /// two direct tests; this one had none, so #6971's "the callees are bound"
+    /// held for one of the two and not for this one.
+    ///
+    /// WHAT MAKES A MISTAKE VISIBLE HERE. The function folds SIX same-typed
+    /// `u64` families off `binding.cos` onto `WorkerRuntimeCounters`, and one of
+    /// them aggregates DIFFERENTLY from the other five:
+    /// `cos_wheel_ticks_advanced_max` is a `.max()` while everything else is a
+    /// `wrapping_add`. A fixture of equal or repeated values cannot separate
+    /// `max` from `sum` from a first-element read, and cannot separate
+    /// `counters.a = sum(binding.a)` from `counters.a = sum(binding.b)` — both
+    /// assertions pass. So every seeded number is distinct, every EXPECTED
+    /// number is distinct, and the wheel-max fixture is chosen so its `max`
+    /// (97) and its `sum` (191) are different numbers.
+    ///
+    /// RED on revert: turning the `.max()` into a `wrapping_add` yields 191,
+    /// turning any `wrapping_add` into a first-element read yields that
+    /// binding's own value, and transposing any two of the six under-grant
+    /// causes lands on another cause's expected total. Each fails on its own
+    /// message.
+    #[test]
+    fn refresh_worker_cos_queue_lease_counters_sums_and_maxes_across_bindings_6971() {
+        let seeds: [(u64, u64, u64, u64, [u64; 6]); 3] = [
+            (7, 1_000_003, 13, 41, [101, 103, 107, 109, 113, 127]),
+            (11, 2_000_003, 17, 97, [131, 137, 139, 149, 151, 157]),
+            (101, 4_000_003, 19, 53, [163, 167, 173, 179, 181, 193]),
+        ];
+        let bindings: Vec<BindingWorker> = seeds
+            .iter()
+            .enumerate()
+            .map(|(slot, (calls, granted, wheel_total, wheel_max, ug))| {
+                let mut binding =
+                    BindingWorker::new_for_mirror_test(slot as u32, 0, 24, slot as u32);
+                binding.cos.cos_queue_lease_acquire_v8_calls = *calls;
+                binding.cos.cos_queue_lease_acquire_v8_granted_bytes = *granted;
+                binding.cos.cos_wheel_ticks_advanced_total = *wheel_total;
+                binding.cos.cos_wheel_ticks_advanced_max = *wheel_max;
+                binding.cos.cos_queue_lease_undergrants =
+                    crate::afxdp::worker_runtime::CoSQueueLeaseUndergrantCounters {
+                        seqlock_give_up: ug[0],
+                        cap_zero: ug[1],
+                        epoch_rotated: ug[2],
+                        share_exhausted: ug[3],
+                        class_cap: ug[4],
+                        outstanding_cap: ug[5],
+                    };
+                binding
+            })
+            .collect();
+
+        let mut counters = crate::afxdp::worker_runtime::WorkerRuntimeCounters::default();
+        refresh_worker_cos_queue_lease_runtime_counters(&mut counters, &bindings);
+
+        assert_eq!(
+            counters.cos_queue_lease_acquire_v8_calls, 119,
+            "lease acquire CALLS must be the SUM over this worker's bindings \
+             (7+11+101); 7 would be a first-element read and 101 a max"
+        );
+        assert_eq!(
+            counters.cos_queue_lease_acquire_v8_granted_bytes, 7_000_009,
+            "lease GRANTED BYTES must be the SUM (1000003+2000003+4000003)"
+        );
+        assert_eq!(
+            counters.cos_wheel_ticks_advanced_total, 49,
+            "wheel ticks TOTAL must be the SUM (13+17+19)"
+        );
+        assert_eq!(
+            counters.cos_wheel_ticks_advanced_max, 97,
+            "wheel ticks MAX must be the MAXIMUM across bindings (max(41,97,53)), \
+             not their sum — 191 here means the one field that aggregates \
+             differently from its five neighbours was folded like them, and the \
+             published per-worker catch-up depth becomes an invented number no \
+             binding ever saw"
+        );
+        let ug = &counters.cos_queue_lease_undergrant;
+        assert_eq!(ug.seqlock_give_up, 395, "under-grant seqlock_give_up sum");
+        assert_eq!(ug.cap_zero, 407, "under-grant cap_zero sum");
+        assert_eq!(ug.epoch_rotated, 419, "under-grant epoch_rotated sum");
+        assert_eq!(ug.share_exhausted, 437, "under-grant share_exhausted sum");
+        assert_eq!(ug.class_cap, 445, "under-grant class_cap sum");
+        assert_eq!(
+            ug.outstanding_cap, 477,
+            "under-grant outstanding_cap sum. All six expected totals are \
+             distinct (395/407/419/437/445/477), so transposing any two causes \
+             lands on another cause's number and fails here rather than passing \
+             with the attribution silently swapped"
+        );
+    }
+
+    /// OVER-REACH GUARD for the CoS lease refresh, mirroring the one its
+    /// sibling already has: it must leave the slots its neighbouring refreshers
+    /// own alone. `new_flow_installs` is refreshed two lines below it on the
+    /// same publish tick, so a CoS refresh that zeroed it would blank a counter
+    /// that is about to be published — and #4800's two cross-worker analyzer
+    /// gates key on exactly that series.
+    ///
+    /// Stays GREEN under every mutation the cell above catches: those change
+    /// which number lands in the CoS slots, which this test does not read.
+    #[test]
+    fn refresh_worker_cos_queue_lease_counters_touches_no_other_slot_6971() {
+        let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+        binding.cos.cos_queue_lease_acquire_v8_calls = 5;
+        let bindings = vec![binding];
+
+        let mut counters = crate::afxdp::worker_runtime::WorkerRuntimeCounters {
+            new_flow_installs: 31,
+            session_install_partial: 3,
+            session_create_drops: 13,
+            session_install_admission_refused: 17,
+            ..Default::default()
+        };
+        refresh_worker_cos_queue_lease_runtime_counters(&mut counters, &bindings);
+
+        assert_eq!(
+            counters.new_flow_installs, 31,
+            "the CoS lease refresh must not disturb new_flow_installs, which the \
+             sibling refresher two lines below it owns"
+        );
+        assert_eq!(
+            counters.session_install_partial, 3,
+            "the CoS lease refresh must not disturb session_install_partial"
+        );
+        assert_eq!(
+            counters.session_create_drops, 13,
+            "the CoS lease refresh must not disturb session_create_drops"
+        );
+        assert_eq!(
+            counters.session_install_admission_refused, 17,
+            "the CoS lease refresh must not disturb session_install_admission_refused"
+        );
+    }
+
     /// OVER-REACH GUARD for the same refresh: it owns exactly ONE slot on
     /// `WorkerRuntimeCounters` and must leave every neighbouring slot alone.
     /// The neighbours are filled by sibling refreshers on the same ~1s

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -3682,6 +3682,189 @@ fn flood_fold_guard_does_not_accept_the_sibling_fold_6938() {
 }
 
 
+/// #6983: the zone-TRAFFIC status publication, the twin of
+/// `status_refresh_publishes_flood_counters_6938` above.
+///
+/// WHAT THE ISSUE GOT RIGHT AND WHAT IT GOT WRONG, both measured on this
+/// branch. #6983 says the worker-loop zone fold "can be severed and nothing
+/// reds". That half is FALSE at this head: deleting
+/// `crate::afxdp::zone_counters::flush_recorded_zone_counters(...)` from the
+/// loop reds `flood_fold_is_wired_into_the_worker_loop_6938`, whose adjacency
+/// assertion looks the zone fold up as its sibling and panics with "the worker
+/// loop no longer calls flush_recorded_zone_counters". So that property is
+/// already owned, incidentally, and this file does NOT add a second pin for it.
+///
+/// The PUBLICATION half is the real gap and it is exactly the shape #6938
+/// closed for flood: replacing `state.afxdp.zone_traffic_counters()` at
+/// server/helpers/status.rs with `Vec::new()` left the entire crate green
+/// (4722 passed / 0 failed). `Coordinator::zone_traffic_counters` itself is
+/// well covered (#6843 binds the accessor's slot-loss filtering), and that is
+/// precisely why the gap survived: every one of those tests calls the accessor
+/// DIRECTLY, so none of them observes `refresh_status` calling it.
+///
+/// Rides the REAL control-socket dispatcher (`handle_stream` via
+/// `run_request`), like its flood twin — `ping` is the minimal real verb,
+/// because the dispatcher's post-match block runs `refresh_status` for every
+/// non-export request.
+///
+/// RED on revert: replace that line with `Vec::new()` (or delete it) and this
+/// fails while the request still succeeds and every other test stays green,
+/// which is exactly how the gap survived.
+#[test]
+fn status_refresh_publishes_zone_traffic_counters_6983() {
+    const Z: u16 = 50675; // config::StableZoneID("trust")
+    const BYTES: u64 = 1500;
+
+    let state = new_state(ProcessStatus::default());
+    {
+        let mut guard = state.lock().expect("state");
+        guard.afxdp.seed_zone_traffic_counter_for_test(Z, "trust", BYTES);
+        // Precondition: the wire status starts EMPTY, so a pass cannot be
+        // explained by the fixture having pre-populated it.
+        assert!(
+            guard.status.zone_traffic_counters.is_empty(),
+            "fixture invalid: status already carried zone-traffic rows before any refresh"
+        );
+    }
+
+    let response = run_request(state.clone(), req("ping"));
+    assert!(response.ok, "ping failed: {}", response.error);
+
+    // Assert on the WIRE payload the daemon actually returns: the attach is the
+    // half an operator sees.
+    let wire = response
+        .status
+        .expect("dispatcher attached no status to the reply");
+    let row = wire
+        .zone_traffic_counters
+        .iter()
+        .find(|r| r.zone_id == Z)
+        .unwrap_or_else(|| {
+            panic!(
+                "the reply's status carries no zone-traffic row for zone {Z}: {:?}. \
+                 refresh_status is not publishing the coordinator's rows, so every \
+                 per-zone byte and packet an operator reads is zero while forwarding \
+                 is perfectly healthy (#6983)",
+                wire.zone_traffic_counters
+            )
+        });
+
+    // The VALUE, not merely the row's presence. A publication that attached an
+    // empty-but-present row, or the wrong zone's totals, would satisfy an
+    // existence check — and existence standing in for content is the failure
+    // this whole family of issues is about.
+    assert!(
+        row.ingress_bytes >= BYTES,
+        "zone {Z} publishes {} ingress bytes, expected at least the {BYTES} the \
+         fixture recorded: the row reaches the wire but its totals do not (#6983)",
+        row.ingress_bytes
+    );
+}
+
+/// #6971: the two per-publish-tick counter refreshes in `worker_loop`.
+///
+/// Measured on this branch's mutation matrix: deleting EITHER line left the
+/// whole userspace-dp suite at 4850 collected / 0 failed. The callee arithmetic
+/// is now covered on both sides (`afxdp/worker/mod.rs` tests, one of which this
+/// branch adds), but a bound callee says nothing about production still calling
+/// it — which is the entire defect class here.
+///
+/// STRUCTURAL for the #6938 reason, unchanged: nothing drives `worker_loop`.
+///
+/// THE TICK ADJACENCY IS PART OF THE CLAIM, not decoration. Both refreshes must
+/// sit INSIDE the `WR_PUBLISH_INTERVAL_NS` block. Above it they would run every
+/// loop iteration — a per-packet-batch sum over every binding on the hot path,
+/// which is what the ~1 s cadence exists to avoid; in the per-RX-batch section
+/// ~32 KB further down they would leave the publish tick reading stale values.
+/// So the pin asserts position relative to the tick guard, not mere presence.
+#[test]
+fn worker_loop_refreshes_publish_tick_counters_6971() {
+    let src = include_str!("../afxdp/worker/loop_body/mod.rs");
+    let tick = "if loop_now_ns.saturating_sub(wr_last_publish_ns) >= WR_PUBLISH_INTERVAL_NS {";
+    let cos = "refresh_worker_cos_queue_lease_runtime_counters(&mut wr_counters, &bindings);";
+    let newflow = "refresh_worker_new_flow_install_counters(&mut wr_counters, &bindings);";
+
+    let tick_at = src.find(tick).unwrap_or_else(|| {
+        panic!(
+            "the worker loop's publish-tick guard is gone — this guard's position \
+             claim is anchored to a line that no longer exists (#6971)"
+        )
+    });
+    for (needle, what, why) in [
+        (
+            cos,
+            "refresh_worker_cos_queue_lease_runtime_counters",
+            "the #1782 CoS lease / wheel-catch-up / under-grant counters stay at \
+             zero on the wire for every worker, so the per-cause under-grant \
+             attribution an operator uses to tell a shaping ceiling from a \
+             misconfiguration reports nothing at all",
+        ),
+        (
+            newflow,
+            "refresh_worker_new_flow_install_counters",
+            "the per-worker `new_flow_installs` wire field pins at 0, and BOTH \
+             #4800 cross-worker analyzer gates key on that series — \
+             `active_workers < 3` and `max_worker_share > 0.60` — so the ceiling \
+             analyzer silently stops discriminating and reports a ceiling with a \
+             dead distribution input",
+        ),
+    ] {
+        let at = src.find(needle).unwrap_or_else(|| {
+            panic!("the worker loop does not call {what}: {why} (#6971)")
+        });
+        assert!(
+            at > tick_at,
+            "{what} is called BEFORE the publish-tick guard (offset {at} vs \
+             {tick_at}), so it runs on every loop iteration instead of once per \
+             ~1 s tick — a per-binding sum moved onto the hot path (#6971)"
+        );
+        assert!(
+            at - tick_at < 2500,
+            "{what} is {} bytes past the publish-tick guard, far enough that it \
+             is no longer inside that block — it would then run at a different \
+             cadence than the counters published alongside it (#6971)",
+            at - tick_at
+        );
+    }
+}
+
+/// OVER-REACH CONTROL for `worker_loop_refreshes_publish_tick_counters_6971`.
+///
+/// Own body, same reason as the two controls above.
+///
+/// The plausible widening here is a shared prefix: both refreshes begin
+/// `refresh_worker_`, and they sit eleven lines apart, so a needle trimmed to
+/// that prefix would match the SIBLING and report a deleted refresh as wired.
+/// This runs each of the binder's two needles against a body containing only
+/// the other, and requires no match — then the converse, so the control cannot
+/// pass by matching nothing ever.
+#[test]
+fn publish_tick_refresh_guard_does_not_accept_its_sibling_6971() {
+    const COS_ONLY: &str =
+        "refresh_worker_cos_queue_lease_runtime_counters(&mut wr_counters, &bindings);";
+    const NEWFLOW_ONLY: &str =
+        "refresh_worker_new_flow_install_counters(&mut wr_counters, &bindings);";
+
+    assert!(
+        COS_ONLY.find(NEWFLOW_ONLY).is_none(),
+        "the new-flow needle matches a body containing ONLY the CoS refresh, so \
+         the binder would report the new-flow refresh as wired after that line \
+         was deleted (#6971)"
+    );
+    assert!(
+        NEWFLOW_ONLY.find(COS_ONLY).is_none(),
+        "the CoS needle matches a body containing ONLY the new-flow refresh, so \
+         the binder would report the CoS refresh as wired after that line was \
+         deleted (#6971)"
+    );
+    assert!(
+        COS_ONLY.find(COS_ONLY).is_some() && NEWFLOW_ONLY.find(NEWFLOW_ONLY).is_some(),
+        "a needle does not match even a body that plainly contains it — the \
+         binder is searching for something unreachable and would pass nothing, \
+         ever"
+    );
+}
+
 /// #5189 (A1-b8-F5): the ~1 s report tick must not build its diagnostics
 /// string in a RELEASE build.
 ///


### PR DESCRIPTION
Closes #6971
Closes #6983

#6983 is **corrected rather than implemented as written** — its central claim is
refuted by measurement below, and the half of it that is genuinely unbound is
fixed here. The correction is also posted on the issue.

## #6971 — both call sites, measured

Single-line severance, unfiltered whole-crate runs at this branch's base:

| severed line | result |
|---|---|
| `refresh_worker_cos_queue_lease_runtime_counters(&mut wr_counters, &bindings);` | 4850 collected / **0 failed** |
| `refresh_worker_new_flow_install_counters(&mut wr_counters, &bindings);` | 4850 collected / **0 failed** |

Nothing drives `worker_loop` — five heavyweight parameters, spawned only from
`coordinator/reconcile/bringup.rs` against real AF_XDP sockets — so these are
pinned **structurally**, the instrument #6938 established for exactly this
shape. Manufacturing a seam to make the loop drivable would move the unbound
boundary one level up and arrive wearing the evidence of a fix.

**The tick adjacency is part of the claim, not decoration.** Above the
`WR_PUBLISH_INTERVAL_NS` guard these run every loop iteration — a per-binding
sum over every binding on the hot path, which the ~1 s cadence exists to avoid;
in the per-RX-batch section ~32 KB below they would leave the publish tick
reading stale values. So the pin asserts position relative to the guard, not
mere presence. An over-reach control guards the plausible widening: both names
begin `refresh_worker_` and they sit eleven lines apart, so a trimmed needle
would match the sibling and report a deleted refresh as wired.

**#6971 says "the callees are bound". That holds for one of the two.**
`refresh_worker_new_flow_install_counters` has two direct tests;
`refresh_worker_cos_queue_lease_runtime_counters` had **zero** references in the
tree outside its definition and its one production call site. Its arithmetic is
added here. It folds six same-typed `u64` families and **one aggregates
differently from the other five** — `cos_wheel_ticks_advanced_max` is a `.max()`
where everything else is a `wrapping_add`. Every seeded number and every
expected total is distinct, and the wheel fixture is chosen so its max (97) and
its sum (191) are different numbers: a repeated-value fixture cannot separate
max from sum from a first-element read, nor `counters.a = sum(binding.a)` from
`counters.a = sum(binding.b)`.

## #6983 — the issue's central claim is FALSE, and the mutation says so

#6983 says the worker-loop zone fold can be severed with nothing reding. It
cannot:

```
thread 'server::tests::flood_fold_is_wired_into_the_worker_loop_6938'
panicked at src/server/tests.rs:3621:
the worker loop no longer calls flush_recorded_zone_counters —
this guard's adjacency claim names a sibling that is gone
```

#6938's flood pin looks the zone fold up as its adjacency sibling, so that
property is **already owned**. **No second pin is added for it** — a duplicate
guard would have looked like coverage while measuring what an existing test
already measures.

The half that *is* unbound is the zone-traffic **publication**. Replacing
`state.afxdp.zone_traffic_counters()` in `server/helpers/status.rs` with
`Vec::new()` leaves the entire crate green (4722 passed / 0 failed).
`Coordinator::zone_traffic_counters` is itself well covered — #6843 binds the
accessor's slot-loss filtering — and that is precisely *why* the gap survived:
every one of those tests calls the accessor **directly**, so none observes
`refresh_status` calling it. A high ratio of direct test callers to production
callers is a flag, not a comfort.

Bound the way #6938 bound its flood twin: through the real control-socket
dispatcher (`handle_stream` via `run_request`), asserting on the wire payload
the reply carries, with an empty-status precondition so a fixture that never
reaches the hook fails loudly, and asserting the row's **bytes** rather than its
presence.

## Mutation matrix — whole crate, `--test-threads=1`, no `-run` filter

| cell | rc | tests passed | named failing | which |
|---|---|---|---|---|
| control | 0 | **4853** | 0 | — |
| MC1 sever the CoS lease refresh call | 101 | 4783 | 1 | `worker_loop_refreshes_publish_tick_counters_6971` |
| MC2 sever the new-flow refresh call | 101 | 4783 | 1 | `worker_loop_refreshes_publish_tick_counters_6971` |
| MC3 CoS wheel MAX folded as a SUM | 101 | 4783 | 1 | `refresh_worker_cos_queue_lease_counters_sums_and_maxes_across_bindings_6971` |
| MC4 transpose the two wheel assignments | 101 | 4783 | 1 | same |
| MC5 zone-traffic publication → `Vec::new()` | 101 | 4783 | 1 | `status_refresh_publishes_zone_traffic_counters_6983` |

Every cell reds a **named** test with tests still being collected, so none is a
build break wearing a red's clothes. `tests_passed` drops in the red cells
because cargo stops after the first failing binary — expected, and the reason
the gate is on the named-failure list rather than on the count. Worktree
restored to **0 dirty files** after the matrix.

The stale `NOT REACHABILITY-BOUND (#6971)` comment in the loop body is updated
to name what now binds it and to keep the reason the pin is structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
