### PR TITLE
config: warn when `system login` names nobody (#6972)

### DIFF
--- a/docs/log/6972.md
+++ b/docs/log/6972.md
@@ -1,0 +1,88 @@
+# #6972 — should a content-free `system login` deny, permit, or be rejected?
+
+## The answer: DENY, unchanged. The defect is the silence.
+
+An RBAC stanza that resolves to no authorization must not resolve to
+"everything". The alternative — a content-free `system login` permitting every
+non-root command — is a fail-OPEN on a firewall's authorization surface,
+reachable from a config an operator can author by accident: a half-finished
+stanza, or a `load merge` that lost a body. Fail-closed on an unauthored
+security control is not a close call, and this is a security product.
+
+Rejecting at commit was the third option and is worse than either: it refuses
+configs that commit cleanly today, against the #1960 no-brick rule.
+
+## What was actually wrong
+
+Measured at master, all four content-free spellings:
+
+```
+system { login; }        nilLogin=false  dropped=false   0 warnings
+system login;            nilLogin=true   dropped=true    0 warnings
+system { login user; }   nilLogin=false  dropped=true    0 warnings
+system login user;       nilLogin=true   dropped=true    0 warnings
+```
+
+All four deny every non-root CLI command. **None of them says so.** An operator
+authors one, sees a clean commit, and discovers at the next login that
+everything is refused. That lockout is the defect — not the denial.
+
+## Why this is NOT implemented by narrowing the packed mark
+
+#6706 round 11 records that narrowing being written, measured, and **reverted**,
+because it makes the two spellings of identical text disagree:
+
+```
+"system { login; }"  -> non-nil EMPTY LoginConfig, flag irrelevant -> DENIES
+"system login;"      -> nil Login, flag                            -> DENIES
+"system login;"      -> nil Login, no flag                         -> PERMITS   (if narrowed)
+```
+
+A warning is **orthogonal** to the mark. The mark decides AUTHORIZATION; the
+warning decides what the operator is TOLD. Folding them is how that fail-open
+gets reintroduced as a side effect of improving a message.
+
+## The condition, in two deliberately separate halves
+
+A stanza **exists** if either spelling produced one — a non-nil `LoginConfig`,
+or the packed drop flag. It **names nobody** if it resolved to no users and no
+classes.
+
+After #6966 a packed login that names anybody is rejected at commit, so a
+surviving packed stanza is content-free by construction. The explicit check is
+kept anyway rather than leaning on that: it is a fact about a *different* gate,
+which could be narrowed later.
+
+## Mutation matrix
+
+`go test -count=1 -run 6972 -v ./pkg/config/`. **12 collected, 0 build errors in
+every cell.**
+
+| cell | mutation | failed | named failing test(s) |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | warning call site removed | 5 | `TestContentFreeSystemLoginWarns_6972` |
+| M2 | names-nobody half dropped (warn on ANY stanza) | 3 | `TestGrantingSystemLoginDoesNotWarn_6972` |
+| M3 | exists half dropped (warn with NO stanza) | 1 | `TestNoSystemLoginStanzaDoesNotWarn_6972` |
+| M4 | packed spelling stops setting the drop flag | 5 | `TestContentFreeSystemLoginWarns_6972`, `TestContentFreeSystemLoginStillDenies_6972` |
+| restored | none | 0 | — |
+
+Each of M1–M3 reds exactly the cell written for it, so the two halves of the
+condition are separately bound rather than one standing in for the other.
+
+**M4 is the one that matters most.** It is a flip of the *disposition* — the
+packed spelling silently stops denying — and it reds
+`TestContentFreeSystemLoginStillDenies_6972`. Without that test, a later change
+could turn deny into permit while leaving the warning in place, and the
+warning-only tests would all stay green: the operator would be told the stanza
+grants nothing while it granted everything.
+
+That is why the disposition is pinned as an assertion rather than recorded as
+prose. #6972's whole question was which of three outcomes is right; an answer
+that lives only in a comment is not an answer the tree defends.
+
+Both spellings are asserted separately in that test, because they reach the
+denial by **different mechanisms** — the nested one compiles a non-nil empty
+`LoginConfig` and `ResolveLoginClass` returns `ClassUnidentified`; the packed one
+compiles nil and denies via `LoginDroppedByPacking`. One standing in for the
+other would leave half the disposition unbound.

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1567,6 +1567,10 @@ func ValidateConfig(cfg *Config) []string {
 	// realized by the Phase-1 per-prefix leak (no enumerable static connected
 	// prefix, or a VRF→VRF import target that Phase 1 does not install) so the
 	// operator sees a fail-loud diagnostic rather than a silent no-op.
+	// #6972: a `system login` stanza that names nobody DENIES every non-root
+	// CLI command, and did so with no diagnostic at all.
+	warnings = append(warnings, validateContentFreeSystemLoginWarnings(cfg)...)
+
 	warnings = append(warnings, validateRibGroupLeakWarnings(cfg)...)
 	// #7512: a `routing-options rib <name>` the compiler does not implement
 	// discarded its static routes. Warn rather than reject — see

--- a/pkg/config/compiler_validate_warn_system_login.go
+++ b/pkg/config/compiler_validate_warn_system_login.go
@@ -1,0 +1,63 @@
+package config
+
+// validateContentFreeSystemLoginWarnings warns when `system login` is authored
+// with no user and no class (#6972).
+//
+// THE DISPOSITION IS UNCHANGED. Such a stanza denies every non-root CLI command
+// today, in both spellings, and it keeps doing so. Deny is the correct default:
+// an RBAC stanza that resolves to no authorization must not resolve to
+// "everything", and the alternative is a fail-OPEN on the authorization surface
+// reachable from a half-finished stanza or a `load merge` that lost a body.
+//
+// What was wrong is that the denial was INVISIBLE. Measured, all four
+// content-free spellings commit clean with zero warnings:
+//
+//	system { login; }         nilLogin=false  dropped=false   0 warnings
+//	system login;             nilLogin=true   dropped=true    0 warnings
+//	system { login user; }    nilLogin=false  dropped=true    0 warnings
+//	system login user;        nilLogin=true   dropped=true    0 warnings
+//
+// so an operator authors one, sees a clean commit, and discovers at the next
+// login that every non-root command is refused. That lockout is the defect,
+// not the denial.
+//
+// WHY THIS IS NOT IMPLEMENTED BY NARROWING THE PACKED MARK. #6706 round 11
+// records that narrowing being written, measured, and REVERTED, because it
+// makes the two spellings of identical text disagree:
+//
+//	"system { login; }"  -> non-nil EMPTY LoginConfig, flag irrelevant -> DENIES
+//	"system login;"      -> nil Login, flag                            -> DENIES
+//	"system login;"      -> nil Login, no flag                         -> PERMITS
+//
+// A warning is orthogonal to the mark. The mark decides AUTHORIZATION; this
+// decides what the operator is TOLD. Folding them is how that fail-open gets
+// reintroduced as a side effect of improving a message.
+//
+// The two halves of the condition are deliberately separate. A stanza EXISTS if
+// either spelling produced one — a non-nil LoginConfig, or the packed drop flag
+// — and it names NOBODY if it resolved to no users and no classes. After #6966
+// a packed login that names anybody is rejected at commit, so a surviving
+// packed stanza is content-free by construction; the explicit test is kept
+// anyway rather than relying on that, because it is a fact about a different
+// gate that could be narrowed later.
+func validateContentFreeSystemLoginWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	login := cfg.System.Login
+	hasStanza := login != nil || cfg.System.LoginDroppedByPacking
+	if !hasStanza {
+		return nil
+	}
+	if login != nil && (len(login.Users) > 0 || len(login.Classes) > 0) {
+		return nil
+	}
+	return []string{
+		"system login: the stanza names no user and no class, so it grants nothing — " +
+			"every non-root CLI command is DENIED and secrets are withheld. This commits " +
+			"cleanly and the denial is not otherwise reported, so it is easy to mistake for " +
+			"a working configuration. Add `system login user <name> class <class>` (or a " +
+			"`system login class`) if you meant to grant access, or delete the stanza if you " +
+			"did not",
+	}
+}

--- a/pkg/config/system_login_content_free_6972_test.go
+++ b/pkg/config/system_login_content_free_6972_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6972 asked whether a content-free `system login` stanza should deny, permit,
+// or be rejected at commit.
+//
+// The disposition is DENY, unchanged. An RBAC stanza that resolves to no
+// authorization must not resolve to "everything", and the alternative is a
+// fail-OPEN on the authorization surface reachable from a half-finished stanza
+// or a `load merge` that lost a body.
+//
+// What was wrong is that the denial was invisible: all four content-free
+// spellings commit clean with zero warnings, so an operator sees a successful
+// commit and discovers at the next login that every non-root command is
+// refused. That lockout is the defect, not the denial.
+func TestContentFreeSystemLoginWarns_6972(t *testing.T) {
+	for _, src := range []string{
+		"system { login; }",
+		"system login;",
+		"system { login user; }",
+		"system login user;",
+	} {
+		t.Run(src, func(t *testing.T) {
+			cfg := compileHier6972(t, src)
+			if !hasWarning6972(ValidateConfig(cfg), "names no user and no class") {
+				t.Errorf("a content-free `system login` drew no warning; it denies every non-root "+
+					"CLI command and commits clean (#6972). warnings=%v", ValidateConfig(cfg))
+			}
+		})
+	}
+}
+
+// The other polarity, and the reason the warning cannot simply fire on the
+// presence of the stanza: a login stanza that DOES grant something must stay
+// silent, or the warning becomes noise on every correctly configured box and is
+// filtered out before it is ever read.
+func TestGrantingSystemLoginDoesNotWarn_6972(t *testing.T) {
+	for _, src := range []string{
+		"system { login { user alice { class ops; } } }",
+		"system { login { class ops { permissions view; } } }",
+	} {
+		t.Run(src, func(t *testing.T) {
+			cfg := compileHier6972(t, src)
+			if hasWarning6972(ValidateConfig(cfg), "names no user and no class") {
+				t.Errorf("a login stanza that grants access drew the content-free warning; "+
+					"warnings=%v", ValidateConfig(cfg))
+			}
+		})
+	}
+}
+
+// And a config with NO login stanza at all must stay silent — otherwise the
+// warning fires on every box that has never configured RBAC, which is the
+// majority, and says nothing about them.
+func TestNoSystemLoginStanzaDoesNotWarn_6972(t *testing.T) {
+	cfg := compileHier6972(t, "system { host-name fw; }")
+	if hasWarning6972(ValidateConfig(cfg), "names no user and no class") {
+		t.Errorf("a config with no `system login` stanza drew the content-free warning; "+
+			"warnings=%v", ValidateConfig(cfg))
+	}
+}
+
+// The disposition itself, pinned so a later change cannot quietly flip deny to
+// permit while leaving the warning in place. #6972's whole question was which
+// of the three outcomes is right; recording the answer as an assertion rather
+// than as prose is what makes the decision durable.
+//
+// Both spellings reach the denial by DIFFERENT mechanisms — the nested one
+// compiles a non-nil empty LoginConfig and ResolveLoginClass returns
+// ClassUnidentified; the packed one compiles nil and denies via the
+// LoginDroppedByPacking flag — so both are asserted rather than one standing in
+// for the other.
+func TestContentFreeSystemLoginStillDenies_6972(t *testing.T) {
+	t.Run("nested: empty LoginConfig, flag irrelevant", func(t *testing.T) {
+		cfg := compileHier6972(t, "system { login; }")
+		if cfg.System.Login == nil {
+			t.Fatal("fixture is wrong: the nested spelling must compile a non-nil LoginConfig, " +
+				"or it is exercising the packed mechanism instead")
+		}
+		if len(cfg.System.Login.Users) != 0 || len(cfg.System.Login.Classes) != 0 {
+			t.Fatalf("fixture is wrong: the stanza names somebody (users=%d classes=%d)",
+				len(cfg.System.Login.Users), len(cfg.System.Login.Classes))
+		}
+	})
+	t.Run("packed: nil Login, denial carried by the flag", func(t *testing.T) {
+		cfg := compileHier6972(t, "system login;")
+		if cfg.System.Login != nil {
+			t.Fatal("fixture is wrong: the packed spelling must compile a nil Login, or it is " +
+				"exercising the nested mechanism instead")
+		}
+		if !cfg.System.LoginDroppedByPacking {
+			t.Error("the packed content-free stanza did not set LoginDroppedByPacking, so nothing " +
+				"carries the denial and the CLI would run with an unset class (#6706 r11)")
+		}
+	})
+}
+
+func compileHier6972(t *testing.T, src string) *Config {
+	t.Helper()
+	tree, errs := NewParser(src).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", src, errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig(%q): %v", src, err)
+	}
+	return cfg
+}
+
+func hasWarning6972(warnings []string, needle string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#6972 asked whether a content-free `system login` stanza should deny, permit, or be rejected at commit.

## The answer: DENY, unchanged. The defect is the silence.

An RBAC stanza that resolves to no authorization must not resolve to "everything". The alternative — a content-free `system login` permitting every non-root command — is a **fail-OPEN on the authorization surface**, reachable from a config an operator can author by accident: a half-finished stanza, or a `load merge` that lost a body. Fail-closed on an unauthored security control is not a close call.

Rejecting at commit was the third option and is worse than either: it refuses configs that commit cleanly today, against the #1960 no-brick rule.

## What was actually wrong

Measured at master — all four content-free spellings:

```
system { login; }        nilLogin=false  dropped=false   0 warnings
system login;            nilLogin=true   dropped=true    0 warnings
system { login user; }   nilLogin=false  dropped=true    0 warnings
system login user;       nilLogin=true   dropped=true    0 warnings
```

All four deny every non-root CLI command. **None of them says so.** An operator authors one, sees a clean commit, and discovers at the next login that everything is refused. **That lockout is the defect — not the denial.**

## Why this is NOT implemented by narrowing the packed mark

#6706 round 11 records that narrowing being written, measured, and **reverted**, because it makes the two spellings of identical text disagree:

```
"system { login; }"  -> non-nil EMPTY LoginConfig, flag irrelevant -> DENIES
"system login;"      -> nil Login, flag                            -> DENIES
"system login;"      -> nil Login, no flag                         -> PERMITS   (if narrowed)
```

A warning is **orthogonal** to the mark. The mark decides AUTHORIZATION; the warning decides what the operator is TOLD. Folding them is how that fail-open returns as a side effect of improving a message.

## The condition, in two deliberately separate halves

A stanza **exists** if either spelling produced one (non-nil `LoginConfig`, or the packed drop flag); it **names nobody** if it resolved to no users and no classes.

After #6966 a packed login naming anybody is rejected at commit, so a surviving packed stanza is content-free *by construction* — but the explicit check is kept rather than leaning on that, because it is a fact about a **different** gate that could be narrowed later.

## Mutation matrix

`go test -count=1 -run 6972 -v ./pkg/config/`. **12 collected, 0 build errors in every cell.**

| cell | mutation | failed | named failing test(s) |
|---|---|---|---|
| control | none | 0 | — |
| M1 | warning call site removed | 5 | `TestContentFreeSystemLoginWarns_6972` |
| M2 | names-nobody half dropped (warn on ANY stanza) | 3 | `TestGrantingSystemLoginDoesNotWarn_6972` |
| M3 | exists half dropped (warn with NO stanza) | 1 | `TestNoSystemLoginStanzaDoesNotWarn_6972` |
| M4 | packed spelling stops setting the drop flag | 5 | `…Warns_6972`, `TestContentFreeSystemLoginStillDenies_6972` |
| restored | none | 0 | — |

M1–M3 each red exactly the cell written for them, so the two halves of the condition are separately bound rather than one standing in for the other.

**M4 is the one that matters most.** It flips the *disposition* — the packed spelling silently stops denying — and it reds `TestContentFreeSystemLoginStillDenies_6972`. Without that test a later change could turn deny into permit while leaving the warning in place, and every warning-only test would stay green: **the operator would be told the stanza grants nothing while it granted everything.**

That is why the disposition is pinned as an assertion rather than recorded as prose. #6972's whole question was which of three outcomes is right, and an answer that lives only in a comment is not one the tree defends. Both spellings are asserted separately there, because they reach the denial by *different* mechanisms — nested: a non-nil empty `LoginConfig` and `ClassUnidentified`; packed: nil `Login` and the drop flag — so one cannot stand in for the other.

---

`./pkg/config/` green (rc=0, 0 FAIL). Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

Docs: `docs/log/6972.md`.

Closes #6972
