### PR TITLE
cluster: decline the epoch raise instead of rejecting the frame (#6969 F5)

### DIFF
--- a/docs/log/6969.md
+++ b/docs/log/6969.md
@@ -1,0 +1,84 @@
+# #6969 — F5: decline the raise instead of rejecting the frame
+
+- **Timestamp**: 2026-08-28
+  - **Action**: the forward bound now gates what its own comment always said it
+    gated — the irreversible operation — instead of the frame.
+  - **The harm**: a rejected frame never reaches the monotonic `lastSeen`
+    update, so a peer that RESTARTS while this receiver's clock is more than
+    `bootEpochMaxSkew` slow is declared dead in ~500ms and the cluster goes
+    dual-master, over a clock fault on THIS node.
+  - **A restart, not "any healthy peer"** — the finding as filed is wider than
+    the code. The boot epoch is per-incarnation and fixed for its life, so an
+    already-latched peer keeps being admitted through the equality exemption
+    however slow this clock is. The bound only meets an epoch NEW to this
+    receiver.
+  - **Three things are withheld from a declined frame**, and the second was
+    found by the tests rather than reasoned out first:
+    1. the FLOOR does not move (a floor raised to an unverifiable value locks
+       out the live peer — #6711, the worst outcome available here);
+    2. the DOWNGRADE LATCH is not armed — `epochSeen` means "this peer has been
+       observed signing boot epochs", and an epoch this node cannot judge is not
+       evidence for that. Arming on it would let one captured far-future frame
+       lock out a genuinely rolled-back peer;
+    3. nothing else — it spends one slot of the same finite, non-refilling
+       per-value session budget an equality frame spends, checked BEFORE
+       `s.replay.admit` for the same reason the equality check is.
+  - **Narrowed to an ESTABLISHED receiver**, which is what makes this small.
+    The harm needs a floor to exist; a receiver with `highEpoch == 0` has no
+    established peer and no liveness to protect, so it still refuses outright.
+    Measured: without that clause the change re-decided **six** deliberate
+    assertions across four files; with it, **one** —
+    `TestBackwardClockStepDoesNotKillALatchedPeer_6169`, whose own message
+    already said the bound "must still gate raising", which still holds.
+  - **What is now ADMITTED that was not** (the safety argument, not the
+    benefit): an authenticated, ring-fresh, inside-the-absolute-band frame whose
+    epoch is above the floor and beyond the clock's forward bound, seen by a
+    receiver that already has a floor. It cannot move the floor, arm the latch,
+    or churn the ring. Its remaining power is forged liveness from a captured
+    frame — already reachable through the equality path and the post-restart
+    archived-frame path, and retired by the same PSK rotation. The one genuine
+    widening: a capture from an incarnation whose epoch sits far ahead of this
+    node's clock was previously unusable and is now usable for liveness and for
+    one budget slot.
+  - **Counter renamed** `epochAheadOfClockRejected` →
+    `epochRaiseDeclinedAheadOfClock` (rendered "Epoch raises declined"): the
+    common case no longer rejects anything, and a counter named for an outcome
+    it does not produce is a wrong message. The NTP guidance the reason string
+    carried moves to `epochRaiseDeclineNote`, rendered beside the count — with
+    no rejection there is no reason string, so the counter is the only place
+    that diagnosis can live.
+  - **F3 and F7 are NOT fixed here, and the reason is not "hard".** Each of the
+    two remedies #6969 names for F3 is already refuted in-tree: plain eviction
+    restores exactly the sustained churn the budget closes (the `k`-larger-than
+    -the-ring counterexample at `heartbeat.go:701-710`), and liveness-based
+    refresh — rebinding a slot on silence — is explicitly DECLINED in
+    `pkg/cluster/README.md`, because waiting out the dead-peer interval between
+    captures is free. F7 needs to tell a legitimately regressed peer from a
+    replay of a retired incarnation, and below-floor frames carry nothing that
+    separates them — a real information problem, the shape #6967 wrongly
+    claimed. Both stay open with that recorded.
+  - **Mutation matrix** (full `pkg/cluster`, `-count=1 -v`, no `-run` filter,
+    fix committed before mutating, each cell restored with `git checkout --`).
+    Control **984 collected, 0 failed**:
+
+    | mutation | collected | failed | named |
+    |---|---|---|---|
+    | reject instead of declining (the shipped behaviour) | 984 | 4 | `TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969`, `TestDeclinedRaiseStillSpendsTheSessionBudget_6969`, `TestCorrectedClockRaisesTheFloorAgain_6969`, `TestBackwardClockStepDoesNotKillALatchedPeer_6169` |
+    | decline but raise the floor anyway | 984 | 4 | same four |
+    | decline but arm the downgrade latch | 984 | 2 | `TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969` (+ one load-sensitive unrelated) |
+    | decline but skip the session budget | 981 | 2 | `TestDeclinedRaiseStillSpendsTheSessionBudget_6969`, `TestEveryEpochCounterIsRendered_6669` |
+    | fresh receiver declines too (drop the `highEpoch == 0` refusal) | 984 | 6 | every fresh-state guard: `TestHeartbeatUnorderableEpochNeverArmsLatch_6169`, `TestHeartbeatEpochImplausibleValueCannotLockOut_6169`, … |
+    | operator note always empty | 984 | 1 | `TestEpochRaiseDeclineIsNamedForTheOperator_6969` |
+
+    The fifth row is the one that shows the narrowing is load-bearing rather
+    than cosmetic: without it, six deliberate fresh-state assertions fall.
+    **A first attempt at the note cell was a non-mutation** — it replaced only
+    the first line of a multi-line concatenation, so the string kept both its
+    non-emptiness and the word NTP and my cell passed; the row above is the
+    redone version (`return ""` unconditionally).
+  - **File(s)**: `pkg/cluster/heartbeat_epoch_admit.go`,
+    `pkg/cluster/heartbeat.go`, `pkg/cluster/heartbeat_manager.go`,
+    `pkg/cluster/status.go`, `pkg/cluster/README.md`,
+    `pkg/cluster/heartbeat_epoch_decline_raise_6969_test.go` (new),
+    `pkg/cluster/heartbeat_epoch_latch_test.go`,
+    `pkg/cluster/heartbeat_epoch_status_6169_test.go`, `docs/log/6969.md`

--- a/docs/log/6969.md
+++ b/docs/log/6969.md
@@ -76,6 +76,11 @@
     the first line of a multi-line concatenation, so the string kept both its
     non-emptiness and the word NTP and my cell passed; the row above is the
     redone version (`return ""` unconditionally).
+  - **Cluster smoke** (mandatory for a `pkg/cluster` admission change, run under
+    the #1875 shared lock cell): `make cluster-deploy && make test-failover` on
+    `loss:xpf-userspace-fw0/fw1` — **17 passed, 0 failed**, iperf3 13.0 Gbps,
+    including the sysrq-crash failover, the rejoin-as-secondary check, the
+    manual failover of all three RGs, and IPv6 transit after it.
   - **File(s)**: `pkg/cluster/heartbeat_epoch_admit.go`,
     `pkg/cluster/heartbeat.go`, `pkg/cluster/heartbeat_manager.go`,
     `pkg/cluster/status.go`, `pkg/cluster/README.md`,

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -1154,6 +1154,37 @@ peer liveness (`lastSeen`) or drive election.
     untouched, and the session binding above already refuses every other
     session at that value.
 
+    **When the bound DOES fire on a raise, it declines the raise rather than
+    rejecting the frame (#6969 F5).** The same defect the equality relaxation
+    above fixed had a second half: a peer that RESTARTS while this receiver's
+    clock is more than `bootEpochMaxSkew` slow presents a NEW epoch, so the
+    equality exemption does not cover it, and the frame was rejected BEFORE the
+    monotonic `lastSeen` update — the peer declared dead in ~500ms, dual-master,
+    over a clock fault on THIS node. The bound now does what its own comment
+    always said it did, gating only the irreversible operation. From an
+    ESTABLISHED receiver the frame is admitted, the FLOOR IS HELD, the downgrade
+    latch is NOT armed (an epoch this node cannot judge is not evidence that the
+    peer signs epochs), and the session spends one slot of the same finite,
+    non-refilling per-value budget an equality frame spends. From a FRESH
+    receiver (`highEpoch == 0`) it is still refused outright: with no floor
+    there is no established peer to strand, so refusing costs nothing and every
+    fresh-state guard — refuse, never latch, leave the floor at 0 — keeps full
+    strength. Recovery is automatic; once the clocks agree the next frame raises
+    the floor normally, with no restart on either node.
+
+    **What this ADMITS that was refused before**, because the change loosens a
+    gate and the benefit is not the safety argument: an authenticated,
+    ring-fresh, inside-the-absolute-band frame whose epoch is above the floor and
+    beyond the clock's forward bound, seen by a receiver that already has a
+    floor. It cannot move the floor, cannot arm the latch, and cannot churn the
+    ring. Its remaining power is forged liveness from a captured frame — already
+    reachable through the equality path and the post-restart archived-frame path
+    (residual 5), and retired by the same PSK rotation. The one genuine widening:
+    a capture from an incarnation whose epoch sits far ahead of this node's clock
+    was previously unusable and is now usable for liveness and for one budget
+    slot. `Epoch raises declined` in `show chassis cluster` counts both arms and
+    carries the NTP guidance the rejection reason used to.
+
     The forward bound is applied ONLY when the receiver's own clock is itself
     credible (`epochClockSaneFloor`, year 2020). An appliance with a dead RTC
     boots near the Unix epoch and syncs NTP seconds later; during that window a

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -1049,7 +1049,7 @@ type heartbeatAuthState struct {
 	// epochDowngradeRejected.
 	epochSessionCollision atomic.Uint64
 
-	// epochOutOfBandRejected and epochAheadOfClockRejected count the two epoch
+	// epochOutOfBandRejected and epochRaiseDeclinedAheadOfClock count the two epoch
 	// refusals that are NOT replays, and that is the whole reason they are
 	// separate counters rather than folded into a general "epoch rejected"
 	// total. Both arms used to be silent AND mislabelled: they returned a bare
@@ -1061,21 +1061,28 @@ type heartbeatAuthState struct {
 	//     refineBootEpoch refuses to chain to such a value, clock-independently
 	//     — so a non-zero count means a corrupt state file on the peer or a peer
 	//     running something that is not this build. Check the PEER.
-	//   - epochAheadOfClockRejected: the epoch is more than bootEpochMaxSkew
+	//   - epochRaiseDeclinedAheadOfClock: the epoch is more than bootEpochMaxSkew
 	//     ahead of OUR clock (epochWithinForwardBound). This is the one that is
 	//     routinely a healthy peer: either its clock runs fast or ours runs
 	//     slow. It is a CLOCK fault and the action is NTP on both nodes, not an
 	//     incident response. It gates only the raise path, so a peer already at
 	//     the floor keeps being accepted while this climbs — which is why it can
 	//     climb with liveness perfectly healthy.
+	//     #6969 F5: the two arms this counts are no longer the same event. From
+	//     an ESTABLISHED receiver (highEpoch != 0) the frame is ADMITTED and only
+	//     the raise is declined, so the floor is held and liveness is preserved;
+	//     from a FRESH one (highEpoch == 0) it is still refused outright, because
+	//     there is no established peer to strand. Both increment this, because
+	//     both mean the same thing to an operator: the peer's epoch is ahead of
+	//     this node's clock.
 	//
 	// The third silent arm, `epoch < s.highEpoch`, deliberately has neither a
 	// counter nor a distinct reason: a frame below the floor IS a replay of a
 	// retired incarnation, so "stale nonce (replay)" is already the true
 	// statement, and the lockout case it can also mean (#6711) is metered by the
 	// floor itself rather than by a rejection count.
-	epochOutOfBandRejected    atomic.Uint64
-	epochAheadOfClockRejected atomic.Uint64
+	epochOutOfBandRejected         atomic.Uint64
+	epochRaiseDeclinedAheadOfClock atomic.Uint64
 
 	// peerAuthSeen is sticky and READ cross-goroutine
 	// (Manager.HeartbeatPeerAuthSeen, consumed by the gRPC fabric listener to

--- a/pkg/cluster/heartbeat_epoch_admit.go
+++ b/pkg/cluster/heartbeat_epoch_admit.go
@@ -279,10 +279,50 @@ func (s *heartbeatAuthState) admitAuthed(hasEpoch bool, epoch, session, counter 
 	// a real clock that regime is unreachable from a test, which left the
 	// absolute band looking redundant with this one. See
 	// TestUncredibleClockLeavesOnlyTheAbsoluteBand_6669.
+	//
+	// #6969 F5: when the bound fires, DECLINE THE RAISE — do not reject the
+	// frame. Rejecting cost liveness: the frame never reaches the monotonic
+	// lastSeen update, so a peer that restarts while this receiver's clock is
+	// more than bootEpochMaxSkew slow is declared dead in ~500ms and the
+	// cluster goes dual-master, over what is a clock fault on ONE node. The
+	// comment above already said the bound gates "ONLY the irreversible
+	// operation"; the implementation was wider than its own stated intent.
+	//
+	// The frame is then treated exactly as if it had arrived AT the floor, so
+	// it must pass the SAME per-value session budget an equality frame does.
+	// That is not incidental: without it, a frame that cannot be latched would
+	// be an unbounded admission path — precisely the epochless bypass the floor
+	// exists to close. Checked here, BEFORE s.replay.admit, for the same reason
+	// the equality check is: admit() records a never-seen session as a side
+	// effect, so a check after it would evict a live watermark while rejecting.
+	//
+	// NARROWED TO AN ESTABLISHED PEER (s.highEpoch != 0), which is the whole
+	// reason this can be a small change. The harm being fixed is "a peer this
+	// receiver has already accepted is declared dead", and that needs a floor to
+	// exist. A receiver with NO floor has no established peer and therefore no
+	// liveness to protect, so refusing there costs nothing — and it keeps every
+	// fresh-state guard at full strength: an unorderable epoch presented to a
+	// fresh receiver is still refused outright, never arms the latch, and leaves
+	// the floor at 0. Without this clause the change would re-decide six
+	// deliberate assertions across four files instead of one.
+	declineRaise := false
 	if epoch > s.highEpoch && !epochWithinForwardBound(epoch, epochNowNanos()) {
-		s.epochAheadOfClockRejected.Add(1)
-		return false, "boot epoch more than bootEpochMaxSkew ahead of our clock " +
-			"(check NTP on BOTH nodes — this is a clock fault, not a replay)"
+		s.epochRaiseDeclinedAheadOfClock.Add(1)
+		if s.highEpoch == 0 {
+			// NO ESTABLISHED PEER, so there is no liveness to protect and the
+			// old refusal is kept exactly. This arm is why the change re-decides
+			// one deliberate assertion instead of six: every fresh-state guard —
+			// an unorderable epoch is refused, never arms the latch, leaves the
+			// floor at 0 — is untouched.
+			return false, "boot epoch more than bootEpochMaxSkew ahead of our clock " +
+				"(check NTP on BOTH nodes — this is a clock fault, not a replay)"
+		}
+		declineRaise = true
+		if !s.epochSessionAdmissible(session) {
+			s.epochSessionCollision.Add(1)
+			return false, "too many peer sessions at one boot epoch (peer cannot advance its " +
+				"epoch store, or a replayed capture set sharing one epoch)"
+		}
 	}
 	if !s.replay.admit(session, counter) {
 		return false, ""
@@ -346,8 +386,28 @@ func (s *heartbeatAuthState) admitAuthed(hasEpoch bool, epoch, session, counter 
 	// only; the forged-liveness half is the same replay, and the same PSK
 	// rotation retires it.
 	// Pinned by TestArchivedEpochReplayReArmsLatchAfterRestart_6169.
-	s.epochSeen = true
-	if epoch > s.highEpoch {
+	// #6969 F5: declineRaise means the epoch is ABOVE the floor but could not be
+	// verified against this node's clock. TWO consequences of admission are
+	// withheld from it, and the second was found by the tests rather than
+	// reasoned out in advance:
+	//
+	//  1. the FLOOR does not move. A floor raised to a value this node cannot
+	//     verify locks out the live peer (#6711 poisoning) — the worst outcome
+	//     in this area, and the reason the bound exists at all.
+	//  2. the DOWNGRADE LATCH is not armed. epochSeen means "this peer has been
+	//     observed signing boot epochs", after which its epochless frames are
+	//     refused. A frame whose epoch this node cannot judge is not evidence
+	//     for that: arming on it would let one captured far-future frame lock
+	//     out a genuinely rolled-back peer, which is exactly what
+	//     TestHeartbeatUnorderableEpochNeverArmsLatch_6169 guards.
+	//
+	// What the frame DOES get is the thing it was rejected for: it reaches the
+	// monotonic lastSeen update, so a peer that restarted while this node's
+	// clock is slow stays alive instead of being declared dead in ~500ms.
+	if !declineRaise {
+		s.epochSeen = true
+	}
+	if epoch > s.highEpoch && !declineRaise {
 		s.highEpoch = epoch
 		// Rebind the floor to THIS incarnation, DISCARDING the sessions bound at
 		// the old value. The two must move together: a floor whose bound

--- a/pkg/cluster/heartbeat_epoch_decline_raise_6969_test.go
+++ b/pkg/cluster/heartbeat_epoch_decline_raise_6969_test.go
@@ -103,6 +103,29 @@ func TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969(t *testing.T) {
 		t.Fatalf("epochRaiseDeclinedAheadOfClock = %d, want 1 — the decline must stay visible "+
 			"to an operator, or a clock fault becomes silent", got)
 	}
+	// THE THIRD WITHHOLDING, and the one that was found by the tests rather than
+	// reasoned out first. Admission normally sets epochSeen, which is the
+	// downgrade latch: after it, the peer's EPOCHLESS frames are refused. An
+	// epoch this node cannot judge against its own clock is not evidence that
+	// the peer signs epochs, and arming on it would let one captured far-future
+	// frame lock out a peer that has genuinely been rolled back to a pre-#6169
+	// build. The latch here was armed by incarnation A, legitimately; what must
+	// not happen is a DECLINED frame arming it on its own.
+	fresh := &heartbeatAuthState{}
+	if ok, _ := admitAt6969(t, fresh, receiverNow, epochA, 0xA1, 1); !ok {
+		t.Fatal("fixture: the second state did not latch incarnation A")
+	}
+	fresh.epochSeen = false // isolate: only the declined frame may re-arm it
+	if ok, _ := admitAt6969(t, fresh, receiverNow, epochB, 0xB1, 1); !ok {
+		t.Fatal("fixture: the declined frame was not admitted, so the latch assertion below " +
+			"would pass by never running the path")
+	}
+	if fresh.epochSeen {
+		t.Fatal("a frame whose epoch this node cannot verify ARMED the downgrade latch. " +
+			"After that the peer's epochless frames are refused, so one captured far-future " +
+			"frame locks out a genuinely rolled-back peer — the lockout the latch guards " +
+			"exist to prevent (#6969 F5)")
+	}
 }
 
 // TestDeclinedRaiseStillSpendsTheSessionBudget_6969 is the security half that

--- a/pkg/cluster/heartbeat_epoch_decline_raise_6969_test.go
+++ b/pkg/cluster/heartbeat_epoch_decline_raise_6969_test.go
@@ -1,0 +1,212 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// heartbeat_epoch_decline_raise_6969_test.go — #6969 F5.
+//
+// The forward bound gates a CLOCK-DEPENDENT judgement, and its own comment says
+// it gates "ONLY the irreversible operation — raising the floor". The
+// implementation was wider: when the bound fired it returned false, rejecting
+// the frame. A rejected frame never reaches the monotonic lastSeen update, so a
+// peer that RESTARTS while this receiver's clock is more than bootEpochMaxSkew
+// slow is declared dead in ~500ms and the cluster goes dual-master — over a
+// clock fault on one node.
+//
+// WHY A RESTART, and not "any healthy peer". The boot epoch is per-INCARNATION
+// and fixed for its life, so a peer already latched keeps being admitted through
+// the equality path however slow this node's clock is — that exemption is
+// deliberate and predates this change (see the DO NOT HOIST paragraph in
+// admitAuthed). The bound only meets a peer whose epoch is NEW to this receiver:
+// first contact, or a restart. That is narrower than the finding as filed and it
+// is what these cases drive.
+//
+// WHAT IS NOW ADMITTED THAT WAS NOT, which is the half that has to be argued
+// rather than asserted, because this change LOOSENS a gate:
+//
+//   - the frame class is {authenticated, ring-fresh, inside the absolute
+//     year-2200 band, epoch above the floor, beyond the clock's forward bound};
+//   - it CANNOT raise the floor, so it cannot lock the live peer out — which is
+//     the worst outcome in this area (#6711 poisoning) and is what a raise on an
+//     unverifiable value would risk;
+//   - it consumes one slot of the same bounded, non-refilling per-value session
+//     budget an equality frame does, so it cannot churn the ring;
+//   - its remaining power is forged liveness from a captured frame, which is
+//     already reachable today through the equality path and the post-restart
+//     archived-frame path documented at the arming comment, and which the same
+//     PSK rotation retires.
+//
+// The one thing that genuinely widens: a capture from an incarnation whose epoch
+// sits far ahead of this node's clock was previously unusable and is now usable
+// for liveness and for one budget slot. It still cannot move the floor.
+
+// admitAt drives one frame with the clock pinned, so the forward bound is
+// exercised rather than raced.
+func admitAt6969(t *testing.T, s *heartbeatAuthState, now int64, epoch, session, counter uint64) (bool, string) {
+	t.Helper()
+	restore := epochNowNanos
+	epochNowNanos = func() int64 { return now }
+	defer func() { epochNowNanos = restore }()
+	return s.admitAuthed(true, epoch, session, counter)
+}
+
+// TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969 is the fix, and both
+// halves are asserted because only the pair distinguishes it from "admit
+// anything": the frame must be ADMITTED (liveness restored) and the floor must
+// be UNCHANGED (the security object untouched).
+func TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969(t *testing.T) {
+	// This receiver's clock. The peer's is correct and two hours ahead of it.
+	const receiverNow = int64(1_800_000_000_000_000_000)
+	slowBy := int64(2 * bootEpochMaxSkew)
+
+	s := &heartbeatAuthState{}
+
+	// Incarnation A, latched normally: its epoch is inside the bound.
+	epochA := uint64(receiverNow) - uint64(time.Minute)
+	if ok, reason := admitAt6969(t, s, receiverNow, epochA, 0xA1, 1); !ok {
+		t.Fatalf("the fixture could not latch incarnation A (%q); nothing below measures "+
+			"what it claims", reason)
+	}
+	if s.highEpoch != epochA {
+		t.Fatalf("floor = %d after latching A, want %d", s.highEpoch, epochA)
+	}
+
+	// The peer RESTARTS. Its clock is correct, so its new epoch is around the
+	// peer's own now — which is beyond this receiver's forward bound.
+	epochB := uint64(receiverNow + slowBy)
+	// Premise: the fixture really does reach the bound, and is not out of band.
+	if !epochUsableAsFloor(epochB) {
+		t.Fatalf("fixture: %d is outside the absolute band, so this measures the out-of-band "+
+			"arm instead of the forward bound", epochB)
+	}
+	if epochWithinForwardBound(epochB, receiverNow) {
+		t.Fatalf("fixture: %d is INSIDE the forward bound at %d, so this case never reaches "+
+			"the branch under test", epochB, receiverNow)
+	}
+
+	ok, reason := admitAt6969(t, s, receiverNow, epochB, 0xB1, 1)
+	if !ok {
+		t.Fatalf("the restarted peer was REFUSED (%q). The frame never reaches the monotonic "+
+			"lastSeen update, so the peer is declared dead in ~500ms and the cluster goes "+
+			"dual-master — over a clock fault on THIS node, not on the peer (#6969 F5)", reason)
+	}
+	if s.highEpoch != epochA {
+		t.Fatalf("the floor moved from %d to %d on an epoch this node cannot verify against "+
+			"its own clock. Declining the RAISE is what makes admitting the frame safe: a "+
+			"floor raised to an unverifiable value locks out the live peer (#6711)",
+			epochA, s.highEpoch)
+	}
+	if got := s.epochRaiseDeclinedAheadOfClock.Load(); got != 1 {
+		t.Fatalf("epochRaiseDeclinedAheadOfClock = %d, want 1 — the decline must stay visible "+
+			"to an operator, or a clock fault becomes silent", got)
+	}
+}
+
+// TestDeclinedRaiseStillSpendsTheSessionBudget_6969 is the security half that
+// the admit alone does not give.
+//
+// A frame that cannot be latched is admitted AT THE FLOOR, so it must be subject
+// to the same bounded per-value session budget an equality frame is. Without
+// that it would be an unbounded admission path for exactly the frames the clock
+// cannot vouch for — the epochless bypass in miniature, which is what the floor
+// exists to close.
+func TestDeclinedRaiseStillSpendsTheSessionBudget_6969(t *testing.T) {
+	const receiverNow = int64(1_800_000_000_000_000_000)
+	ahead := uint64(receiverNow) + 3*bootEpochMaxSkew
+
+	s := &heartbeatAuthState{}
+	epochA := uint64(receiverNow) - uint64(time.Minute)
+	if ok, _ := admitAt6969(t, s, receiverNow, epochA, 0xA1, 1); !ok {
+		t.Fatal("fixture: incarnation A did not latch")
+	}
+
+	// The floor now holds one bound session (A). heartbeatEpochSessionsPerEpoch
+	// slots exist in total, so exactly one more may be spent.
+	admitted := 0
+	for i := 0; i < heartbeatEpochSessionsPerEpoch+2; i++ {
+		if ok, _ := admitAt6969(t, s, receiverNow, ahead+uint64(i), uint64(0xC000+i), 1); ok {
+			admitted++
+		}
+	}
+	if want := heartbeatEpochSessionsPerEpoch - 1; admitted != want {
+		t.Fatalf("%d beyond-bound frames were admitted at the floor, want %d. A frame the "+
+			"clock cannot vouch for is admitted AS IF at the floor, so it must spend the same "+
+			"finite, non-refilling budget: an unbounded path for unverifiable frames is the "+
+			"ring churn the floor exists to stop (#6969 F5)", admitted, want)
+	}
+	if s.highEpoch != epochA {
+		t.Fatalf("the floor moved to %d while spending the budget; not one of these frames "+
+			"may raise it", s.highEpoch)
+	}
+	if got := s.epochSessionCollision.Load(); got == 0 {
+		t.Fatal("no session collision was counted, so the refusals above did not come from " +
+			"the budget and this case is measuring something else")
+	}
+}
+
+// TestCorrectedClockRaisesTheFloorAgain_6969 is the recovery half: declining is
+// not a permanent state. Once the clocks agree the same incarnation's next frame
+// raises the floor normally, so the decline costs nothing once the fault is
+// fixed and needs no restart on either node.
+func TestCorrectedClockRaisesTheFloorAgain_6969(t *testing.T) {
+	const receiverNow = int64(1_800_000_000_000_000_000)
+	slowBy := int64(2 * bootEpochMaxSkew)
+
+	s := &heartbeatAuthState{}
+	epochA := uint64(receiverNow) - uint64(time.Minute)
+	if ok, _ := admitAt6969(t, s, receiverNow, epochA, 0xA1, 1); !ok {
+		t.Fatal("fixture: incarnation A did not latch")
+	}
+	epochB := uint64(receiverNow + slowBy)
+	if ok, _ := admitAt6969(t, s, receiverNow, epochB, 0xB1, 1); !ok {
+		t.Fatal("fixture: the restarted peer was not admitted, so there is nothing to recover")
+	}
+	if s.highEpoch != epochA {
+		t.Fatalf("fixture: the floor already moved to %d, so the recovery below proves nothing",
+			s.highEpoch)
+	}
+
+	// NTP corrects this node's clock: it is no longer slow.
+	correctedNow := receiverNow + slowBy
+	if ok, reason := admitAt6969(t, s, correctedNow, epochB, 0xB1, 2); !ok {
+		t.Fatalf("the peer's next frame was refused after the clock was corrected (%q)", reason)
+	}
+	if s.highEpoch != epochB {
+		t.Fatalf("the floor is still %d after the clock was corrected, want %d. Declining a "+
+			"raise must be a HOLD, not a permanent refusal — otherwise the fix trades a "+
+			"dual-master for a floor that never tracks the peer again", s.highEpoch, epochB)
+	}
+}
+
+// TestEpochRaiseDeclineIsNamedForTheOperator_6969 keeps the diagnosis the
+// re-decided arm gave up.
+//
+// The rejection used to carry "check NTP on BOTH nodes — this is a clock fault,
+// not a replay" in its reason string. There is no rejection any more, so that
+// text has nowhere to travel except the counter's rendering. Losing it would
+// leave an operator reading a bare number during exactly the incident where
+// mistaking a clock fault for a replay costs the most.
+func TestEpochRaiseDeclineIsNamedForTheOperator_6969(t *testing.T) {
+	if note := epochRaiseDeclineNote(HeartbeatStats{}); note != "" {
+		t.Fatalf("a zero decline count rendered a note (%q); the line must stay quiet when "+
+			"there is nothing to say", note)
+	}
+	note := epochRaiseDeclineNote(HeartbeatStats{EpochRaiseDeclinedAheadOfClock: 1})
+	if note == "" {
+		t.Fatal("a non-zero decline count renders NO note. The reason string that carried " +
+			"this guidance is gone with the rejection, so the counter is the only place it " +
+			"can live (#6969 F5)")
+	}
+	if !strings.Contains(note, "NTP") {
+		t.Fatalf("the note does not name the action (NTP): %q. An operator reading a bare "+
+			"count opens a security incident for what is a clock fault", note)
+	}
+	if !strings.Contains(note, "admitted") {
+		t.Fatalf("the note does not say the frames are still admitted: %q. Without that an "+
+			"operator reads a rising count as lost heartbeats and starts looking for a "+
+			"liveness problem that no longer exists", note)
+	}
+}

--- a/pkg/cluster/heartbeat_epoch_latch_test.go
+++ b/pkg/cluster/heartbeat_epoch_latch_test.go
@@ -864,10 +864,22 @@ func TestBackwardClockStepDoesNotKillALatchedPeer_6169(t *testing.T) {
 	}
 
 	// The one-way door is still shut: a HIGHER out-of-bound epoch must not be
-	// latched, because raising the floor is the irreversible operation.
+	// LATCHED, because raising the floor is the irreversible operation.
+	//
+	// #6969 F5 re-decided the frame's DISPOSITION here, and only that. This
+	// case's own message already said the bound "must still gate raising", and
+	// that is what is asserted below and still holds: the floor is pinned. What
+	// changed is that the frame is no longer REJECTED — rejecting it dropped it
+	// before the monotonic lastSeen update, so a peer that restarts while this
+	// receiver's clock is slow was declared dead in ~500ms and the cluster went
+	// dual-master over a clock fault on THIS node. The receiver has an
+	// established floor here, which is exactly the condition under which the
+	// decline applies; a FRESH receiver still refuses outright.
 	higher := stepped + 1
-	if e.feed(marshalHeartbeatAuthEpoch(samplePkt(), e.key, 0x7702, 1, higher)) {
-		t.Fatal("an out-of-bound HIGHER epoch was admitted; the forward bound must still gate raising")
+	if !e.feed(marshalHeartbeatAuthEpoch(samplePkt(), e.key, 0x7702, 1, higher)) {
+		t.Fatal("an out-of-bound HIGHER epoch was REJECTED by an already-latched receiver. " +
+			"The frame must be admitted with the RAISE declined: the floor is the " +
+			"irreversible operation, liveness is not (#6969 F5)")
 	}
 	if got := e.r.auth.peerEpochFloor(); got != stepped {
 		t.Fatalf("floor moved to %d, want it pinned at %d", got, stepped)

--- a/pkg/cluster/heartbeat_epoch_status_6169_test.go
+++ b/pkg/cluster/heartbeat_epoch_status_6169_test.go
@@ -234,7 +234,7 @@ func TestEpochlessCounterQuietWhenClean_6169(t *testing.T) {
 // The gap it closes: "Epoch session collisions" was rendered on every surface
 // and asserted by no test, so all three copies could be deleted with the
 // package green. The two #6669 counters added alongside it
-// (EpochOutOfBandRejected, EpochAheadOfClockRejected) would have inherited the
+// (EpochOutOfBandRejected, EpochRaiseDeclinedAheadOfClock) would have inherited the
 // same hole. A counter that is populated but not rendered is documentation, not
 // observability — and one that is rendered but unbound is one careless edit
 // away from being neither.
@@ -304,7 +304,7 @@ func TestEveryEpochCounterIsRendered_6669(t *testing.T) {
 		t.Fatal("setup: no session collisions were produced")
 	}
 
-	// (6) EpochAheadOfClockRejected — above the floor AND beyond the forward
+	// (6) EpochRaiseDeclinedAheadOfClock — above the floor AND beyond the forward
 	// bound, so only epochWithinForwardBound can refuse it.
 	ahead := uint64(time.Now().UnixNano()) + bootEpochMaxSkew*3
 	if !epochUsableAsFloor(ahead) {
@@ -326,7 +326,7 @@ func TestEveryEpochCounterIsRendered_6669(t *testing.T) {
 		{"Epoch downgrades rejected:", st.EpochDowngradeRejected},
 		{"Epoch session collisions:", st.EpochSessionCollision},
 		{"Epoch out-of-band rejected:", st.EpochOutOfBandRejected},
-		{"Epoch ahead of our clock:", st.EpochAheadOfClockRejected},
+		{"Epoch raises declined:", st.EpochRaiseDeclinedAheadOfClock},
 	}
 
 	// THE PRECONDITION THAT MAKES THIS A GUARD RATHER THAN A LABEL CHECK.

--- a/pkg/cluster/heartbeat_epoch_wire_6669_test.go
+++ b/pkg/cluster/heartbeat_epoch_wire_6669_test.go
@@ -271,7 +271,7 @@ func TestEpochDowngradeIsRaisedOnTheRealReceivePath_6169(t *testing.T) {
 //     operator hunting an on-link attacker during what is an NTP problem.
 //
 // RED-on-revert: drop either `s.epochOutOfBandRejected.Add(1)` /
-// `s.epochAheadOfClockRejected.Add(1)`, or collapse either arm's reason back to
+// `s.epochRaiseDeclinedAheadOfClock.Add(1)`, or collapse either arm's reason back to
 // a bare `return false, ""`.
 func TestNonReplayEpochRefusalsAreNamedAndCounted_6669(t *testing.T) {
 	t.Run("out_of_band_epoch", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestNonReplayEpochRefusalsAreNamedAndCounted_6669(t *testing.T) {
 			t.Fatalf("the out-of-band reason does not name the range: %q", reason)
 		}
 		// The OTHER counter must not move — the two arms are distinguishable.
-		if got := s.epochAheadOfClockRejected.Load(); got != 0 {
+		if got := s.epochRaiseDeclinedAheadOfClock.Load(); got != 0 {
 			t.Fatalf("the clock-skew counter moved (%d) on an out-of-band refusal; the two "+
 				"arms must be separable or the split buys nothing", got)
 		}
@@ -311,8 +311,8 @@ func TestNonReplayEpochRefusalsAreNamedAndCounted_6669(t *testing.T) {
 		if ok {
 			t.Fatal("an epoch beyond the forward bound must be refused")
 		}
-		if got := s.epochAheadOfClockRejected.Load(); got != 1 {
-			t.Fatalf("epochAheadOfClockRejected = %d, want 1", got)
+		if got := s.epochRaiseDeclinedAheadOfClock.Load(); got != 1 {
+			t.Fatalf("epochRaiseDeclinedAheadOfClock = %d, want 1", got)
 		}
 		if reason == "" {
 			t.Fatal("#6669: an epoch past the forward bound was refused with NO reason, so " +
@@ -346,7 +346,7 @@ func TestNonReplayEpochRefusalsAreNamedAndCounted_6669(t *testing.T) {
 			t.Fatalf("a below-floor frame IS a replay of a retired incarnation, so it must "+
 				"keep the generic replay wording; got a distinct reason %q", reason)
 		}
-		if s.epochOutOfBandRejected.Load() != 0 || s.epochAheadOfClockRejected.Load() != 0 {
+		if s.epochOutOfBandRejected.Load() != 0 || s.epochRaiseDeclinedAheadOfClock.Load() != 0 {
 			t.Fatal("a below-floor replay moved one of the two non-replay counters")
 		}
 	})

--- a/pkg/cluster/heartbeat_manager.go
+++ b/pkg/cluster/heartbeat_manager.go
@@ -636,7 +636,7 @@ func (m *Manager) HeartbeatStats() HeartbeatStats {
 	s.EpochlessAdmitted = m.hbAuth.epochlessAdmitted.Load()
 	s.EpochDowngradeRejected = m.hbAuth.epochDowngradeRejected.Load()
 	s.EpochOutOfBandRejected = m.hbAuth.epochOutOfBandRejected.Load()
-	s.EpochAheadOfClockRejected = m.hbAuth.epochAheadOfClockRejected.Load()
+	s.EpochRaiseDeclinedAheadOfClock = m.hbAuth.epochRaiseDeclinedAheadOfClock.Load()
 	s.EpochSessionCollision = m.hbAuth.epochSessionCollision.Load()
 	s.PeerEpochLatched = m.hbAuth.peerEpochLatched()
 	return s
@@ -721,7 +721,7 @@ type HeartbeatStats struct {
 	// EpochDowngradeRejected).
 	EpochSessionCollision uint64
 
-	// EpochOutOfBandRejected and EpochAheadOfClockRejected are the two epoch
+	// EpochOutOfBandRejected and EpochRaiseDeclinedAheadOfClock are the two epoch
 	// refusals that are NOT replays, split out so the operator action differs
 	// from the one "stale nonce (replay)" implies.
 	//
@@ -731,15 +731,19 @@ type HeartbeatStats struct {
 	// so this points at the peer's state file or at the peer running something
 	// that is not this build — never at this node's clock.
 	//
-	// A non-zero EpochAheadOfClockRejected is a CLOCK fault and usually a
+	// A non-zero EpochRaiseDeclinedAheadOfClock is a CLOCK fault and usually a
 	// perfectly healthy peer: its epoch is more than bootEpochMaxSkew (one hour)
 	// ahead of THIS node's clock, so either the peer runs fast or this node runs
 	// slow. Check NTP on both nodes. It gates only the RAISE path, so a peer
 	// already at the floor keeps being admitted — which is why this can climb
 	// while peer liveness stays healthy, and why reading it as an attack wastes
 	// an incident. It self-clears once the clocks agree; no restart is needed.
-	EpochOutOfBandRejected    uint64
-	EpochAheadOfClockRejected uint64
+	// #6969 F5: from an established receiver the frame itself is ADMITTED with
+	// the raise declined (the floor is held, liveness is not lost); from a fresh
+	// one it is still refused. The name says "declined" rather than "rejected"
+	// for that reason — the common case no longer drops the frame.
+	EpochOutOfBandRejected         uint64
+	EpochRaiseDeclinedAheadOfClock uint64
 
 	// PeerEpochLatched is the DOWNGRADE LATCH itself (heartbeatAuthState.
 	// epochSeen): an epoch-bearing frame has been accepted from this peer.

--- a/pkg/cluster/heartbeat_wiring_binders_6669_test.go
+++ b/pkg/cluster/heartbeat_wiring_binders_6669_test.go
@@ -165,8 +165,8 @@ func TestEpochCountersAreExposedWithoutAReceiver_6669(t *testing.T) {
 			"but the counter was incremented on the admission path: the exposure is " +
 			"receiver-scoped, so a VRF rebind blanks a real refusal count")
 	}
-	if st.EpochAheadOfClockRejected == 0 {
-		t.Fatal("HeartbeatStats reports EpochAheadOfClockRejected=0 with no receiver installed, " +
+	if st.EpochRaiseDeclinedAheadOfClock == 0 {
+		t.Fatal("HeartbeatStats reports EpochRaiseDeclinedAheadOfClock=0 with no receiver installed, " +
 			"but the counter was incremented on the admission path")
 	}
 }
@@ -187,9 +187,9 @@ func TestEpochCountersStillExposedWithAReceiver_6669(t *testing.T) {
 	if st.EpochOutOfBandRejected == 0 {
 		t.Fatal("EpochOutOfBandRejected=0 WITH a receiver installed; the counter is not being read")
 	}
-	if st.EpochAheadOfClockRejected != 0 {
-		t.Fatalf("EpochAheadOfClockRejected = %d with nothing driving it, want 0: the accessor is "+
-			"not reporting real state", st.EpochAheadOfClockRejected)
+	if st.EpochRaiseDeclinedAheadOfClock != 0 {
+		t.Fatalf("EpochRaiseDeclinedAheadOfClock = %d with nothing driving it, want 0: the accessor is "+
+			"not reporting real state", st.EpochRaiseDeclinedAheadOfClock)
 	}
 }
 

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -333,7 +333,8 @@ func (m *Manager) FormatInformation() string {
 	fmt.Fprintf(&b, "  Epoch downgrades rejected:  %d\n", hbStats.EpochDowngradeRejected)
 	fmt.Fprintf(&b, "  Epoch session collisions:   %d\n", hbStats.EpochSessionCollision)
 	fmt.Fprintf(&b, "  Epoch out-of-band rejected: %d\n", hbStats.EpochOutOfBandRejected)
-	fmt.Fprintf(&b, "  Epoch ahead of our clock:   %d\n", hbStats.EpochAheadOfClockRejected)
+	fmt.Fprintf(&b, "  Epoch raises declined:      %d%s\n",
+		hbStats.EpochRaiseDeclinedAheadOfClock, epochRaiseDeclineNote(hbStats))
 	fmt.Fprintln(&b)
 
 	// Sync link statistics.
@@ -561,7 +562,8 @@ func (m *Manager) FormatStatistics() string {
 	fmt.Fprintf(&b, "    Epoch downgrades rejected:  %d\n", hbStats.EpochDowngradeRejected)
 	fmt.Fprintf(&b, "    Epoch session collisions:   %d\n", hbStats.EpochSessionCollision)
 	fmt.Fprintf(&b, "    Epoch out-of-band rejected: %d\n", hbStats.EpochOutOfBandRejected)
-	fmt.Fprintf(&b, "    Epoch ahead of our clock:   %d\n", hbStats.EpochAheadOfClockRejected)
+	fmt.Fprintf(&b, "    Epoch raises declined:      %d%s\n",
+		hbStats.EpochRaiseDeclinedAheadOfClock, epochRaiseDeclineNote(hbStats))
 	fmt.Fprintln(&b)
 
 	// Services synchronized table.
@@ -614,7 +616,8 @@ func (m *Manager) FormatControlPlaneStatistics() string {
 	fmt.Fprintf(&b, "    Epoch downgrades rejected:  %d\n", hbStats.EpochDowngradeRejected)
 	fmt.Fprintf(&b, "    Epoch session collisions:   %d\n", hbStats.EpochSessionCollision)
 	fmt.Fprintf(&b, "    Epoch out-of-band rejected: %d\n", hbStats.EpochOutOfBandRejected)
-	fmt.Fprintf(&b, "    Epoch ahead of our clock:   %d\n", hbStats.EpochAheadOfClockRejected)
+	fmt.Fprintf(&b, "    Epoch raises declined:      %d%s\n",
+		hbStats.EpochRaiseDeclinedAheadOfClock, epochRaiseDeclineNote(hbStats))
 	fmt.Fprintf(&b, "    Authentication:             %s\n", m.controlLinkAuthStatus())
 	// #6630: the rotation line appears ONLY while an additional key is
 	// configured. A permanent line reading "no rotation in progress" would be
@@ -1052,6 +1055,22 @@ func (m *Manager) FormatInterfaces(input InterfacesInput) string {
 // the counter still at 0 — and reported "replay protection is ring-only" when
 // it was not. The exposure the note describes ends when the latch arms, so the
 // latch is what it must test.
+// epochRaiseDeclineNote carries the operator guidance that used to travel on
+// the REJECTION reason string for this arm (#6969 F5). The frame is no longer
+// rejected — declining the raise while admitting the frame is the fix — so the
+// reason string is gone, and the counter is the only place the diagnosis can
+// live. Rendering it bare would lose the one thing an operator needs from it:
+// this is a CLOCK fault, and reading it as a replay sends them hunting an
+// on-link attacker during an NTP problem.
+func epochRaiseDeclineNote(s HeartbeatStats) string {
+	if s.EpochRaiseDeclinedAheadOfClock == 0 {
+		return ""
+	}
+	return "  (peer boot epoch is more than bootEpochMaxSkew ahead of THIS node's " +
+		"clock — check NTP on BOTH nodes; the frames are still admitted, only the " +
+		"floor is held)"
+}
+
 func epochlessExposureNote(s HeartbeatStats) string {
 	if s.EpochlessAdmitted == 0 {
 		return ""


### PR DESCRIPTION
Closes #6969

Not all of it. **F5 is fixed; F3 and F7 stay open, and the reason is not that they are hard** — each remedy the issue names for F3 is already refuted in-tree, and F7 is a genuine information problem. That is recorded below and in `pkg/cluster/README.md` so the next attempt does not re-derive it.

## F5 — the bound gates the raise, not the frame

The forward bound is clock-dependent, and its own comment says it gates *"ONLY the irreversible operation — raising the floor"*. The implementation was wider: when the bound fired it `return false`d. A rejected frame never reaches the monotonic `lastSeen` update, so a peer that **restarts** while this receiver's clock is more than `bootEpochMaxSkew` slow is declared dead in ~500ms and the cluster goes **dual-master** — over a clock fault on *this* node.

**A restart, not "any healthy peer"** — the finding as filed is wider than the code. The boot epoch is per-incarnation and fixed for its life, so an already-latched peer keeps being admitted through the equality exemption however slow this clock is. The bound only meets an epoch that is NEW to this receiver.

### Three things are withheld from a declined frame

1. the **floor** does not move — a floor raised to a value this node cannot verify locks out the live peer (#6711), the worst outcome available here;
2. the **downgrade latch** is not armed — `epochSeen` means "this peer has been observed signing boot epochs", and an epoch this node cannot judge is not evidence for that. Arming on it would let one captured far-future frame lock out a genuinely rolled-back peer. **This one was found by the tests, not reasoned out in advance**, and it had no cell until I added one: the existing never-arms-latch guards use a *fresh* receiver, which still refuses outright, so none of them reaches the declined path;
3. nothing else — it spends one slot of the same finite, non-refilling per-value session budget an equality frame spends, checked *before* `s.replay.admit` for the same reason the equality check is.

### Narrowed to an ESTABLISHED receiver, and that is what makes it small

The harm is "a peer this receiver already accepted is declared dead", which needs a floor to exist. A receiver with `highEpoch == 0` has no established peer and no liveness to protect, so it still refuses outright.

**Measured**: without that clause the change re-decided **six** deliberate assertions across four files. With it, **one** — `TestBackwardClockStepDoesNotKillALatchedPeer_6169`, whose own message already said the bound *"must still gate raising"*, which is exactly what still holds (the floor-pinned assertion beside it is untouched and still passes).

## What is now ADMITTED that was not

Stated because this **loosens a fail-closed gate**, and "it no longer strands live peers" is the benefit, not the safety argument.

The newly-admitted class: an **authenticated, ring-fresh, inside-the-absolute-band** frame whose epoch is **above the floor and beyond the clock's forward bound**, seen by a receiver that **already has a floor**.

* It **cannot move the floor** — so it cannot lock out the live peer, which is the #6711 poisoning and the most damaging thing in this area.
* It **cannot arm the latch** — so it cannot make a genuinely rolled-back, epochless peer unacceptable.
* It **cannot churn the ring** — it spends one slot of the same bounded, non-refilling budget, and the (k+1)-th distinct session at the floor is still refused.
* It is still filtered by the absolute year-2200 band and by `s.replay.admit`.

Its remaining power is **forged liveness from a captured frame**, which is already reachable today through the equality path and the post-restart archived-frame path documented at the arming comment, and which the same PSK rotation retires.

**The one genuine widening**: a capture from an incarnation whose epoch sits far ahead of this node's clock was previously unusable, and is now usable for liveness and for one budget slot. It still cannot move the floor.

## The counter had to be renamed, not just re-documented

`epochAheadOfClockRejected` → `epochRaiseDeclinedAheadOfClock` (rendered `Epoch raises declined`). The common case no longer rejects anything, and a counter named for an outcome it does not produce is a wrong message rather than a wording preference.

The NTP guidance the *reason string* carried has nowhere else to go — there is no rejection any more — so it moves to `epochRaiseDeclineNote`, rendered beside the count. An operator reading a bare rising number during a clock fault opens a security incident instead of checking NTP, which is exactly what the original reason string existed to prevent.

## Why F3 and F7 are not fixed here

Both remedies #6969 proposes for **F3** are already refuted in this tree:

* **plain eviction** restores exactly the sustained churn the budget closes — the `k`-larger-than-the-ring counterexample at `heartbeat.go:701-710`;
* **liveness-based refresh** (rebinding a slot on silence) is *explicitly declined* in `pkg/cluster/README.md`: "waiting out the dead-peer interval between captures is free, so it hands the attacker back the unbounded churn the bound exists to stop".

**F7** needs to tell a legitimately regressed peer (#6711's backward step) from a replay of a retired incarnation, and a below-floor frame carries nothing that separates them. That is a real information problem — the shape #6967 wrongly claimed for itself, where the discriminator turned out to exist.

So F3 and F7 need a design decision, not a patch, and I am not making it unilaterally inside a lane. Both are recorded with the refutations so the next attempt starts past them.

## Interaction with #6967, since I have both in view

#6967's residual (a backward step beyond `bootEpochPreserveMaxSkew` heals over an intact predecessor) lands on the **sender** side and produces a regressed epoch. On the receiver that shows up as F7's below-floor frame — so #6967's residual is one of the ways F7 becomes reachable, and closing F7 would blunt it. They are the same failure seen from the two ends of the wire. Neither is touched here.

**#7850 merged while this was in flight, so the reconcile is done here.** Its admission-triage table said F5 was *live*; that row now reads **FIXED by #6969 (live when measured)** and points at the forward-bound section. The two `docs/log/6969.md` files (its triage, this fix) conflicted as an add/add; resolved from the STAGES rather than by editing around markers — master's file kept whole, this branch's entry appended under its own heading — with `git ls-files -u` verified empty and a repo-wide marker sweep clean before the merge commit.

## Test plan

**Cluster smoke — owed and run.** `make cluster-deploy && make test-failover` on `loss:xpf-userspace-fw0/fw1`, under the #1875 shared lock cell: **17 passed, 0 failed**, iperf3 **13.0 Gbps** — sysrq-crash failover, rejoin as secondary without auto-preempt, manual failover of all three RGs, IPv6 transit after it. A green unit suite is not sufficient evidence that a change to heartbeat admission still lets the cluster form, fail over and rejoin.

**Mutation matrix.** Full `pkg/cluster`, `-count=1 -v`, no `-run` filter, fix committed BEFORE mutating, each cell restored with `git checkout --`. Control **984 collected, 0 failed, rc 0**.

| mutation | collected | failed | named failing test(s) |
|---|---|---|---|
| reject instead of declining (the shipped behaviour) | 984 | 4 | `TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969`, `TestDeclinedRaiseStillSpendsTheSessionBudget_6969`, `TestCorrectedClockRaisesTheFloorAgain_6969`, `TestBackwardClockStepDoesNotKillALatchedPeer_6169` |
| decline but **raise the floor anyway** | 984 | 4 | same four |
| decline but **arm the downgrade latch** | 984 | 2 | `TestSlowReceiverAdmitsARestartedPeerWithoutRaising_6969` (+ one load-sensitive unrelated) |
| decline but **skip the session budget** | 981 | 2 | `TestDeclinedRaiseStillSpendsTheSessionBudget_6969`, `TestEveryEpochCounterIsRendered_6669` |
| **fresh receiver declines too** (drop the `highEpoch == 0` refusal) | 984 | 6 | every fresh-state guard: `TestHeartbeatUnorderableEpochNeverArmsLatch_6169`, `TestHeartbeatEpochImplausibleValueCannotLockOut_6169`, `TestNonReplayEpochRefusalsAreNamedAndCounted_6669`, … |
| operator note always empty | 984 | 1 | `TestEpochRaiseDeclineIsNamedForTheOperator_6969` |

The fifth row is the one that shows the narrowing is load-bearing rather than cosmetic: without it, six deliberate fresh-state assertions fall.

**A first attempt at the note cell was a NON-MUTATION** and is reported as such: it replaced only the first line of a multi-line string concatenation, so the note kept both its non-emptiness and the word `NTP`, and the cell passed against a helper it had not changed. The row above is the redone version (`return ""` unconditionally).

- [x] `go build ./... && go test -count=1 ./...` post-merge with `origin/master`, `merge-base --is-ancestor` verified.
- [x] `go test -count=1 ./pkg/cluster/` green, including the one re-decided assertion and the six fresh-state guards left untouched.
- [x] Docs updated in the same change: `pkg/cluster/README.md` (the forward-bound section stated the rejection as the behaviour), the counter docs on both the internal and exported structs, and `docs/log/6969.md`.
