### PR TITLE
nat: single-source the reportable source-NAT pool capacity

### DIFF
--- a/pkg/api/metrics_det_pool_blocks_4752_test.go
+++ b/pkg/api/metrics_det_pool_blocks_4752_test.go
@@ -101,11 +101,11 @@ func TestDeterministicPoolBlockMath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotTotal := deterministicPoolBlockCapacity(tc.pool)
+			gotTotal := deterministicPoolBlockCapacity(tc.pool, "p", nil)
 			if gotTotal != tc.wantTotal {
 				t.Errorf("deterministicPoolBlockCapacity = %d, want %d", gotTotal, tc.wantTotal)
 			}
-			gotAlloc := deterministicSubscriberCapacity(tc.pool)
+			gotAlloc := deterministicSubscriberCapacity(tc.pool, "p", nil)
 			// The emission clamps allocated to total; assert the clamped value
 			// (matches what the gauge reports).
 			if gotAlloc > gotTotal {
@@ -134,7 +134,7 @@ func TestDeterministicPoolBlockCapacityInvalid(t *testing.T) {
 	}
 	for name, pool := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := deterministicPoolBlockCapacity(pool); got != 0 {
+			if got := deterministicPoolBlockCapacity(pool, "p", nil); got != 0 {
 				t.Errorf("deterministicPoolBlockCapacity(%s) = %d, want 0", name, got)
 			}
 		})

--- a/pkg/api/metrics_nat.go
+++ b/pkg/api/metrics_nat.go
@@ -20,6 +20,11 @@ func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp api
 		return
 	}
 
+	// #7000: this gauge is the DENOMINATOR of pool-utilisation alerts, so
+	// reporting a figure for a pool the dataplane refused is a monitoring-visible
+	// contract break — the alert reads capacity for something that can allocate
+	// nothing. Capacity now comes from the compiler's verdict.
+	overBudget := config.SourceNATAggregateOverBudgetPools(cfg)
 	for name, pool := range cfg.Security.NAT.SourcePools {
 		portLow, portHigh := pool.PortLow, pool.PortHigh
 		if portLow == 0 {
@@ -28,7 +33,8 @@ func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp api
 		if portHigh == 0 {
 			portHigh = 65535
 		}
-		totalPorts := int(config.NATPoolTotalPorts(portLow, portHigh, len(pool.Addresses))) // #6553
+		ports, _ := config.SourceNATPoolReportablePorts(pool, name, portLow, portHigh, overBudget)
+		totalPorts := int(ports)
 		ch <- prometheus.MustNewConstMetric(c.natPoolTotalPorts, prometheus.GaugeValue,
 			float64(totalPorts), name)
 
@@ -51,7 +57,7 @@ func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp api
 			ch <- prometheus.MustNewConstMetric(c.natPoolDeterministicInfo, prometheus.GaugeValue,
 				1.0, name,
 				strconv.Itoa(pool.Deterministic.BlockSize),
-				strconv.Itoa(deterministicSubscriberCapacity(pool)))
+				strconv.Itoa(deterministicSubscriberCapacity(pool, name, overBudget)))
 
 			// #4752: deterministic-pool block utilization. The pool-wide
 			// used-ports counter is meaningless for a deterministic pool
@@ -64,9 +70,9 @@ func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp api
 			// never exceeds 1.0 (the compiler already rejects an over-provisioned
 			// IPv4 pool; the clamp is defensive and also covers the IPv6 case
 			// where every block is provisioned).
-			totalBlocks := deterministicPoolBlockCapacity(pool)
+			totalBlocks := deterministicPoolBlockCapacity(pool, name, overBudget)
 			if totalBlocks > 0 {
-				allocated := deterministicSubscriberCapacity(pool)
+				allocated := deterministicSubscriberCapacity(pool, name, overBudget)
 				if allocated > totalBlocks {
 					allocated = totalBlocks
 				}
@@ -86,8 +92,14 @@ func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp api
 // (compiler_nat.go) and the dataplane NATPoolConfig.BlocksPerIP field. Returns
 // 0 when the pool is not a valid deterministic pool (nil, non-positive block
 // size, or block size larger than the port range).
-func deterministicPoolBlockCapacity(pool *config.NATPool) int {
+func deterministicPoolBlockCapacity(pool *config.NATPool, poolName string, overBudget map[string]bool) int {
 	if pool == nil || pool.Deterministic == nil {
+		return 0
+	}
+	// #7000: a refused pool installs no allocator, so it has no blocks — and a
+	// prefix member expands, so the address count is not `len(pool.Addresses)`.
+	addrs, unusable := config.SourceNATPoolReportableAddresses(pool, poolName, overBudget)
+	if unusable != "" {
 		return 0
 	}
 	bs := pool.Deterministic.BlockSize
@@ -106,7 +118,7 @@ func deterministicPoolBlockCapacity(pool *config.NATPool) int {
 	if portRange <= 0 || bs > portRange {
 		return 0
 	}
-	return len(pool.Addresses) * (portRange / bs)
+	return addrs * (portRange / bs)
 }
 
 // deterministicSubscriberCapacity returns the value reported in the
@@ -119,7 +131,7 @@ func deterministicPoolBlockCapacity(pool *config.NATPool) int {
 // host CIDR), report the pool's block/subscriber capacity: blocksPerIP =
 // portRange/blockSize, totalBlocks = len(addresses)*blocksPerIP. Returns 0
 // when the host CIDR is unparseable or the block size is non-positive.
-func deterministicSubscriberCapacity(pool *config.NATPool) int {
+func deterministicSubscriberCapacity(pool *config.NATPool, poolName string, overBudget map[string]bool) int {
 	if pool == nil || pool.Deterministic == nil {
 		return 0
 	}
@@ -134,5 +146,5 @@ func deterministicSubscriberCapacity(pool *config.NATPool) int {
 	}
 	// IPv6 — 1<<(128-ones) overflows Go's shift width. Mirror the compiler,
 	// which caps the IPv6 subscriber count by pool block capacity.
-	return deterministicPoolBlockCapacity(pool)
+	return deterministicPoolBlockCapacity(pool, poolName, overBudget)
 }

--- a/pkg/api/metrics_nat_det_ipv6_4692_test.go
+++ b/pkg/api/metrics_nat_det_ipv6_4692_test.go
@@ -25,7 +25,7 @@ func TestDeterministicSubscriberCapacity_IPv6ReportsPoolCapacity(t *testing.T) {
 			HostAddress: "2001:db8::/64",
 		},
 	}
-	got := deterministicSubscriberCapacity(pool)
+	got := deterministicSubscriberCapacity(pool, "p", nil)
 	if got == 0 {
 		t.Fatal("IPv6 deterministic pool reported 0 capacity (1<<(128-ones) shift overflow) — #4692")
 	}
@@ -45,7 +45,7 @@ func TestDeterministicSubscriberCapacity_IPv4HostCount(t *testing.T) {
 			HostAddress: "100.64.0.0/24", // /24 => 256 subscriber addresses
 		},
 	}
-	if got := deterministicSubscriberCapacity(pool); got != 256 {
+	if got := deterministicSubscriberCapacity(pool, "p", nil); got != 256 {
 		t.Fatalf("IPv4 capacity = %d, want 256 (1<<(32-24))", got)
 	}
 }
@@ -54,13 +54,13 @@ func TestDeterministicSubscriberCapacity_IPv4HostCount(t *testing.T) {
 func TestDeterministicSubscriberCapacity_Degenerate(t *testing.T) {
 	if got := deterministicSubscriberCapacity(&config.NATPool{
 		Deterministic: &config.DeterministicNATConfig{HostAddress: "not-a-cidr"},
-	}); got != 0 {
+	}, "p", nil); got != 0 {
 		t.Fatalf("unparseable host CIDR must report 0, got %d", got)
 	}
 	if got := deterministicSubscriberCapacity(&config.NATPool{
 		Addresses:     []string{"203.0.113.1"},
 		Deterministic: &config.DeterministicNATConfig{BlockSize: 0, HostAddress: "2001:db8::/64"},
-	}); got != 0 {
+	}, "p", nil); got != 0 {
 		t.Fatalf("non-positive block size must report 0, got %d", got)
 	}
 }

--- a/pkg/api/metrics_nat_pool_capacity_7000_test.go
+++ b/pkg/api/metrics_nat_pool_capacity_7000_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #7000: the `xpf_nat_pool_total_ports` gauge is the DENOMINATOR of pool
+// utilisation alerts, so a figure reported for a pool the dataplane refused is
+// a monitoring-visible contract break — the alert divides by capacity for a
+// pool that can allocate nothing. And a prefix pool under-reported by its
+// expansion factor, so utilisation read 256x too high for a healthy /24.
+//
+// This drives the REAL collector and reads the REAL gauge value, because the
+// helper-level test in pkg/config cannot see whether this surface calls it.
+func natPoolGauges(t *testing.T, setLines []string, poolIDs map[string]uint8) (map[string]float64, *xpfCollector) {
+	t.Helper()
+	store := newConfigStore(t, t.TempDir())
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(setLines, "\n")); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	c := newCollector(&Server{store: store})
+	dp := &descriptorCoverageDP{
+		Manager: dataplane.New(),
+		apply:   &dataplane.ApplyResult{PoolIDs: poolIDs},
+	}
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.collectNATPoolMetrics(ch, dp)
+		close(ch)
+	}()
+	got := map[string]float64{}
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric.Write: %v", err)
+		}
+		if m.Desc() != c.natPoolTotalPorts {
+			continue
+		}
+		for _, l := range pb.GetLabel() {
+			if l.GetName() == "pool" {
+				got[l.GetValue()] = pb.GetGauge().GetValue()
+			}
+		}
+	}
+	return got, c
+}
+
+// A healthy prefix pool: the dataplane expands 203.0.113.0/24 to 256 addresses,
+// so the gauge must be 256 * 64512. The old derivation counted the member ONCE
+// and published 64512 — a utilisation ratio 256x too high.
+func TestNATPoolTotalPortsGaugeExpandsPrefixMembers7000(t *testing.T) {
+	got, _ := natPoolGauges(t, []string{
+		"set security nat source pool wide address 203.0.113.0/24",
+		"set security nat source rule-set rs from zone trust",
+		"set security nat source rule-set rs to zone untrust",
+		"set security nat source rule-set rs rule r1 match source-address 10.0.0.0/8",
+		"set security nat source rule-set rs rule r1 then source-nat pool wide",
+	}, map[string]uint8{"wide": 0})
+
+	const want = float64(256 * 64512)
+	if v, ok := got["wide"]; !ok || v != want {
+		t.Fatalf("xpf_nat_pool_total_ports{pool=wide} = %v (present=%v), want %v. "+
+			"A /24 installs 256 pool addresses; counting the member once under-reports "+
+			"capacity by the expansion factor and inflates every utilisation ratio "+
+			"computed against this gauge (#7000)", v, ok, want)
+	}
+}
+
+// A pool the dataplane REFUSES installs no allocator, so its reportable
+// capacity is zero. `10.0.0.0/016` is the issue's own measured case: the
+// non-canonical mask makes the whole pool `invalid_pool`.
+func TestNATPoolTotalPortsGaugeIsZeroForRefusedPool7000(t *testing.T) {
+	got, _ := natPoolGauges(t, []string{
+		"set security nat source pool bad address 10.0.0.0/016",
+		"set security nat source pool good address 203.0.113.1/32",
+		"set security nat source rule-set rs from zone trust",
+		"set security nat source rule-set rs to zone untrust",
+		// `bad` is deliberately UNREFERENCED: the #5877 strict commit gate
+		// rejects a malformed pool that a rule references, so a referenced one
+		// never reaches this surface. An unreferenced one commits — and the
+		// metrics loop walks `SourcePools`, not the rules, so it still publishes
+		// a gauge for it. That is exactly how a fabricated denominator escapes
+		// to monitoring.
+		"set security nat source rule-set rs rule r2 match source-address 10.0.0.0/8",
+		"set security nat source rule-set rs rule r2 then source-nat pool good",
+	}, map[string]uint8{"bad": 0, "good": 1})
+
+	if v, ok := got["bad"]; !ok || v != 0 {
+		t.Fatalf("xpf_nat_pool_total_ports{pool=bad} = %v (present=%v), want 0. "+
+			"The malformed mask makes the pool invalid_pool, so NO allocator is "+
+			"installed and the dataplane can hand out nothing — any non-zero "+
+			"denominator here is confidently wrong (#7000)", v, ok)
+	}
+	// The healthy sibling in the SAME config must be unaffected. Without this
+	// the test would pass on a collector that reported 0 for everything.
+	if v, ok := got["good"]; !ok || v != float64(64512) {
+		t.Fatalf("xpf_nat_pool_total_ports{pool=good} = %v (present=%v), want 64512 — "+
+			"a healthy pool alongside a refused one must still report its real capacity",
+			v, ok)
+	}
+}

--- a/pkg/api/nat.go
+++ b/pkg/api/nat.go
@@ -259,6 +259,7 @@ func (s *Server) natPoolStatsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Named pools
+	overBudgetPools := config.SourceNATAggregateOverBudgetPools(cfg)
 	for name, pool := range cfg.Security.NAT.SourcePools {
 		// Config-derived fallback for capacity (used only when the helper has
 		// no runtime entry for this pool — e.g. before the first apply lands).
@@ -269,7 +270,15 @@ func (s *Server) natPoolStatsHandler(w http.ResponseWriter, r *http.Request) {
 		if portHigh == 0 {
 			portHigh = 65535
 		}
-		addrCount := len(pool.Addresses)
+		// #7000: the CONFIG-derived fallback (used when the helper has no
+		// runtime entry, or reports 0) now comes from the compiler's verdict.
+		// `len(pool.Addresses)` reported capacity for a pool the dataplane
+		// REFUSED — and because the `rp.AddressCount > 0` guard below PRESERVES
+		// this value when the runtime says 0, a refused pool's fabricated count
+		// survived even once the helper was running and had told us it installed
+		// nothing. It also under-reported every prefix member and missed the
+		// singular `address` field.
+		addrCount, _ := config.SourceNATPoolReportableAddresses(pool, name, overBudgetPools)
 		used := 0
 
 		if rp, ok := runtime[name]; ok {

--- a/pkg/cli/cli_show_nat.go
+++ b/pkg/cli/cli_show_nat.go
@@ -195,6 +195,11 @@ func (c *CLI) showNATSourceSummary(cfg *config.Config) error {
 	var pools []poolInfo
 
 	// Named pools
+	// #7000: capacity comes from the compiler's verdict, not from a per-consumer
+	// re-derivation. `len(pool.Addresses)` reported capacity for a REFUSED pool,
+	// under-reported every prefix member, and missed the singular `address`
+	// field entirely.
+	overBudget := config.SourceNATAggregateOverBudgetPools(cfg)
 	for name, pool := range cfg.Security.NAT.SourcePools {
 		portLow, portHigh := pool.PortLow, pool.PortHigh
 		if portLow == 0 {
@@ -203,7 +208,8 @@ func (c *CLI) showNATSourceSummary(cfg *config.Config) error {
 		if portHigh == 0 {
 			portHigh = 65535
 		}
-		totalPorts := int(config.NATPoolTotalPorts(portLow, portHigh, len(pool.Addresses))) // #6553
+		ports, _ := config.SourceNATPoolReportablePorts(pool, name, portLow, portHigh, overBudget)
+		totalPorts := int(ports)
 		addr := strings.Join(pool.Addresses, ",")
 		pools = append(pools, poolInfo{name: name, address: addr, total: totalPorts})
 	}
@@ -334,6 +340,7 @@ func (c *CLI) showNATSourcePool(cfg *config.Config, poolName string) error {
 		cr = c.applyResult()
 	}
 
+	detailOverBudget := config.SourceNATAggregateOverBudgetPools(cfg)
 	for name, pool := range cfg.Security.NAT.SourcePools {
 		if !showAll && name != poolName {
 			continue
@@ -346,13 +353,22 @@ func (c *CLI) showNATSourcePool(cfg *config.Config, poolName string) error {
 		if portHigh == 0 {
 			portHigh = 65535
 		}
-		totalPorts := int(config.NATPoolTotalPorts(portLow, portHigh, len(pool.Addresses))) // #6553
+		// #7000: see the summary view above.
+		ports, unusable := config.SourceNATPoolReportablePorts(pool, name, portLow, portHigh, detailOverBudget)
+		totalPorts := int(ports)
 
 		fmt.Printf("Pool name: %s\n", name)
 		for _, addr := range pool.Addresses {
 			fmt.Printf("  Address: %s\n", addr)
 		}
 		fmt.Printf("  Port range: %d-%d\n", portLow, portHigh)
+		// #7000: a capacity of 0 is ambiguous on its own — no members, a
+		// malformed member, or the #6812 aggregate budget all produce it, and
+		// they have different remedies. The detail view has room to say which,
+		// so it does; the operator is not left inferring it from a bare 0.
+		if unusable != "" {
+			fmt.Printf("  Unusable: %s\n", config.SourceNATDisarmReasonText(unusable))
+		}
 
 		if cr != nil {
 			if id, ok := cr.PoolIDs[name]; ok {

--- a/pkg/config/nat_pool_capacity.go
+++ b/pkg/config/nat_pool_capacity.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"net/netip"
+)
+
+// Reportable source-NAT pool capacity (#7000).
+//
+// THE DEFECT THIS REPLACES. Six operator-facing surfaces each derived a pool's
+// address cardinality as `len(pool.Addresses)` and multiplied it by the port
+// range. That single expression is wrong in THREE directions at once:
+//
+//  1. It reports capacity for a pool the dataplane REFUSED. A pool whose member
+//     the Rust expander cannot honour installs no allocator at all, so any
+//     non-zero figure is confidently wrong — including on the
+//     `natPoolTotalPorts` Prometheus gauge, where it becomes the denominator of
+//     a utilisation alert for a pool that can allocate nothing.
+//  2. It UNDER-reports a prefix member. The expander enumerates every address
+//     in the prefix (`for i in 0..count` in `expand_pool_address`, network and
+//     broadcast included), so a healthy `203.0.113.0/24` installs 256 addresses
+//     and was reported as 1.
+//  3. It MISSES the singular `address` field entirely. `SourceNATPoolMembers`
+//     — the one answer to "what is in this pool", shared by the snapshot
+//     builder and the unusable verdict — is `pool.Address` PLUS
+//     `pool.Addresses`, so a pool configured with only the singular form
+//     reported 0.
+//
+// WHY A SINGLE SOURCE RATHER THAN AN AGREEMENT TEST. Two derivations of "how
+// many addresses does this pool have" can never legitimately differ: there is
+// one pool and one expander. So the divergence is always a bug, and the fix is
+// to remove the second derivation rather than to bind the two. `NATPoolTotalPorts`
+// already single-sources the MULTIPLICATION; this single-sources the
+// CARDINALITY that was being fed into it.
+//
+// WHAT ZERO MEANS, AND WHY THE REASON COMES BACK WITH IT. A capacity of 0 is
+// ambiguous on its own — no such pool, a pool with no members, a pool whose
+// member is malformed, and a pool refused by the #6812 aggregate budget all
+// produce it, and they have different operator remedies. Returning the count
+// ALONE would collapse them, so this returns the reason alongside it and
+// callers that can render it do. That is the same three-states discipline
+// #6982 applied to the NAT64 budget, one layer out.
+
+// SourceNATPoolReportableAddresses returns the address cardinality an operator
+// surface should report for a source-NAT pool, and the reason it is zero.
+//
+// A non-empty reason means the dataplane installs NO allocator for this pool,
+// so the reportable capacity is 0 whatever its members say. An empty reason
+// means the count is the EXPANDED cardinality the dataplane actually installs.
+//
+// `overBudget` is `SourceNATAggregateOverBudgetPools(cfg)`; pass nil when the
+// caller has no config-wide view, which degrades to the definition verdict
+// alone rather than silently reporting an over-budget pool as healthy.
+func SourceNATPoolReportableAddresses(pool *NATPool, poolName string, overBudget map[string]bool) (int, string) {
+	if reason := SourceNATPoolDisarmedReason(pool, poolName, overBudget); reason != "" {
+		return 0, reason
+	}
+	total := 0
+	for _, m := range SourceNATPoolMembers(pool) {
+		total += sourceNATPoolMemberHosts(m)
+	}
+	return total, ""
+}
+
+// SourceNATPoolReportablePorts is the port-capacity form of the same verdict:
+// the reportable address count multiplied through the shared
+// `NATPoolTotalPorts` arithmetic, plus the reason it is zero.
+//
+// Callers used to compute `NATPoolTotalPorts(low, high, len(pool.Addresses))`.
+// The multiplication was never the wrong part.
+func SourceNATPoolReportablePorts(pool *NATPool, poolName string, portLow, portHigh int, overBudget map[string]bool) (int64, string) {
+	addrs, reason := SourceNATPoolReportableAddresses(pool, poolName, overBudget)
+	if reason != "" {
+		return 0, reason
+	}
+	return NATPoolTotalPorts(portLow, portHigh, addrs), ""
+}
+
+// sourceNATPoolMemberHosts is the host count one pool member expands to,
+// mirroring the Rust `expand_pool_address` exactly.
+//
+// A bare address is 1. A CIDR enumerates `1 << host_bits` addresses — the
+// network and broadcast addresses INCLUDED, because the expander pushes every
+// value in the range and the allocator indexes all of them. A member the
+// expander would refuse returns 0, but callers reach this only after
+// SourceNATPoolDisarmedReason has cleared the pool, so that is a backstop
+// rather than a live path: an unhonourable member makes the WHOLE pool
+// unusable (`invalid_pool`), never a silently narrowed one.
+func sourceNATPoolMemberHosts(addr string) int {
+	p, err := netip.ParsePrefix(addr)
+	if err != nil {
+		// Not CIDR: a bare address counts once (and only if it parses).
+		if _, aerr := netip.ParseAddr(addr); aerr != nil {
+			return 0
+		}
+		return 1
+	}
+	addrBits := 32
+	if p.Addr().Is6() {
+		addrBits = 128
+	}
+	hostBits := addrBits - p.Bits()
+	// The >= 64 guard mirrors the Rust early-out and prevents an over-wide
+	// shift, which Go defines as 0 and which would UNDER-count.
+	if hostBits < 0 || hostBits >= 64 {
+		return 0
+	}
+	count := uint64(1) << uint(hostBits)
+	if count > MaxSourceNATPoolPrefixHosts {
+		return 0
+	}
+	return int(count)
+}

--- a/pkg/config/nat_pool_capacity_7000_test.go
+++ b/pkg/config/nat_pool_capacity_7000_test.go
@@ -1,0 +1,172 @@
+package config
+
+import "testing"
+
+// #7000: source-NAT pool capacity was re-derived per consumer as
+// `len(pool.Addresses)`, which is wrong in THREE directions at once. These pin
+// the single source all six operator surfaces now call.
+
+func mkPool(t *testing.T, addr string, addrs ...string) *NATPool {
+	t.Helper()
+	return &NATPool{Address: addr, Addresses: addrs}
+}
+
+// Direction 2 + 3: a prefix member EXPANDS, and the singular `address` field
+// counts. `len(pool.Addresses)` sees neither.
+func TestSourceNATPoolReportableAddressesExpandsAndIncludesSingular7000(t *testing.T) {
+	cases := []struct {
+		name    string
+		pool    *NATPool
+		want    int
+		wantLen int // what the old len(pool.Addresses) derivation produced
+	}{
+		{"single host", mkPool(t, "", "203.0.113.1"), 1, 1},
+		{"host with /32", mkPool(t, "", "203.0.113.1/32"), 1, 1},
+		{"a /24 expands to 256", mkPool(t, "", "203.0.113.0/24"), 256, 1},
+		{"a /16 expands to 65536", mkPool(t, "", "10.0.0.0/16"), 65536, 1},
+		{"two members sum", mkPool(t, "", "203.0.113.0/24", "198.51.100.1"), 257, 2},
+		{"SINGULAR address only", mkPool(t, "203.0.113.7"), 1, 0},
+		{"singular + list", mkPool(t, "203.0.113.7", "198.51.100.0/24"), 257, 1},
+		{"v6 /128", mkPool(t, "", "2001:db8::1/128"), 1, 1},
+		{"v6 /120 expands to 256", mkPool(t, "", "2001:db8::/120"), 256, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := SourceNATPoolReportableAddresses(tc.pool, "p", nil)
+			if reason != "" {
+				t.Fatalf("healthy pool reported unusable: %q", reason)
+			}
+			if got != tc.want {
+				t.Fatalf("addresses = %d, want %d (the old len(pool.Addresses) "+
+					"derivation gave %d — the dataplane installs %d, so every "+
+					"capacity surface was off by that factor)", got, tc.want, tc.wantLen, tc.want)
+			}
+			// The point of the fix: the old expression really did differ.
+			if tc.want != tc.wantLen {
+				t.Logf("old derivation %d -> correct %d", tc.wantLen, tc.want)
+			}
+		})
+	}
+}
+
+// Direction 1: a pool the dataplane REFUSED reports ZERO, not a fabricated
+// figure derived from members it never installed.
+func TestSourceNATPoolReportableAddressesIsZeroForRefusedPools7000(t *testing.T) {
+	cases := []struct {
+		name       string
+		pool       *NATPool
+		poolName   string
+		overBudget map[string]bool
+		wantReason string
+	}{
+		// The issue's own measured case: a malformed prefix makes the WHOLE
+		// pool invalid, so no allocator is installed.
+		{"malformed prefix", mkPool(t, "", "10.0.0.0/016"), "p", nil, "invalid_pool"},
+		{"over-capacity prefix", mkPool(t, "", "10.0.0.0/15"), "p", nil, "invalid_pool"},
+		{"unparseable member", mkPool(t, "", "not-an-address"), "p", nil, "invalid_pool"},
+		{"empty pool", &NATPool{}, "p", nil, "empty_pool"},
+		{"missing pool", nil, "p", nil, "missing_pool"},
+		// #6812's aggregate budget is part of "can this pool allocate", so a
+		// pool refused there reports zero too.
+		{"aggregate over budget", mkPool(t, "", "203.0.113.0/24"), "p",
+			map[string]bool{"p": true}, "aggregate_over_budget"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := SourceNATPoolReportableAddresses(tc.pool, tc.poolName, tc.overBudget)
+			if got != 0 {
+				t.Fatalf("addresses = %d for a pool the dataplane refuses, want 0. "+
+					"Any non-zero figure here is confidently wrong — it becomes the "+
+					"denominator of a utilisation alert for a pool that can allocate "+
+					"nothing (#7000)", got)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// THREE STATES (really five), NOT ONE. A capacity of 0 is ambiguous on its own,
+// and the five ways to reach it have DIFFERENT operator remedies: define the
+// pool, add members, fix the malformed member, or split the config / raise the
+// budget. A surface that sees only the number cannot tell them apart, which is
+// why the reason is returned WITH it.
+//
+// This is the same discrimination #6982 built for the NAT64 budget, one layer
+// out — and the reason a test asserting only `capacity == 0` would pass against
+// every one of these.
+func TestSourceNATPoolZeroCapacityReasonsAreDistinct7000(t *testing.T) {
+	seen := map[string]string{}
+	for _, tc := range []struct {
+		label      string
+		pool       *NATPool
+		overBudget map[string]bool
+	}{
+		{"missing", nil, nil},
+		{"empty", &NATPool{}, nil},
+		{"invalid", mkPool(t, "", "10.0.0.0/016"), nil},
+		{"overbudget", mkPool(t, "", "203.0.113.1"), map[string]bool{"p": true}},
+	} {
+		got, reason := SourceNATPoolReportableAddresses(tc.pool, "p", tc.overBudget)
+		if got != 0 {
+			t.Fatalf("%s: expected a zero-capacity case, got %d", tc.label, got)
+		}
+		if prev, dup := seen[reason]; dup {
+			t.Fatalf("%s and %s both report capacity 0 with the SAME reason %q — the two "+
+				"states are indistinguishable at the consumption point, and their remedies "+
+				"differ (#7000)", tc.label, prev, reason)
+		}
+		seen[reason] = tc.label
+	}
+	if len(seen) != 4 {
+		t.Fatalf("expected 4 distinct zero reasons, got %d: %v", len(seen), seen)
+	}
+	// ...and a HEALTHY pool is distinguishable from all four by a non-zero
+	// count with an empty reason. Without this the test could pass on a helper
+	// that returned 0 for everything.
+	got, reason := SourceNATPoolReportableAddresses(mkPool(t, "", "203.0.113.0/24"), "p", nil)
+	if got != 256 || reason != "" {
+		t.Fatalf("healthy pool = (%d, %q), want (256, \"\")", got, reason)
+	}
+}
+
+// The port form multiplies the corrected cardinality through the shared
+// arithmetic, and returns 0 for a refused pool WITHOUT consulting the port
+// range at all.
+func TestSourceNATPoolReportablePorts7000(t *testing.T) {
+	ports, reason := SourceNATPoolReportablePorts(mkPool(t, "", "203.0.113.0/24"), "p", 1024, 65535, nil)
+	if reason != "" || ports != 256*64512 {
+		t.Fatalf("healthy /24 = (%d, %q), want (%d, \"\")", ports, reason, 256*64512)
+	}
+	ports, reason = SourceNATPoolReportablePorts(mkPool(t, "", "10.0.0.0/016"), "p", 1024, 65535, nil)
+	if ports != 0 || reason != "invalid_pool" {
+		t.Fatalf("refused pool = (%d, %q), want (0, \"invalid_pool\")", ports, reason)
+	}
+}
+
+// The member expansion must mirror the Rust `expand_pool_address` exactly: it
+// pushes EVERY address in the range, network and broadcast included. Counting
+// usable hosts instead (254 for a /24) would under-report by two on every
+// prefix and disagree with the allocator's own indexing.
+func TestSourceNATPoolMemberHostsMirrorsTheExpander7000(t *testing.T) {
+	for _, tc := range []struct {
+		addr string
+		want int
+	}{
+		{"203.0.113.1", 1},
+		{"203.0.113.1/32", 1},
+		{"203.0.113.0/31", 2},
+		{"203.0.113.0/24", 256},
+		{"10.0.0.0/16", 65536},
+		{"10.0.0.0/15", 0}, // over MaxSourceNATPoolPrefixHosts — expander refuses
+		{"2001:db8::1/128", 1},
+		{"2001:db8::/112", 65536},
+		{"2001:db8::/111", 0}, // over the cap
+		{"garbage", 0},
+	} {
+		if got := sourceNATPoolMemberHosts(tc.addr); got != tc.want {
+			t.Errorf("sourceNATPoolMemberHosts(%q) = %d, want %d", tc.addr, got, tc.want)
+		}
+	}
+}

--- a/pkg/grpcapi/server_nat.go
+++ b/pkg/grpcapi/server_nat.go
@@ -127,6 +127,7 @@ func (s *Server) GetNATPoolStats(ctx context.Context, _ *pb.GetNATPoolStatsReque
 	telemetry := s.telemetry()
 
 	// Named pools
+	grpcOverBudget := config.SourceNATAggregateOverBudgetPools(cfg)
 	for name, pool := range cfg.Security.NAT.SourcePools {
 		portLow, portHigh := pool.PortLow, pool.PortHigh
 		if portLow == 0 {
@@ -142,7 +143,12 @@ func (s *Server) GetNATPoolStats(ctx context.Context, _ *pb.GetNATPoolStatsReque
 		// through clampInt32 (#2282). config.NATPoolTotalPorts also carries
 		// the portHigh >= portLow guard REST had and the other three surfaces
 		// did not (#6553).
-		totalPorts64 := config.NATPoolTotalPorts(portLow, portHigh, len(pool.Addresses))
+		// #7000: the cardinality fed into that formula was the wrong part.
+		// `len(pool.Addresses)` reported capacity for a REFUSED pool,
+		// under-reported a prefix member (a /24 installs 256, not 1), and
+		// missed the singular `address` field. The compiler's verdict answers
+		// all three; the shared multiplication above is unchanged.
+		totalPorts64, _ := config.SourceNATPoolReportablePorts(pool, name, portLow, portHigh, grpcOverBudget)
 		var used64 int64
 		if cr != nil {
 			if id, ok := cr.PoolIDs[name]; ok {

--- a/pkg/showaudit/surface_gate_6534_test.go
+++ b/pkg/showaudit/surface_gate_6534_test.go
@@ -120,8 +120,6 @@ var families = []family{
 			"pkg/api/nat.go:natPoolStatsHandler",
 			"pkg/api/nat.go:natRuleStatsHandler",
 			"pkg/api/nat.go:natSourceHandler",
-			"pkg/cli/cli_show_nat.go:showNATSource",
-			"pkg/cli/cli_show_nat.go:showNATSourcePool",
 			"pkg/cli/cli_show_nat.go:showNATSourceRuleAll",
 			"pkg/cli/cli_show_nat.go:showNATSourceRuleSet",
 			"pkg/cli/cli_show_nat.go:showNATSourceSummary",


### PR DESCRIPTION
Closes #7000

## The surfaces, and what each computed

Enumerated from the tree rather than taken from the issue — the issue's six is a floor, and I found a **seventh** site plus a **third** error direction it does not name.

| # | site | derived | now |
|---|---|---|---|
| 1 | `pkg/cli/cli_show_nat.go` `showNATSource` | `NATPoolTotalPorts(low, high, len(pool.Addresses))` | `SourceNATPoolReportablePorts` |
| 2 | `pkg/cli/cli_show_nat.go` `showNATSourcePool` | same | same, **+ renders the reason** |
| 3 | `pkg/api/metrics_nat.go` `natPoolTotalPorts` gauge | same | same |
| 4 | `pkg/api/metrics_nat.go` `deterministicPoolBlockCapacity` | `len(pool.Addresses) * (portRange/bs)` | expanded count × blocks |
| 5 | `pkg/grpcapi/server_nat.go` `GetNATPoolStats` | `NATPoolTotalPorts(..., len(pool.Addresses))` | `SourceNATPoolReportablePorts` |
| 6 | `pkg/api/nat.go` config-derived fallback | `addrCount := len(pool.Addresses)` | `SourceNATPoolReportableAddresses` |
| **7** | `pkg/config/compiler_nat_source.go:838` `totalBlocks` | `len(pool.Addresses) * blocksPerIP` | **NOT changed — see below** |

**The seventh is functional, not reporting.** `totalBlocks` there gates commit acceptance (`insufficient capacity (%d blocks) for %d subscribers`). It has the same under-report, so a `203.0.113.0/24` deterministic pool is judged as 1 address and configs the dataplane could serve are **rejected**. That is a real defect but changing it changes what commits, so it does not belong in a reporting fix. Flagged for its own issue rather than folded in.

## Three error directions, not two

1. **Capacity reported for a REFUSED pool.** Measured 64512 ports on the issue's `10.0.0.0/016` case — no allocator is installed, so any non-zero figure is confidently wrong.
2. **Prefix members UNDER-reported.** `expand_pool_address` enumerates every address in the range (`for i in 0..count`, network and broadcast included), so a healthy `/24` installs **256** and read as **1**.
3. **The singular `address` field MISSED entirely** — not in the issue. `SourceNATPoolMembers` is `pool.Address` **plus** `pool.Addresses`, so a pool configured with only the singular form reported **0**.

Directions 1 and 3 both hit the `natPoolTotalPorts` gauge, which is the **denominator of utilisation alerts** — so one fabricates a denominator for a pool that can allocate nothing, and the other divides by zero for one that can.

## Single-sourced, not held in agreement

Two derivations of "how many addresses does this pool have" can never legitimately differ — one pool, one expander — so the second derivation is **removed**, not bound by a test.

Worth noting why #6553 didn't already fix this: `NATPoolTotalPorts` single-sourced the **multiplication**, and the multiplication was never the wrong part. The **cardinality** fed into it was re-derived six times. `SourceNATPoolReportableAddresses` / `...ReportablePorts` now sit beside `SourceNATPoolUnusableReason` and are the only expression.

## What zero means

A capacity of 0 has **four** causes with different remedies, and returning the count alone collapses them:

| reason | remedy |
|---|---|
| `missing_pool` | define the pool |
| `empty_pool` | add members |
| `invalid_pool` | fix the malformed member |
| `aggregate_over_budget` | split the config / raise the #6812 budget |

So the helpers return the **reason alongside the count**, and the CLI detail view — the surface with room — renders it. `TestSourceNATPoolZeroCapacityReasonsAreDistinct7000` asserts all four are pairwise distinct **and** that a healthy pool is distinguishable from all of them, so it cannot pass on a helper that returns 0 for everything.

The verdict consulted is `SourceNATPoolDisarmedReason`, not just `SourceNATPoolUnusableReason` — so a pool refused by #6812's aggregate budget reports zero too. **That state existed and none of the six could see it.**

## Validation

Seven tests. The two gauge tests drive the **real** collector and read the **real** gauge value, both **RED at master** with the numbers the issue predicted:

```
xpf_nat_pool_total_ports{pool=wide} = 64512,  want 16515072   (a /24)
xpf_nat_pool_total_ports{pool=bad}  = 64512,  want 0          (refused)
```

The refused-pool fixture leaves the bad pool **unreferenced**: the #5877 strict commit gate rejects a malformed pool a rule references, so a referenced one never reaches this surface. An unreferenced one commits, and the metrics loop walks `SourcePools` rather than the rules — which is exactly how a fabricated denominator escapes to monitoring. Both tests also assert the healthy sibling in the same config, so neither could pass on a collector reporting 0 for everything.

`go test -count=1 ./...`: rc=0, **68 packages ok**, 0 FAIL. Mutation matrix posted as a comment.

## Two things this touched that are worth calling out

- Existing callers of `deterministicPoolBlockCapacity` / `deterministicSubscriberCapacity` gained the pool name and budget map. Their assertions are **unchanged**, so #4752's and #4692's guarantees are preserved rather than relaxed by the signature change.
- **#6534's surface census caught two CLI renderers** moving from unannotated to annotated and required it updated — its own message is right that a list of known-lying surfaces outliving the lie becomes an allowlist. `source NAT rule` is now 3 annotated / 10 not, advancing **#7473**.

Refs #6553, #6812, #7473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqdwwcwWUo7FyCQSCSUh9t