### PR TITLE
userspace: required-protocol gates defer when no helper has ever answered

### DIFF
--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -955,6 +955,9 @@ func (m *Manager) ensureScopedGlobalZoneSetProtocolLocked(cfg *config.Config) er
 			return nil
 		}
 	}
+	if m.noHelperVersionObservedLocked() {
+		return nil
+	}
 	return fmt.Errorf(
 		"%w: helper config snapshot protocol version %d < required %d for multi-zone scoped global policies "+
 			"(an older helper reads only the singular match from-zone/to-zone and would NARROW the scope)",
@@ -1059,7 +1062,7 @@ func (m *Manager) ensureSecureTunnelProtocolLocked(snap *ConfigSnapshot) error {
 	// helper has never reported is #7002, which has to weigh each one's own
 	// fail-closed argument. Fixing the one this PR introduces is not a licence
 	// to change three others under the same commit.
-	if !m.helperStatusObserved {
+	if m.noHelperVersionObservedLocked() {
 		return nil
 	}
 	return fmt.Errorf(
@@ -1088,6 +1091,9 @@ func (m *Manager) ensurePolicySchedulerProtocolLocked(cfg *config.Config) error 
 			return nil
 		}
 	}
+	if m.noHelperVersionObservedLocked() {
+		return nil
+	}
 	return fmt.Errorf(
 		"%w: helper config snapshot protocol version %d < required %d for policy scheduler snapshots",
 		ErrPolicySchedulerProtocolIncompatible,
@@ -1110,12 +1116,46 @@ func (m *Manager) ensurePersistentSourceNATProtocolLocked(cfg *config.Config) er
 			return nil
 		}
 	}
+	if m.noHelperVersionObservedLocked() {
+		return nil
+	}
 	return fmt.Errorf(
 		"%w: helper config snapshot protocol version %d < required %d for persistent source NAT snapshots",
 		ErrPersistentSourceNATProtocolIncompatible,
 		m.lastStatus.ConfigSnapshotProtocolVersion,
 		MinProtocolPersistentSourceNAT,
 	)
+}
+
+// noHelperVersionObservedLocked reports that NO helper has ever told this
+// Manager a config-snapshot protocol version — the state every required-protocol
+// gate must DEFER on rather than arm (#7002).
+//
+// WHY DEFER. Arming here aborts the operator's commit and DISARMS a dataplane
+// that is not running, on the strength of a reading that never happened — a
+// brick, not a fence (#1960). The fail-closed property is kept one step later:
+// when the helper returns it gets a fresh apply, and if it is genuinely too old
+// its own exact-equality gate refuses that snapshot. This is the answer #6691
+// round 10 and #6722 each reached independently; #7002 exists because the other
+// three gates had not been brought in line.
+//
+// WHY BOTH TERMS. Three states share one value. "Never observed" and "a helper
+// ANSWERED reporting 0" both leave ConfigSnapshotProtocolVersion at 0, and only
+// the first is not evidence of a mismatch — a helper that answers with 0 is one
+// old enough not to emit the field, exactly what these gates exist to refuse.
+// helperStatusObserved is what separates them, which is why manager_status.go
+// maintains the two as a PAIR in one function.
+//
+// In production the pair is always consistent — lastStatus is written only by
+// setLastStatusLocked (which sets the flag) and clearLastStatusLocked (which
+// clears both) — so on every reachable state this conjunction is EXACTLY
+// `!helperStatusObserved`. The version term is what makes the predicate
+// well-defined on the inconsistent pair too, and it resolves that pair toward
+// ARMING: a non-zero version with no recorded observation is treated as an
+// observation. That is the fail-closed direction, and it is the direction a
+// future producer that forgets the flag should land in.
+func (m *Manager) noHelperVersionObservedLocked() bool {
+	return !m.helperStatusObserved && m.lastStatus.ConfigSnapshotProtocolVersion <= 0
 }
 
 // ensureRequiredSnapshotProtocolLocked takes the SNAPSHOT, not the config
@@ -1201,6 +1241,24 @@ func (m *Manager) ensureEgressZoneProtocolLocked() error {
 			return nil
 		}
 	}
+	// #7002, deliberately NOT unified onto noHelperVersionObservedLocked.
+	//
+	// This gate is the one that keeps `observed <= 0`, and the reason is
+	// measured rather than stylistic. The shared predicate resolves "a helper
+	// ANSWERED reporting 0" toward ARMING, which is the stronger reading and the
+	// one ensureSecureTunnelProtocolLocked argues for. But no shipping helper
+	// reports 0 — lifecycle.rs sets the field unconditionally to a non-zero
+	// constant — so the case this gate would newly fence does not occur, while
+	// the cost is real and wide: unlike its four siblings this gate has NO shape
+	// predicate, so it runs on every commit and every route-overlay publish, and
+	// tightening it fences any caller whose status probe answers with a partial
+	// or stub ProcessStatus (measured: TestSyncFabricStatePersistsResolvedFabrics
+	// IntoLastSnapshot reds on exactly that).
+	//
+	// Changing a deliberate, documented #6722 design for a benefit that cannot
+	// currently be reached is a revert wearing the shape of a fix. The
+	// divergence is recorded in the #7002 census test instead, so a later change
+	// that makes a zero-reporting helper reachable finds the note.
 	if observed <= 0 {
 		// No helper has told us a version. Not evidence of a mismatch.
 		return nil

--- a/pkg/dataplane/userspace/required_protocol_gate_unknown_version_7002_test.go
+++ b/pkg/dataplane/userspace/required_protocol_gate_unknown_version_7002_test.go
@@ -1,0 +1,221 @@
+package userspace
+
+import (
+	"testing"
+)
+
+// #7002: what every required-protocol gate does when NO helper version has ever
+// been observed — i.e. when the helper is DOWN.
+//
+// THE DISPOSITION, and why it is not an open design question. The issue asks
+// whether arming while the helper is down is the behaviour we want. The project
+// had already answered it twice, in the same direction, before the issue was
+// filed — and both answers carry their reasoning:
+//
+//   - ensureSecureTunnelProtocolLocked (#6691 round 10): "arming would disarm a
+//     dataplane and abort the operator's commit on the strength of a reading
+//     that never happened." It defers on !helperStatusObserved.
+//   - ensureEgressZoneProtocolLocked (#6722): "a gate that fired on 'version
+//     unknown' would abort every commit made while the helper is down or still
+//     starting — a brick, not a fence." It deferred on `observed <= 0`.
+//
+// So the answer is "defer", and this file makes the remaining gates agree with
+// the two that already did rather than re-litigating the question per lane.
+//
+// THE ISSUE'S ENUMERATION IS A FLOOR. It names FOUR gates; there are FIVE —
+// ensureEgressZoneProtocolLocked joined the set in #6722 and is in
+// requiredProtocolGateSentinels alongside the other four. Its measured table is
+// also stale: it lists secure-tunnel as arming, which stopped being true when
+// #6691 round 10 landed the deferral and cited this issue by number while
+// deliberately scoping the fix to itself.
+//
+// WHY helperStatusObserved AND NOT `version <= 0`. Three states share one
+// value: "never observed" and "a helper answered reporting 0" both leave
+// ConfigSnapshotProtocolVersion at 0, and only the first is not evidence of a
+// mismatch. A helper that ANSWERS with 0 is one old enough not to emit the
+// field, which is exactly what these gates exist to refuse. Only the pair
+// (lastStatus, helperStatusObserved) separates them, which is why
+// manager_status.go maintains them in a single function — and it is the reason
+// this file's `observed-zero` column is asserted separately from
+// `never-observed` rather than folded into it.
+//
+// MEASURED BEFORE THE CHANGE, on origin/master, all five gates x four states:
+//
+//	gate                   never-observed  observed-v1  observed-0  observed-current
+//	policy-scheduler       ARM             ARM          ARM         DEFER
+//	persistent-source-nat  ARM             ARM          ARM         DEFER
+//	scoped-global-zoneset  ARM             ARM          ARM         DEFER
+//	secure-tunnel          DEFER           ARM          ARM         DEFER
+//	egress-zone            DEFER           ARM          DEFER  <--  DEFER
+//
+// The `persistent-source-nat` row is the one the issue explicitly could not
+// measure ("no fixture built for it — its inclusion rests on the identical
+// body, which is a READ"). It is measured here, and the read was right.
+//
+// The marked cell is the divergence the census turned up on its own: the two
+// gates that already deferred disagreed about a helper reporting 0, because
+// they used different discriminators. Latent rather than live — no shipping
+// helper reports 0, since lifecycle.rs sets the field unconditionally to a
+// non-zero constant — but a weaker discriminator with no stated reason is one a
+// later helper change makes live.
+
+// gateCase is one required-protocol gate, driven directly with a config or
+// snapshot whose SHAPE arms it. A gate whose shape predicate returns false
+// returns nil for every version, so a fixture that does not arm the gate would
+// make every cell below pass vacuously; `TestRequiredProtocolGateFixturesArm7002`
+// asserts each fixture actually reaches the version comparison.
+type gateCase struct {
+	name string
+	run  func(m *Manager) error
+}
+
+func requiredProtocolGateCases(t *testing.T) []gateCase {
+	t.Helper()
+	t.Cleanup(stubLinkSnapshot5619(t, map[string]int{"st0": 42, "ge-0-0-0": 11}))
+	stCfg, _, _ := spellingConfig(t, "st0.0", "st0", 0)
+	stSnap := gateSnapshot(t, stCfg)
+	if !snapshotRequiresRefusalProtocol(stSnap) {
+		t.Fatal("fixture invalid: the secure-tunnel snapshot carries no flagged row, " +
+			"so that gate's cells would pass without ever reaching its version check")
+	}
+	return []gateCase{
+		{"policy-scheduler", func(m *Manager) error {
+			return m.ensurePolicySchedulerProtocolLocked(schedulerFloorCfg())
+		}},
+		{"persistent-source-nat", func(m *Manager) error {
+			return m.ensurePersistentSourceNATProtocolLocked(persistentNATFloorCfg())
+		}},
+		{"scoped-global-zoneset", func(m *Manager) error {
+			return m.ensureScopedGlobalZoneSetProtocolLocked(multiZoneScopeFloorCfg())
+		}},
+		{"secure-tunnel", func(m *Manager) error {
+			return m.ensureSecureTunnelProtocolLocked(stSnap)
+		}},
+		{"egress-zone", func(m *Manager) error {
+			return m.ensureEgressZoneProtocolLocked()
+		}},
+	}
+}
+
+// TestRequiredProtocolGateDefersOnNeverObserved7002 is the #7002 disposition,
+// executable.
+//
+// RED on revert: drop the `!m.helperStatusObserved` deferral from any one of
+// the five gates and that gate's row fails on the never-observed cell alone —
+// the other three cells are unchanged by the mutation, so the row localises
+// which gate regressed.
+func TestRequiredProtocolGateDefersOnNeverObserved7002(t *testing.T) {
+	for _, g := range requiredProtocolGateCases(t) {
+		t.Run(g.name, func(t *testing.T) {
+			// NEVER OBSERVED: a fresh Manager, no helper has ever answered.
+			m := New()
+			if m.helperStatusObserved {
+				t.Fatal("fixture invalid: a fresh Manager already claims to have " +
+					"observed a helper status")
+			}
+			if err := g.run(m); err != nil {
+				t.Errorf("gate ARMED with no helper version ever observed: %v.\n"+
+					"There is no helper present to misenforce anything, so this aborts "+
+					"the operator's commit and DISARMS a dataplane that is not running "+
+					"— a brick, not a fence (#7002/#1960). The fail-closed property is "+
+					"kept one step later: the helper gets a fresh apply when it returns "+
+					"and its own exact-equality gate refuses the snapshot if it must",
+					err)
+			}
+
+			// OBSERVED, AND TOO OLD: the state the gate exists for.
+			m = New()
+			m.setLastStatusLocked(ProcessStatus{ConfigSnapshotProtocolVersion: 1})
+			if err := g.run(m); err == nil {
+				t.Error("gate DEFERRED for a helper that answered with version 1. " +
+					"That is a real incompatibility, and deferring lets the commit " +
+					"report success against a helper that stays ARMED on its " +
+					"previous-good image with the new config never installed (#2138)")
+			}
+
+			// OBSERVED, REPORTING 0: the third state, and the one the census
+			// turned up a divergence on. A helper old enough not to emit the
+			// field ANSWERED — evidence of a mismatch, not silence — and a gate
+			// keying on the value alone cannot tell it from the first cell.
+			//
+			// Four gates arm here. `egress-zone` DEFERS, and that is recorded
+			// rather than corrected: no shipping helper reports 0 (lifecycle.rs
+			// sets the field unconditionally to a non-zero constant), so the case
+			// is unreachable, while that gate alone has no shape predicate and
+			// runs on every commit and route-overlay publish — tightening it
+			// fences callers whose status probe answers with a partial
+			// ProcessStatus. Changing a deliberate #6722 design for an
+			// unreachable benefit would be a revert wearing the shape of a fix.
+			// This cell is what a later change making zero-reporting helpers
+			// reachable will trip over.
+			m = New()
+			m.setLastStatusLocked(ProcessStatus{ConfigSnapshotProtocolVersion: 0})
+			if !m.helperStatusObserved {
+				t.Fatal("fixture invalid: setLastStatusLocked must record the observation")
+			}
+			err := g.run(m)
+			if g.name == "egress-zone" {
+				if err != nil {
+					t.Errorf("egress-zone armed for an answering-zero helper (%v). That is "+
+						"the STRONGER behaviour, and this census records the gate as "+
+						"deferring — if the divergence was deliberately closed, update "+
+						"this cell and the comment above it (#7002)", err)
+				}
+			} else if err == nil {
+				t.Error("gate DEFERRED for a helper that ANSWERED reporting version 0. " +
+					"`version <= 0` cannot distinguish that from never having heard " +
+					"from a helper; only helperStatusObserved can, which is why " +
+					"manager_status.go maintains the two as a pair (#7002)")
+			}
+
+			// OBSERVED AND CURRENT: the ordinary case must not be fenced.
+			m = New()
+			m.setLastStatusLocked(ProcessStatus{ConfigSnapshotProtocolVersion: ProtocolVersion})
+			if err := g.run(m); err != nil {
+				t.Errorf("gate armed against a CURRENT helper: %v", err)
+			}
+		})
+	}
+}
+
+// TestRequiredProtocolGateFixturesArm7002 is the anti-vacuity control for the
+// cells above. Every gate short-circuits to nil when its SHAPE predicate is
+// false, so a fixture that does not carry the feature would make the
+// never-observed and current cells pass while proving nothing. This asserts
+// each fixture DOES reach the version comparison, by driving it at a version
+// that must arm.
+//
+// It stays green under the mutation the test above catches (removing a
+// deferral changes only the never-observed cell), which is what makes it a
+// control rather than a second copy.
+func TestRequiredProtocolGateFixturesArm7002(t *testing.T) {
+	for _, g := range requiredProtocolGateCases(t) {
+		t.Run(g.name, func(t *testing.T) {
+			m := New()
+			m.setLastStatusLocked(ProcessStatus{ConfigSnapshotProtocolVersion: 1})
+			if err := g.run(m); err == nil {
+				t.Fatal("this gate's fixture does not arm it even at version 1, so its " +
+					"shape predicate is returning false and every #7002 cell for it is " +
+					"vacuous")
+			}
+		})
+	}
+}
+
+// TestRequiredProtocolGateSentinelsCoverEveryGate7002 pins the census's
+// population. #7002 names FOUR gates; there are FIVE, and the abort/disarm
+// contract keys on this list — a gate added without an entry disarms the helper
+// while the commit reports success, which is exactly #2138.
+func TestRequiredProtocolGateSentinelsCoverEveryGate7002(t *testing.T) {
+	const wantGates = 5
+	if got := len(requiredProtocolGateSentinels); got != wantGates {
+		t.Fatalf("requiredProtocolGateSentinels has %d entries, want %d. A gate was "+
+			"added or removed: add its cell to TestRequiredProtocolGateDefersOnNeverObserved7002 "+
+			"so the #7002 disposition covers it, or this census silently stops being a "+
+			"census (#7002)", got, wantGates)
+	}
+	if got := len(requiredProtocolGateCases(t)); got != wantGates {
+		t.Fatalf("the #7002 census drives %d gates but %d sentinels are registered",
+			got, wantGates)
+	}
+}


### PR DESCRIPTION
Closes #7002

## The disposition: the question was already answered in-tree, twice

#7002 asks whether ARMING — aborting the commit and disarming the helper — is
right when no helper version has ever been observed, i.e. when the helper is
DOWN. It frames this as an open design question. It is not: the project reached
the same answer twice before the issue was filed, and both answers carry their
reasoning in the code.

- `ensureSecureTunnelProtocolLocked` (#6691 r10) — *"arming would disarm a
  dataplane and abort the operator's commit on the strength of a reading that
  never happened"*. It defers, and its comment cites **this issue by number**
  while deliberately scoping the fix to itself: *"Fixing the one this PR
  introduces is not a licence to change three others under the same commit."*
- `ensureEgressZoneProtocolLocked` (#6722) — *"a gate that fired on 'version
  unknown' would abort every commit made while the helper is down or still
  starting — a brick, not a fence."*

So this brings the remaining gates in line rather than re-litigating.

## The census — five gates × four states, measured on `origin/master`

| gate | never-observed | observed v1 | observed **0** | current |
|---|---|---|---|---|
| policy-scheduler | **ARM** | ARM | ARM | DEFER |
| persistent-source-nat | **ARM** | ARM | ARM | DEFER |
| scoped-global-zoneset | **ARM** | ARM | ARM | DEFER |
| secure-tunnel | DEFER | ARM | ARM | DEFER |
| egress-zone | DEFER | ARM | **DEFER** ← | DEFER |

Three corrections to the issue fall straight out of it:

**Five gates, not four.** `ensureEgressZoneProtocolLocked` joined the set in
#6722 and sits in `requiredProtocolGateSentinels` with the other four. The
issue's enumeration is a floor.

**Its measured table is stale.** It lists secure-tunnel as arming; that stopped
being true when #6691 r10 landed.

**The persistent-source-NAT row is now measured.** The issue says it could not
be — *"no fixture built for it — its inclusion rests on the identical body,
which is a READ"*. The read was right.

## The change

`noHelperVersionObservedLocked`, called by four of the five gates. Three states
share one value: "never observed" and "a helper **answered** reporting 0" both
leave the version at 0, and only the first is not evidence of a mismatch. So the
predicate reads the **pair** `(lastStatus, helperStatusObserved)` that
`manager_status.go` maintains in one function for exactly this purpose.

In production the pair is always consistent — `lastStatus` is written only by
`setLastStatusLocked` (sets the flag) and `clearLastStatusLocked` (clears both)
— so on every reachable state the conjunction is exactly `!helperStatusObserved`.
The version term makes it well-defined on the inconsistent pair too, and
resolves that toward **arming**: the fail-closed direction, and where a future
producer that forgets the flag should land. Cell F6 below measures what that
term is actually holding up.

## The fifth gate deliberately keeps `observed <= 0`

I tried unifying it and backed the change out on evidence, not taste.

Unifying would newly fence a helper that answers reporting 0 — which **no
shipping helper does**: `lifecycle.rs` sets the field unconditionally to a
non-zero constant. Meanwhile the cost is real and wide: alone among the five,
this gate has **no shape predicate**, so it runs on every commit and every
route-overlay publish, and tightening it fences any caller whose status probe
answers with a partial `ProcessStatus`. Measured —
`TestSyncFabricStatePersistsResolvedFabricsIntoLastSnapshot` reds on exactly
that.

Changing a deliberate, documented #6722 design for a benefit that cannot
currently be reached is a revert wearing the shape of a fix. The divergence is
**recorded** — in the gate and in the census cell, which will trip over any
later change that makes a zero-reporting helper reachable — rather than closed.

## Mutation matrix — `go test -count=1 ./...`, whole repo, per cell

| cell | rc | named failing | which |
|---|---|---|---|
| control | 0 | **0** | — |
| F1 drop the deferral from policy-scheduler | 1 | 2 | `…7002/policy-scheduler` |
| F2 drop it from persistent-source-nat | 1 | 2 | `…7002/persistent-source-nat` |
| F3 drop it from scoped-global-zoneset | 1 | 2 | `…7002/scoped-global-zoneset` |
| F4 drop it from secure-tunnel | 1 | 5 | `…7002/secure-tunnel` **+ the pre-existing `TestSecureTunnelGateNeedsAnObservedVersion`** |
| F5 drop it from egress-zone | 1 | 6 | `…7002/egress-zone` **+ the pre-existing `TestEgressZoneProtocolGate_6722/unknown-version-does-not-fire`** |
| F6 reduce the shared predicate to the bare flag | 1 | 11 | 11 pre-existing tests, none of them mine |

F1–F3 each red **exactly one** subtest — their own gate's row — so each
localises. F4 and F5 are the honest accounting: **those two gates were already
bound** by their own issues' tests; my census adds a uniform row, not a new
binding. Only three of the five deferrals are newly guarded.

**F6 is the interesting one.** It reds 11 pre-existing tests and **none** of
mine, which is precisely the claim in the code comment: the version term is
load-bearing for the existing test corpus (67 sites set
`m.lastStatus.ConfigSnapshotProtocolVersion` directly, without the observation
flag — a pair production cannot produce), not for production behaviour. Keeping
the term is what let this land without rewriting 67 unrelated test sites.

Worktree restored to **0 dirty files** after the matrix.

## Anti-vacuity

Every gate short-circuits to nil when its SHAPE predicate is false, so a fixture
not carrying the feature would make the never-observed cell pass while proving
nothing. `TestRequiredProtocolGateFixturesArm7002` drives each fixture at
version 1 and requires it to arm.
`TestRequiredProtocolGateSentinelsCoverEveryGate7002` pins the population at
five, so a gate added without a census cell cannot silently shrink the census —
which is how this issue came to name four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
