### PR TITLE
config: correct a false claim about the pool-expansion shift guard

### DIFF
--- a/pkg/config/nat_pool_capacity.go
+++ b/pkg/config/nat_pool_capacity.go
@@ -99,8 +99,25 @@ func sourceNATPoolMemberHosts(addr string) int {
 		addrBits = 128
 	}
 	hostBits := addrBits - p.Bits()
-	// The >= 64 guard mirrors the Rust early-out and prevents an over-wide
-	// shift, which Go defines as 0 and which would UNDER-count.
+	// BEHAVIOURALLY REDUNDANT, AND SAID SO RATHER THAN CLAIMED OTHERWISE.
+	//
+	// This guard mirrors the Rust early-out, but unlike the Rust one it changes
+	// no output here. Go DEFINES an over-wide shift as 0 (it is not UB and does
+	// not wrap), and 0 fails the `count > MaxSourceNATPoolPrefixHosts` check
+	// below exactly as a huge value does, so both paths return 0 for every
+	// hostBits >= 64. Measured at 63 / 64 / 65 / 128.
+	//
+	// An earlier revision of this comment said the guard "prevents an over-wide
+	// shift ... which would UNDER-count". That was FALSE: under-counting to 0 is
+	// precisely the right answer for an over-cap prefix, which is why the cap
+	// check already produces it. #7000's mutation cell M5 relaxed this bound to
+	// `>= 1024` and the whole suite stayed GREEN — an unbound guard, correctly
+	// reported as an escape rather than dressed up as a red.
+	//
+	// It is kept as a structural guard for a refactor that moves or widens the
+	// cap check, and for parity with the Rust expander it mirrors — not because
+	// it is load-bearing today. Do not write a test claiming it is; there is no
+	// input that distinguishes the two.
 	if hostBits < 0 || hostBits >= 64 {
 		return 0
 	}


### PR DESCRIPTION
Follow-up to #7855 (merged). Its mutation matrix produced an **escape**, and the honest reading is that a comment I shipped is wrong — not that a guard is missing.

## The escape

Cell **M5** relaxed `hostBits >= 64` to `hostBits >= 1024` in `sourceNATPoolMemberHosts`:

```
M5 | vet=0 | rc=0 | 7000-collected=22 | named-failing=0 |
```

Suite fully green. The guard is unbound.

## Why it is unbound

Because it is **behaviourally redundant**. Go *defines* an over-wide shift as `0` — not undefined, not modular — and `0` fails the `count > MaxSourceNATPoolPrefixHosts` check exactly as a huge value does. Measured directly:

| hostBits | `1 << hostBits` | guarded | unguarded |
|---|---|---|---|
| 63 | 9223372036854775808 | 0 | 0 |
| 64 | 0 | 0 | 0 |
| 65 | 0 | 0 | 0 |
| 128 | 0 | 0 | 0 |

There is no input that distinguishes them, so **no behavioural test can bind it**.

## What was actually wrong

The comment said the guard *"prevents an over-wide shift, which Go defines as 0 and which would UNDER-count"*. False in the part that matters: under-counting to 0 is **precisely the correct answer** for an over-cap prefix — it is what the cap check already produces.

A sentence asserting a guard is load-bearing when it is not is the same defect class as #6968: it tells the next reader the property is covered when nothing covers it. I would rather correct it than leave an escape looking like a red I never claimed.

## What changes

The guard **stays** — it mirrors the Rust expander's early-out and would matter to a refactor that moves or widens the cap check. The comment now states it is redundant today, records the measurement, and explicitly tells the next reader **not** to write a test claiming it is load-bearing, because such a test could only pass vacuously.

No behaviour change; comment only. `go test -count=1 -run 7000 ./pkg/config/` green.

Refs #7000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqdwwcwWUo7FyCQSCSUh9t