### PR TITLE
userspace-dp: prune policy and NAT hit counters at the commit point

### DIFF
--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1391,6 +1391,7 @@ impl Coordinator {
     /// a legitimate config-transition reset still lands.
     ///
     /// Returns `true` when the bump was applied, `false` when it was refused
+
     /// as a rollback.
     #[must_use]
     pub fn bump_fib_generation(&mut self, fib_generation: u32) -> bool {

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -415,6 +415,13 @@ impl Coordinator {
         // time — see `forwarding_build::commit_zone_counter_prune`.
         if bringup_result.is_ok() {
             crate::afxdp::forwarding_build::commit_zone_counter_prune(&self.forwarding, snapshot);
+            // #7010: the policy / NAT hit-counter prune shares this commit
+            // point, for the reason on `commit_rule_counter_prune`.
+            crate::afxdp::forwarding_build::commit_rule_counter_prune(
+                &self.policy_counters,
+                &self.nat_counters,
+                snapshot,
+            );
         }
         // #4952 / #5143: a POST-TEARDOWN worker-bringup failure fails the
         // reconcile closed. `bring_up_workers` returned the specific failure —

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -567,11 +567,19 @@ pub(super) fn apply_snapshot(
         config_generation: snapshot.generation,
         fib_generation: snapshot.fib_generation,
     };
-    coord.policy_counters.reconcile_rules(&snapshot.policies);
-    // #2218: drop hit counters for NAT rules removed by this config.
-    coord
-        .nat_counters
-        .reconcile_ids(&super::super::snapshot_active_nat_counter_ids(snapshot));
+    // #7010: the destructive prune of the policy / NAT hit counters USED to be
+    // here, above `bring_up_workers`. It moved to
+    // `Coordinator::commit_rule_counter_prune`, which each apply path calls at
+    // ITS OWN commit point — the same split #6832 made for the per-zone
+    // counters, and for the same measured reason: a build can succeed and the
+    // apply still be rejected by a worker spawn failure (#4952) or an
+    // incomplete queue bind (#5143), and pruning here destroyed the removed
+    // rules' cumulative hit counts for a configuration that never forwarded a
+    // packet. Worse than the zone case, which is why it needed its own issue:
+    // `stop_inner` defaults `coord.forwarding` and takes the zone store's
+    // publisher with it, but `policy_counters` and `nat_counters` are
+    // Coordinator fields it never touches — so BOTH bring-up failure arms leaked
+    // here, and `nat_rule_counters()` kept serving from the pruned store.
     // #1866 D3: WG endpoint-set transition log at the reconcile apply
     // boundary (mirrors refresh_runtime_snapshot).
     super::super::log_wg_endpoint_set_transition("reconcile", &coord.forwarding, &new_forwarding);

--- a/userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs
+++ b/userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs
@@ -344,10 +344,6 @@ impl super::Coordinator {
             config_generation: snapshot.generation,
             fib_generation: snapshot.fib_generation,
         };
-        self.policy_counters.reconcile_rules(&snapshot.policies);
-        // #2218: drop hit counters for NAT rules removed by this config.
-        self.nat_counters
-            .reconcile_ids(&super::snapshot_active_nat_counter_ids(snapshot));
         // #1866 D3: WG endpoint-set transition log at the Rust apply
         // boundary. Rare (only when the set actually changes); pairs
         // with the Go publish-boundary log to pin which layer dropped
@@ -386,6 +382,17 @@ impl super::Coordinator {
         // `forwarding_build::commit_zone_counter_prune` for why the two halves
         // are split.
         crate::afxdp::forwarding_build::commit_zone_counter_prune(&self.forwarding, snapshot);
+        // #7010: the policy / NAT hit-counter prune, moved down from above the
+        // swap to sit beside the zone one. BEHAVIOUR-NEUTRAL on this path —
+        // nothing between the old position and here can return, so the prune
+        // already ran only on a committed refresh — but leaving it above the
+        // swap left two counter families pruning at two different points in one
+        // function, which is the shape that let the reconcile path drift.
+        crate::afxdp::forwarding_build::commit_rule_counter_prune(
+            &self.policy_counters,
+            &self.nat_counters,
+            snapshot,
+        );
         if self.forwarding.fabrics.is_empty() && !preserved_fabrics.is_empty() {
             self.forwarding.fabrics = preserved_fabrics;
         } else if !preserved_fabrics.is_empty() {

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -5032,6 +5032,276 @@ fn rejected_apply_does_not_prune_live_zone_counters_6832() {
     );
 }
 
+/// #7010 fixtures. The policy and NAT HIT-counter twin of the #6832 zone
+/// fixtures above, and the same three directions.
+///
+/// Both stores are seeded through the PRODUCTION entry points — the policy half
+/// via `parse_policy_state_with_counters` (which get-or-creates a block per
+/// rule) and the NAT half via `NatCounterStore::rule_counter` — so the seeding
+/// path is the one the builder itself takes.
+const RULE_COUNTER_LIVE_NAT_ID: u32 = 7;
+const RULE_COUNTER_DOOMED_NAT_ID: u32 = 4243;
+const RULE_COUNTER_LIVE_POLICY_ID: &str = "zone100->zone200/live-rule";
+const RULE_COUNTER_DOOMED_POLICY_ID: &str = "zone100->zone200/doomed-rule";
+
+fn rule_counter_policy_snapshots() -> Vec<crate::PolicyRuleSnapshot> {
+    ["live-rule", "doomed-rule"]
+        .iter()
+        .map(|name| crate::PolicyRuleSnapshot {
+            name: (*name).into(),
+            from_zone: "zone100".into(),
+            to_zone: "zone200".into(),
+            action: "permit".into(),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Seed BOTH stores with a live id and a doomed id, and give the live policy
+/// rule a non-zero hit count.
+///
+/// The live id is what separates a correctly deferred prune from a prune that
+/// simply never runs: an over-correction that stops pruning entirely passes
+/// "the doomed id survived a rejection" and fails
+/// `committed_reconcile_prunes_rule_counters_for_removed_rules_7010`.
+fn rule_counter_live_coordinator(coord: &mut Coordinator) {
+    let mut zone_map = rustc_hash::FxHashMap::default();
+    zone_map.insert("zone100".to_string(), 100u16);
+    zone_map.insert("zone200".to_string(), 200u16);
+    crate::policy::parse_policy_state_with_counters(
+        "deny",
+        &rule_counter_policy_snapshots(),
+        &zone_map,
+        &[],
+        &coord.policy_counters,
+    )
+    .expect("the live seed policy must parse");
+    // A real total on the LIVE NAT row. This is what separates "the block
+    // SURVIVED the prune" from "the build re-created it": a committed reconcile
+    // runs the additive get-or-create BEFORE the prune, so a present id alone
+    // is satisfied by a freshly minted zero block.
+    coord
+        .nat_counters
+        .rule_counter(RULE_COUNTER_LIVE_NAT_ID)
+        .expect("the live NAT counter must be creatable")
+        .add(64);
+    let _ = coord.nat_counters.rule_counter(RULE_COUNTER_DOOMED_NAT_ID);
+
+    for want in [RULE_COUNTER_LIVE_POLICY_ID, RULE_COUNTER_DOOMED_POLICY_ID] {
+        assert!(
+            coord.policy_counters.tracked_rule_ids().iter().any(|id| id == want),
+            "fixture: policy id {want} must be seeded, or every assertion below is \
+             vacuous. Got {:?}",
+            coord.policy_counters.tracked_rule_ids()
+        );
+    }
+    let mut nat_ids = coord.nat_counters.tracked_ids();
+    nat_ids.sort_unstable();
+    assert_eq!(
+        nat_ids,
+        vec![RULE_COUNTER_LIVE_NAT_ID, RULE_COUNTER_DOOMED_NAT_ID],
+        "fixture: both NAT ids must be seeded"
+    );
+}
+
+/// The candidate: it keeps the live policy rule and the live NAT rule, and
+/// DROPS the doomed pair. A committed apply must prune exactly the doomed two.
+fn rule_counter_candidate(generation: u64) -> crate::ConfigSnapshot {
+    let mut snap = mandatory_ok_snapshot(generation);
+    snap.zones = zone_counter_zones(&[100, 200]);
+    snap.policies = vec![crate::PolicyRuleSnapshot {
+        name: "live-rule".into(),
+        from_zone: "zone100".into(),
+        to_zone: "zone200".into(),
+        action: "permit".into(),
+        ..Default::default()
+    }];
+    snap.static_nat_rules = vec![crate::StaticNATRuleSnapshot {
+        name: "live-static".into(),
+        counter_id: RULE_COUNTER_LIVE_NAT_ID,
+        external_ip: "198.51.100.7".into(),
+        internal_ip: "10.9.9.7".into(),
+        ..Default::default()
+    }];
+    snap
+}
+
+fn rule_counter_state(coord: &Coordinator) -> (Vec<String>, Vec<u32>) {
+    let mut policy = coord.policy_counters.tracked_rule_ids();
+    policy.sort();
+    let mut nat = coord.nat_counters.tracked_ids();
+    nat.sort_unstable();
+    (policy, nat)
+}
+
+/// #7010 NEGATIVE, `WorkerSpawn` arm — the arm that leaves the candidate state
+/// PUBLISHED, so `nat_rule_counters()` keeps serving from a store the rejected
+/// apply already pruned.
+///
+/// RED before the fix: the prune ran inside `apply_snapshot`, above
+/// `bring_up_workers`, so the doomed ids were already gone. Measured on
+/// origin/master, both arms.
+#[test]
+fn rejected_spawn_apply_does_not_prune_live_rule_counters_7010() {
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
+    // `StoppedCoordinator`, not a trailing `coordinator.stop()`: a cell that
+    // PANICS skips the trailing call and leaks its neigh-monitor thread into the
+    // process-wide #6637 gates, which then red alongside it. Measured — the
+    // first #7010 mutation matrix showed this cell's G1 red carrying two
+    // collateral #6637 failures that had nothing to do with the mutation, and a
+    // mutation cell that reds three tests when it should red one cannot
+    // localise.
+    let mut coordinator = StoppedCoordinator::new();
+    rule_counter_live_coordinator(&mut coordinator);
+
+    let mut bindings = zone_counter_binding();
+    coordinator.force_worker_spawn_fail = 1;
+    let result = coordinator.reconcile(Some(&rule_counter_candidate(6)), &mut bindings, 64);
+    assert!(
+        matches!(result, Err(ReconcileError::WorkerSpawn(_))),
+        "fixture: this apply must be rejected by the worker SPAWN arm — got {result:?}"
+    );
+
+    let (policy, nat) = rule_counter_state(&coordinator);
+    assert!(
+        policy.iter().any(|id| id == RULE_COUNTER_DOOMED_POLICY_ID),
+        "a REJECTED apply destroyed the hit counter of a policy rule the refused \
+         candidate removed. The config never brought up a worker and the \
+         WorkerSpawn arm leaves it published, so `show security policies \
+         hit-count` serves from a store whose history is already gone — and \
+         unlike the zone store, `stop_inner` never resets this one, so it stays \
+         gone (#7010). Got {policy:?}"
+    );
+    assert!(
+        nat.contains(&RULE_COUNTER_DOOMED_NAT_ID),
+        "same, NAT half: `nat_rule_counters()` serves from this store (#7010). \
+         Got {nat:?}"
+    );
+    assert!(
+        policy.iter().any(|id| id == RULE_COUNTER_LIVE_POLICY_ID)
+            && nat.contains(&RULE_COUNTER_LIVE_NAT_ID),
+        "control: the LIVE ids must also still be present — an assertion that \
+         only the doomed ids survive would pass against a store nothing pruned \
+         and nothing seeded"
+    );
+}
+
+/// #7010 NEGATIVE, `WorkerBindIncomplete` arm.
+///
+/// The zone case only leaked on the spawn arm, because `stop_inner(false)`
+/// defaults `coord.forwarding` and takes the zone store's publisher with it.
+/// These two stores are Coordinator fields that `stop_inner` never touches, so
+/// BOTH arms leak here — which is why this arm gets its own cell rather than
+/// being folded into the one above.
+#[test]
+fn rejected_bind_apply_does_not_prune_live_rule_counters_7010() {
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
+    let mut coordinator = StoppedCoordinator::new();
+    rule_counter_live_coordinator(&mut coordinator);
+
+    let mut bindings = zone_counter_binding();
+    // No healthy-worker stub: a real XSK bind is impossible in-process, so the
+    // reconcile is rejected at the bind-incomplete arm.
+    let result = coordinator.reconcile(Some(&rule_counter_candidate(6)), &mut bindings, 64);
+    assert!(
+        result.is_err(),
+        "fixture: this apply must be REJECTED — got {result:?}"
+    );
+
+    let (policy, nat) = rule_counter_state(&coordinator);
+    assert!(
+        policy.iter().any(|id| id == RULE_COUNTER_DOOMED_POLICY_ID)
+            && nat.contains(&RULE_COUNTER_DOOMED_NAT_ID),
+        "a reconcile rejected at the BIND arm destroyed the removed rules' hit \
+         counters. `stop_inner` defaults only `self.forwarding`; policy_counters \
+         and nat_counters are untouched, so this arm leaks exactly as the spawn \
+         arm does (#7010). policy={policy:?} nat={nat:?}"
+    );
+}
+
+/// #7010 POSITIVE — the anti-over-fix direction. Deferring the prune must not
+/// DELETE it: a COMMITTED apply must still drop the removed rules.
+#[test]
+fn committed_reconcile_prunes_rule_counters_for_removed_rules_7010() {
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
+    let mut coordinator = StoppedCoordinator::new();
+    rule_counter_live_coordinator(&mut coordinator);
+
+    let mut bindings = zone_counter_binding();
+    coordinator.force_worker_healthy_stub = true;
+    let result = coordinator.reconcile(Some(&rule_counter_candidate(6)), &mut bindings, 64);
+    assert!(
+        result.is_ok(),
+        "fixture: this apply must COMMIT (workers up) — got {result:?}"
+    );
+
+    let (policy, nat) = rule_counter_state(&coordinator);
+    assert!(
+        !policy.iter().any(|id| id == RULE_COUNTER_DOOMED_POLICY_ID),
+        "a COMMITTED reconcile must still prune the removed policy rule's \
+         counter; deferring the prune past worker bring-up must not delete it. \
+         Got {policy:?}"
+    );
+    assert!(
+        !nat.contains(&RULE_COUNTER_DOOMED_NAT_ID),
+        "same, NAT half. Got {nat:?}"
+    );
+    assert!(
+        policy.iter().any(|id| id == RULE_COUNTER_LIVE_POLICY_ID),
+        "the surviving rule must keep its block across the commit, not be swept \
+         with the doomed one — a prune that empties the store passes the two \
+         assertions above for the wrong reason. Got {policy:?}"
+    );
+    assert!(
+        nat.contains(&RULE_COUNTER_LIVE_NAT_ID),
+        "NAT half of the same control. Got {nat:?}"
+    );
+    let live_row = coordinator
+        .nat_counters
+        .snapshots()
+        .into_iter()
+        .find(|r| r.counter_id == RULE_COUNTER_LIVE_NAT_ID)
+        .expect("the live NAT row must still exist after a committed prune");
+    assert!(
+        live_row.packets > 0,
+        "the surviving NAT row must keep its CARRIED-FORWARD totals. A zero here \
+         means the block was re-created by the build's get-or-create rather than \
+         retained — which the id-presence assertion above cannot tell apart"
+    );
+}
+
+/// #7010, the REFRESH call site. The reconcile cells above cannot see this one
+/// and vice versa — one production line, one assertion.
+///
+/// This path's prune MOVED in #7010, from above the `self.forwarding` swap to
+/// beside the zone prune below it. The move is behaviour-neutral (nothing
+/// between the two positions can return, so the prune already ran only on a
+/// committed refresh), but "behaviour-neutral" was an unbound claim until this
+/// cell existed: deleting the call outright leaves every other test green.
+#[test]
+fn committed_refresh_prunes_rule_counters_for_removed_rules_7010() {
+    let mut coordinator = StoppedCoordinator::new();
+    rule_counter_live_coordinator(&mut coordinator);
+
+    coordinator
+        .refresh_runtime_snapshot(&rule_counter_candidate(6))
+        .expect("fixture: the candidate must refresh cleanly");
+
+    let (policy, nat) = rule_counter_state(&coordinator);
+    assert!(
+        !policy.iter().any(|id| id == RULE_COUNTER_DOOMED_POLICY_ID)
+            && !nat.contains(&RULE_COUNTER_DOOMED_NAT_ID),
+        "a COMMITTED same-plan refresh must drop the removed rules' hit counters. \
+         policy={policy:?} nat={nat:?}"
+    );
+    assert!(
+        policy.iter().any(|id| id == RULE_COUNTER_LIVE_POLICY_ID)
+            && nat.contains(&RULE_COUNTER_LIVE_NAT_ID),
+        "...and must keep the surviving rules — a prune that empties the store \
+         passes the assertion above for the wrong reason. policy={policy:?} nat={nat:?}"
+    );
+}
+
 #[test]
 fn committed_reconcile_prunes_zone_counters_for_removed_zones_6832() {
     // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -420,6 +420,48 @@ pub(in crate::afxdp) fn commit_zone_counter_prune(
     state.flood_counter_store.reconcile(&configured);
 }
 
+/// #7010: the DESTRUCTIVE half of the policy / NAT hit-counter reconcile —
+/// `commit_zone_counter_prune`'s twin, and deliberately its neighbour.
+///
+/// The additive half — `PolicyCounterStore::rule_hit_counter` and
+/// `NatCounterStore::rule_counter` get-or-creating a block per rule — stays in
+/// the fallible builder, where #6995 rolls it back on a rejected build. This
+/// half must NOT run there: a build can succeed and the apply still be rejected
+/// afterwards by a worker-thread spawn failure (#4952) or an incomplete queue
+/// bind (#5143), and pruning at build time destroyed the removed rules'
+/// cumulative hit counts for a configuration that never brought up a worker.
+///
+/// STRICTLY WORSE EXPOSURE than the #6832 zone case this copies, which is why it
+/// needed its own fix rather than riding along. `stop_inner(false)` defaults
+/// `coord.forwarding`, so the zone store lost its publisher on the
+/// `WorkerBindIncomplete` arm and only the `WorkerSpawn` arm was
+/// operator-visible. `policy_counters` and `nat_counters` are Coordinator fields
+/// `stop_inner` never touches, so BOTH arms leaked and `nat_rule_counters()`
+/// kept serving from the pruned store. Measured on the pre-fix head, both arms:
+/// `policy=["default-policy", "zone100->zone200/live-rule"] nat=[7]` — the
+/// removed rule's block already gone, and it stays gone.
+///
+/// Takes the two stores rather than the Coordinator so it can live beside its
+/// zone twin: a reader looking for "where the destructive halves commit" finds
+/// both in one place, which is the property that let the reconcile path drift
+/// from the refresh path in the first place.
+///
+/// What guards it is exactly three named tests, one per direction —
+/// `rejected_spawn_apply_does_not_prune_live_rule_counters_7010`,
+/// `rejected_bind_apply_does_not_prune_live_rule_counters_7010` and
+/// `committed_reconcile_prunes_rule_counters_for_removed_rules_7010`. They bind
+/// the call sites that EXIST; if you add an apply path, add its row.
+pub(in crate::afxdp) fn commit_rule_counter_prune(
+    policy_counters: &crate::policy::PolicyCounterStore,
+    nat_counters: &crate::nat::NatCounterStore,
+    snapshot: &ConfigSnapshot,
+) {
+    policy_counters.reconcile_rules(&snapshot.policies);
+    // #2218: drop hit counters for NAT rules removed by this config.
+    nat_counters
+        .reconcile_ids(&crate::afxdp::coordinator::snapshot_active_nat_counter_ids(snapshot));
+}
+
 /// Every fallible step of the forwarding build. Returns `Err` on any snapshot
 /// integrity violation, having touched no live ZONE-COUNTER state — see the
 /// caller for why the per-zone counter binding is deliberately not done here.


### PR DESCRIPTION
Closes #7010

## Premise measured first — both bring-up arms

The destructive prune of the policy / NAT hit counters ran inside
`apply_snapshot`, above `bring_up_workers`. The new cells fail at master with
the store contents quoted:

```
rejected_bind_apply_does_not_prune_live_rule_counters_7010
  policy=["default-policy", "zone100->zone200/live-rule"] nat=[7]
rejected_spawn_apply_does_not_prune_live_rule_counters_7010
  (same)
```

The doomed policy id and the doomed NAT id `4243` are already gone on a
reconcile that returned `Err`. The issue's premise holds, on **both** arms.

## Strictly worse than the zone case it copies

`stop_inner(false)` defaults `coord.forwarding`, so the #6832 zone store lost its
publisher on the `WorkerBindIncomplete` arm and only `WorkerSpawn` was
operator-visible. `policy_counters` and `nat_counters` are Coordinator fields
`stop_inner` never touches — so **both arms leak**, and `nat_rule_counters()`
keeps serving from the pruned store until the next committed apply. That is why
this needed its own fix rather than a fold into #6832.

## Both directions, as asked

**Newly RETAINED:** on a rejected apply, through either bring-up arm, the hit
counters of policy rules and NAT rules the refused candidate removed.
Previously destroyed and never restored.

**Newly PRUNED: nothing.** The committed reconcile prunes exactly as before, and
the refresh path's prune only **moved** — from above the `self.forwarding` swap
to below it, with no early exit between the two positions, so it already ran
only on a committed refresh. That behaviour-neutrality was an **unbound claim**
until `committed_refresh_prunes_rule_counters_for_removed_rules_7010`, added
here: deleting the refresh call leaves every other test green (cell G2 proves
it).

## The shape

#6832's, copied rather than re-invented. `commit_rule_counter_prune` lives
beside `commit_zone_counter_prune` in `forwarding_build`, and each apply path
calls it at its own commit point. It takes the two stores rather than the
Coordinator so it can sit next to its twin — a reader looking for "where the
destructive halves commit" now finds both in one place, which is the property
whose absence let the reconcile path drift from the refresh path.

The positive cells seed the live NAT row with a **real total** before the apply.
That is what separates "the block survived the prune" from "the build re-created
it": a committed reconcile runs the additive get-or-create *before* the prune, so
a present id alone is satisfied by a freshly minted zero block.

## Mutation matrix — whole crate, `--test-threads=1`, no `-run` filter

| cell | rc | tests passed | named failing | which |
|---|---|---|---|---|
| control | 0 | **4877** | 0 | — |
| G1 delete the RECONCILE commit-point call | 101 | 4807 | **1** | `committed_reconcile_prunes_rule_counters_for_removed_rules_7010` |
| G2 delete the REFRESH commit-point call | 101 | 4807 | **1** | `committed_refresh_prunes_rule_counters_for_removed_rules_7010` |
| G3 hoist the prune back into `apply_snapshot` (the pre-fix shape) | 101 | 4806 | **2** | both `rejected_*_apply_does_not_prune_live_rule_counters_7010` cells |

Every cell localises: G1 and G2 each red exactly one call site's own cell — one
production line, one assertion — and G3, the true revert, reds exactly the two
rejected-arm cells and nothing else. Worktree restored to 0 dirty files.

### A test-quality fix the first matrix run forced

The first run's G1 red carried **two collateral failures**,
`coordinator_bringup_does_not_leak_a_neigh_monitor_thread_6637` and its sibling.
Cause: my cells ended with a trailing `coordinator.stop()`, which a **panicking**
cell skips — leaking the neigh-monitor thread into the process-wide #6637 gates.
A mutation cell that reds three tests when it should red one cannot localise, so
the cells now use the existing `StoppedCoordinator` stop-on-drop guard. The
table above is the re-run.

## Placement note

`commit_rule_counter_prune` was first written as a `Coordinator` method and
moved: it took `coordinator/mod.rs` from 1480 to 1515 LOC and crossed the 1500
`[WATCH]` floor (`TestTouchedFileCrossedModularityThreshold`). Relocating beside
its zone twin is the better home anyway and leaves that file at 1481 — the
threshold pointed at a real improvement rather than needing an exemption.

## Gates

Rust whole crate `rc=0`, 4746 passed. Go `./...` `rc=0`, 68 packages ok,
`TMPDIR=/var/tmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
