### PR TITLE
userspace: narrow the zone-map agreement claim to what is true

### DIFF
--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1186,15 +1186,47 @@ Scope of the fallback:
   incidental, so each has a binder in
   `pkg/dataplane/userspace/egress_zone_identity_6722_test.go` (#6722 round 12):
 
-  - **The two zone maps must not disagree.** `authoredZoneRefs` and
-    `buildInterfaceZoneMap` are built by separate code for separate consumers,
-    but they read the same operator sentences through the same canonicalizer and
-    pick a winner the same way — zone names sorted, first write wins. Rule 2
-    resolves from the first while the helper's corroboration check reads rows
-    stamped from the second, so a divergence about a reference BOTH maps hold is
-    a claim the helper will honour under a zone the operator did not write for
-    that identity. They are free to diverge in future — a move to Junos per-unit
-    zoning would want one to stop fanning up to the base — but not silently.
+  - **The two zone maps must not disagree about a UNIT reference** — and they
+    CAN disagree about a base one (#7024). `authoredZoneRefs` and
+    `buildInterfaceZoneMap` are built by separate code for separate consumers.
+    Neither synthesizes a unit reference, so both record a `<ifd>.<unit>` from
+    the operator's literal sentence and a disagreement there really is one of
+    them changing its write policy or canonicalization alone.
+
+    A BASE reference is different, and the earlier wording here — that the two
+    "pick a winner the same way" — was **false**. `buildInterfaceZoneMap` fans a
+    unit reference UP to its base (first write wins over sorted zone names);
+    `authoredZoneRefs` deliberately does not, because it is PROVENANCE: what the
+    operator literally wrote. So a bare reference in one zone plus a dotted
+    reference from an alphabetically EARLIER zone naming the same interface
+    yields two different answers, and both are right for their own consumer:
+
+    ```
+    set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24
+    set security zones security-zone aaa interfaces ge-0/0/1.0
+    set security zones security-zone zzz interfaces ge-0/0/1
+
+    authored = map[ge-0/0/1:zzz ge-0/0/1.0:aaa]
+    derived  = map[ge-0/0/1:aaa ge-0/0/1.0:aaa]
+    ```
+
+    Making them literally agree is not the fix. Fanning up in `authoredZoneRefs`
+    too would DISCARD the operator's bare sentence, destroying the provenance
+    that map exists to preserve; making `buildInterfaceZoneMap` stop fanning up
+    would break the per-row ingress attribution it exists to derive. The maps
+    SHOULD differ here; what was wrong was the claim.
+
+    What must hold instead, and is now asserted: a base divergence is tolerated
+    ONLY when the derived value is the zone of some authored unit under that
+    base (i.e. the fan-up explains it), and the ifindex then resolves
+    **fail-closed** — rule 2's conflict arm sees both zones and refuses, so
+    `EgressZone` is `""` and nothing forwards under a zone the operator did not
+    write. `TestBaseAndUnitClaimedByDifferentZonesFailsClosed_7024` pins the
+    outcome, because a tolerated divergence with nothing asserting its safety
+    would be the same defect one step along.
+
+    Reachable only on the tolerant load / HA peer-sync path (#1960): strict
+    `CompileConfig` rejects the doubly-claimed interface outright.
   - **Every answer must be order-stable.** Nothing here may depend on Go's
     randomized map iteration. An egress zone that varies with the map seed is a
     to-zone that changes across daemon restarts on an unchanged config, and a

--- a/pkg/dataplane/userspace/egress_zone_identity_6722_test.go
+++ b/pkg/dataplane/userspace/egress_zone_identity_6722_test.go
@@ -1387,6 +1387,33 @@ func zoneMapCorpus6722() []struct {
 			"set security zones security-zone zzz interfaces ge-0/0/1",
 			"set security zones security-zone zzz interfaces reth1",
 		}, true},
+		// #7024: THE FALSIFYING SHAPE. A BARE reference in one zone and a
+		// DOTTED reference from a DIFFERENT zone naming the same interface.
+		// buildInterfaceZoneMap fans the dotted ref UP to the base
+		// (first-write-wins over sorted zone names, so `aaa` beats `zzz`);
+		// authoredZoneRefs deliberately does not fan up, and records the bare
+		// sentence. The two therefore give different answers for `ge-0/0/1`.
+		//
+		// This is the ONLY shape that falsifies the old unconditional
+		// agreement claim, and the corpus had nothing like it: the five strict
+		// shapes never double-claim, and `member-claimed-by-two-zones` uses TWO
+		// BARE refs, so no fan-up is involved.
+		{"base-and-unit-claimed-by-different-zones", []string{
+			"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+			"set security zones security-zone aaa interfaces ge-0/0/1.0",
+			"set security zones security-zone zzz interfaces ge-0/0/1",
+		}, true},
+		// ...and its MIRROR, with the zone names swapped so the fan-up winner
+		// is also the bare ref's zone. This samples the BENIGN side of the same
+		// axis: no divergence. Both are here because a fixture that picked only
+		// this order would prove nothing — the ordering is what makes the shape
+		// falsifying, and a corpus sitting on the passing point of an axis it
+		// varies is the defect this issue is about.
+		{"base-and-unit-same-zone-wins-fanup", []string{
+			"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+			"set security zones security-zone zzz interfaces ge-0/0/1.0",
+			"set security zones security-zone aaa interfaces ge-0/0/1",
+		}, true},
 	}
 }
 
@@ -1419,6 +1446,12 @@ func zoneMapCorpus6722() []struct {
 // dropping CanonicalInterfaceUnitRef from authoredZoneRefs reds it on
 // `noncanonical-unit-ref` (authored keys `.01`, the zone map keys `.1`).
 func TestAuthoredAndDerivedZoneMapsAgreeOnEveryAuthoredRef_6722(t *testing.T) {
+	// #7024 ANTI-VACUITY. The narrowing below tolerates a base-reference
+	// divergence, which is only safe to tolerate if the corpus actually
+	// CONTAINS one — otherwise the loop degrades to the old unconditional
+	// claim and the tolerance is untested prose. The old corpus had no such
+	// shape, which is exactly how the guard passed while its claim was false.
+	sawExplainedBaseDivergence := false
 	for _, tc := range zoneMapCorpus6722() {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := compileWithStubbedLinks6722(t, tc.lines, map[string]int{}, map[string]string{}, tc.lenient)
@@ -1437,20 +1470,68 @@ func TestAuthoredAndDerivedZoneMapsAgreeOnEveryAuthoredRef_6722(t *testing.T) {
 			}
 			sort.Strings(refs)
 			for _, ref := range refs {
-				if got, want := derived[ref], authored[ref]; got != want {
-					t.Errorf("the two zone maps DISAGREE about the authored "+
-						"reference %q: authoredZoneRefs=%q buildInterfaceZoneMap=%q. "+
-						"Both read the same operator sentence, so a disagreement "+
-						"means one of them changed its write policy or its "+
-						"canonicalization alone. stampEgressZones resolves rule 2 "+
-						"from the first and the helper corroborates against rows "+
-						"stamped from the second, so this is a claim the helper "+
-						"will honour under a zone the operator never wrote for "+
-						"that identity.\n  authored=%v\n  derived =%v",
-						ref, want, got, authored, derived)
+				got, want := derived[ref], authored[ref]
+				if got == want {
+					continue
 				}
+				// #7024: a UNIT reference must ALWAYS agree. Both maps record a
+				// unit ref from the operator's literal sentence and neither
+				// synthesizes one, so a disagreement here really is one of them
+				// changing its write policy or canonicalization alone.
+				if strings.Contains(ref, ".") {
+					t.Errorf("the two zone maps DISAGREE about the authored UNIT "+
+						"reference %q: authoredZoneRefs=%q buildInterfaceZoneMap=%q. "+
+						"Neither map synthesizes a unit reference, so this is one of "+
+						"them changing its write policy or its canonicalization "+
+						"alone.\n  authored=%v\n  derived =%v",
+						ref, want, got, authored, derived)
+					continue
+				}
+				// A BASE reference MAY diverge, and #7024 is the record of why.
+				// buildInterfaceZoneMap fans a unit reference UP to its base;
+				// authoredZoneRefs deliberately does not, because it is
+				// PROVENANCE — what the operator literally wrote. When a bare
+				// ref in one zone and a dotted ref from an alphabetically
+				// earlier zone name the same interface, the derived map answers
+				// with the fan-up winner and the authored map answers with the
+				// bare sentence. Both are correct for their own consumer.
+				//
+				// What must hold is that the divergence is EXPLAINED by the
+				// fan-up rather than arbitrary: the derived value has to be the
+				// zone of some authored UNIT under this base. A derived value
+				// from nowhere would mean the fan-up itself had changed.
+				explained := false
+				for other, otherZone := range authored {
+					if other == ref || !strings.HasPrefix(other, ref+".") {
+						continue
+					}
+					if otherZone == got {
+						explained = true
+						break
+					}
+				}
+				if !explained {
+					t.Errorf("the two zone maps disagree about the authored BASE "+
+						"reference %q (authoredZoneRefs=%q buildInterfaceZoneMap=%q) "+
+						"and the derived value is NOT the zone of any authored unit "+
+						"under it, so the fan-up does not explain it. A base "+
+						"divergence is tolerated ONLY as the fan-up of a unit "+
+						"reference (#7024); this one came from somewhere else.\n"+
+						"  authored=%v\n  derived =%v",
+						ref, want, got, authored, derived)
+					continue
+				}
+				sawExplainedBaseDivergence = true
 			}
 		})
+	}
+	if !sawExplainedBaseDivergence {
+		t.Fatalf("no corpus shape produced a base-reference divergence, so the #7024 " +
+			"tolerance above was never exercised and this guard has silently " +
+			"reverted to the unconditional agreement claim it replaced. Restore " +
+			"`base-and-unit-claimed-by-different-zones` (a BARE ref in one zone and " +
+			"a DOTTED ref from an alphabetically EARLIER zone naming one interface) " +
+			"— note the zone ORDER is what makes it falsifying")
 	}
 }
 
@@ -1882,4 +1963,60 @@ func TestBarePortOfADifferentRethDoesNotDeferToThisOne_6722(t *testing.T) {
 			"reth whose unit it aliases, the two cohere, and the authored zone "+
 			"resolves; if this control also answers \"\" then the cell above is "+
 			"measuring the aliasing, not the redundant-parent match")
+}
+
+
+// #7024: the OUTCOME half. A base/unit divergence must resolve FAIL-CLOSED.
+//
+// Cell P now TOLERATES a base-reference divergence, which is only defensible if
+// the divergence cannot produce a wrong answer. This is the cell that shows it
+// cannot: the ifindex resolves to no zone at all, so nothing forwards under a
+// zone the operator did not write for it.
+//
+// Tolerating a divergence without pinning its outcome would be the same defect
+// this issue is about, moved one step: a claim that reads as safe with nothing
+// asserting the safety.
+//
+// Strict rejects the doubly-claimed interface, so — like cells O, P's sixth
+// shape and Q — the surface this defends is the tolerant load / HA peer-sync
+// path (#1960 no-brick).
+func TestBaseAndUnitClaimedByDifferentZonesFailsClosed_7024(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+		"set security zones security-zone aaa interfaces ge-0/0/1.0",
+		"set security zones security-zone zzz interfaces ge-0/0/1",
+	}
+	links := map[string]int{"ge-0-0-1": 24}
+	macs := map[string]string{"ge-0-0-1": "02:bf:72:01:00:01"}
+
+	// Pinned rather than assumed, mirroring cell Q: if strict ever admitted
+	// this, "reachable only leniently" would be false and a reader would be
+	// misled about which surface this defends.
+	if _, err := config.CompileConfig(treeFromSet6722(t, lines)); err == nil {
+		t.Fatalf("precondition: strict CompileConfig ADMITTED an interface whose " +
+			"base and unit are claimed by different zones; this cell claims the " +
+			"shape reaches the builder only on the tolerant path")
+	}
+
+	cfg := compileWithStubbedLinks6722(t, lines, links, macs, true)
+
+	// The divergence itself, pinned here too so this cell fails for its OWN
+	// reason if the maps are ever made to agree — rather than quietly becoming
+	// a test of a shape that no longer exists.
+	authored, derived := authoredZoneRefs(cfg), buildInterfaceZoneMap(cfg)
+	if authored["ge-0/0/1"] != "zzz" || derived["ge-0/0/1"] != "aaa" {
+		t.Fatalf("precondition: authored[ge-0/0/1]=%q derived[ge-0/0/1]=%q, want "+
+			"\"zzz\" and \"aaa\" — the fan-up winner must differ from the bare "+
+			"sentence, or there is no divergence here to fail closed on",
+			authored["ge-0/0/1"], derived["ge-0/0/1"])
+	}
+
+	snaps := buildInterfaceSnapshots(cfg)
+	assertEgressZone6722(t, snaps, 24, "",
+		"the operator's sentences put `aaa` on ge-0/0/1.0 and `zzz` on ge-0/0/1, "+
+			"and both land on one netdev, so it identifies no single egress zone. "+
+			"Answering either one adjudicates transit under a zone the operator "+
+			"did not write for that identity — and cell P now TOLERATES this "+
+			"divergence, so if the outcome stops being fail-closed the tolerance "+
+			"becomes a hole rather than a documented limit (#7024)")
 }


### PR DESCRIPTION
Closes #7024

## Confirmed at current master first

The issue measured at `413c6818c`. Reproduced at **`db1b009be`**, byte-identical:

```
authored = map[ge-0/0/1:zzz ge-0/0/1.0:aaa]
derived  = map[ge-0/0/1:aaa ge-0/0/1.0:aaa]
DIVERGE ref="ge-0/0/1" authored="zzz" derived="aaa"
```

**And the reversed-alphabet control:** with `zzz` on the dotted ref and `aaa` on the bare, the maps **do not diverge at all**. The ordering is what makes the shape falsifying — `buildInterfaceZoneMap` fans up first-write-wins over *sorted* zone names, so `aaa` beats `zzz`. A fixture picking the other order sits on the benign side of the axis and proves nothing. Both orders are now in the corpus for exactly that reason.

## Why the corpus could not reach it

The five strict shapes never double-claim, and `member-claimed-by-two-zones` uses **two BARE refs** — so no fan-up is involved. The falsifying shape needs a bare ref in one zone **and** a dotted ref from a *different* zone on one interface. Adding that shape alone turns the old guard RED.

## Which option, and why

**(a) — narrow the claim.** The two maps *should* differ here:

- `authoredZoneRefs` is **provenance**: what the operator literally wrote.
- `buildInterfaceZoneMap` derives per-row **ingress attribution**, fanning a unit ref up to its base.

Making them literally agree would mean either fanning up in the authored map — which **discards the operator's bare sentence**, destroying the provenance it exists to preserve — or making the derived map stop fanning up, which breaks the attribution it exists to derive. Option (b) from the issue (record the fan-up as distinct non-authoritative provenance) is a larger change to rule 2's inputs and buys **no correctness**, because the divergence already resolves fail-closed. What was wrong was the sentence, not the code.

## What is asserted now

- A **UNIT** reference must always agree — neither map synthesizes one.
- A **BASE** reference may diverge **only** when the derived value is the zone of some authored unit under that base, i.e. the fan-up *explains* it. A derived value from nowhere would mean the fan-up itself changed, and is still a failure.
- The **outcome** is fail-closed: `TestBaseAndUnitClaimedByDifferentZonesFailsClosed_7024` drives the real snapshot and asserts `EgressZone == ""`. Tolerating a divergence without asserting its safety would be this same defect moved one step. That cell also pins the divergence itself, so it fails for its own reason if the maps are ever made to agree, rather than quietly becoming a test of a shape that no longer exists.

## Two anti-vacuity measures

A tolerance is precisely the thing that rots into a hole:

1. **Both orders in the corpus** — the falsifying shape and its benign mirror.
2. **The guard fails if no shape produced a base divergence.** Without that, deleting the new shape would silently return the loop to the unconditional claim it replaced — which is how this defect arose in the first place. Cell **M1** is that check working.

## Lenient-only, pinned not asserted

Both new shapes are reachable only on the tolerant load / HA peer-sync path (#1960): strict `CompileConfig` rejects the doubly-claimed interface with a multi-zone error. The outcome cell **pins** that with a precondition rather than claiming it in prose, mirroring cell Q — a fixture built on the strict path would fail for the wrong reason and be testing the rejection, not the divergence.

## Doc

`docs/userspace-dataplane-architecture.md` recorded "the two zone maps must not disagree", and specifically that they "pick a winner the same way". **That sentence was false.** It is replaced with the measured counterexample, why making them agree is the wrong fix, and the fail-closed property that holds instead.

## Validation

`go test -count=1 ./...`: rc=0, **68 packages ok**, 0 FAIL. [Mutation matrix](https://github.com/psaab/xpf/pull/7866#issuecomment-5458804877) — every cell full-suite over the package, never under a `-run <issue>` filter, each anchor refused unless it matched exactly once.

**Read the matrix before merging: it reports two ESCAPES.** The narrowed guard's two arms — unit-refs-must-agree and the fan-up explanation — are *structurally unbindable*: no config can violate either, so no mutation can red them. They stay as statements of the invariant, but they are not tested properties and this PR does not claim they are. What carries the fix is the corpus shape plus the anti-vacuity backstop (cells M1/M2, which fire the backstop **by name**) and the fail-closed outcome (M7).

Re-verified at current master `7451cafaa` after #7863/#7864/#7865 merged — the counterexample still reproduces byte-identically. Branch merged up to it, no conflicts.

Refs #6722, #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqdwwcwWUo7FyCQSCSUh9t
