### PR TITLE
userspace: bind the Go/Rust agreement on the egress-zone wire key

### DIFF
--- a/docs/log/7037.md
+++ b/docs/log/7037.md
@@ -1,0 +1,50 @@
+# docs/log/7037.md — #7037 (egress-zone protocol binding)
+
+- **Timestamp**: 2026-08-28
+- **Action**: Bind the Go/Rust agreement on the `egress_zone` wire key after
+  measuring that #7037's stated premise no longer holds.
+- **File(s)**:
+  - `pkg/dataplane/userspace/egress_zone_wire_key_lockstep_7037_test.go` (new)
+  - `docs/userspace-dataplane-architecture.md`
+
+## The premise was stale, and the proposed fix was already forbidden
+
+#7037 says reverting `ProtocolVersion` leaves the whole suite green. Measured at
+head: it reds **three** tests — `TestMixedVersionMatrix_6691`,
+`TestSnapshotProtocolVersionLockstepWithRust`,
+`TestSecureTunnelFieldIsNotIgnorableByAPreV5Helper`. #6691's pins landed after
+the issue was written.
+
+So the issue's own fix shape would have been a fourth copy of the same literal.
+The other obvious move — a per-feature `MinProtocolEgressZone` floor — is ruled
+out explicitly by `protocol.go`: the acceptance question is answered in exactly
+one place and a second gate is the divergent copy #6649 forbids.
+
+## A void cell, caught before it became a false report
+
+The first wire-key mutation used `json:"egress_zone,omitempty"` as its anchor.
+The real tag has no `,omitempty`, so the `sed` matched nothing and the suite went
+green on an unmodified tree. That green read exactly like "the wire key is
+unbound" and was one step from being written up as a serious defect.
+
+The tell was in the output already: the post-mutation grep printed only comment
+lines and never the struct-tag line. Every mutation in the matrix below asserts
+`count == 1` before writing, and aborts otherwise.
+
+## What was actually unbound
+
+Nothing asserted the two planes AGREE on the key. Go pins `egress_zone` against
+the emitted blob (#6722); Rust states its own `rename`. A Rust-side rename, or
+dropping the attribute, was invisible to the Go suite — and `#[serde(default)]`
+makes that failure silent rather than loud.
+
+## Matrix (full package, no `-run` filter, 0 build errors in every cell)
+
+| cell | mutation | reds |
+|---|---|---|
+| M0 | control | — (green) |
+| M1 | Go `json:` tag renamed | `...CrossesTheWireAndTheQuarantine_6722` **and** the new guard |
+| M2 | Rust `serde(rename)` renamed | the new guard **only** |
+| M3 | Rust `rename` attribute dropped | the new guard **only** |
+
+M2 and M3 are the hole: before this change neither reddened anything.

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1106,6 +1106,31 @@ Scope of the fallback:
   ifindex egresses into, and ships it as `InterfaceSnapshot.egress_zone`.
   `populate_interfaces` reads it and adjudicates nothing.
 
+  **The wire KEY is bound by an agreement test, not by a literal on one side
+  (#7037).** Both planes spell `egress_zone` independently — Go's `json:` tag on
+  `InterfaceSnapshot.EgressZone`, Rust's `#[serde(rename = "egress_zone",
+  default)]` in `protocol/snapshot.rs` — and the Rust `default` is what makes a
+  disagreement SILENT: an absent key does not fail to decode, it fills the empty
+  String. A one-sided rename would ship a snapshot in which every interface
+  resolves egress zone `""`, while both planes still agree the version is 8, so
+  no version gate fires. `TestEgressZoneWireKeyLockstepWithRust_7037` parses
+  `snapshot.rs` and compares it to the Go tag read by REFLECTION, asserting the
+  two AGREE rather than pinning either to a literal — pinning one side encodes
+  which side you trust. A consistent rename of BOTH sides passes there and is
+  caught instead by `TestEgressZoneCrossesTheWireAndTheQuarantine_6722`, which
+  pins the Go literal against the emitted blob. Measured: a Rust-side rename, or
+  dropping the `rename` attribute altogether, reds the lockstep test and
+  **nothing else** in the Go suite.
+
+  Note what this is NOT. #7037 was filed against the version NUMBER; that premise
+  is stale — reverting `ProtocolVersion` at head reds three tests, because
+  #6691's pins landed after the issue was written. A fourth equality pin would be
+  another copy of the same literal, and a per-feature `MinProtocolEgressZone`
+  floor is ruled out by the decision recorded above in `protocol.go`: the
+  acceptance question is answered in exactly ONE place
+  (`ensureEgressZoneProtocolLocked`), and a second gate would be the divergent
+  copy #6649 forbids.
+
   **Why the decision had to move.** Rounds 4 through 9 built the answer in Rust
   by polling the rows — "do all rows on this ifindex agree?" — and exempting the
   rows whose agreement or dissent was an artefact rather than an observation.

--- a/pkg/dataplane/userspace/egress_zone_wire_key_lockstep_7037_test.go
+++ b/pkg/dataplane/userspace/egress_zone_wire_key_lockstep_7037_test.go
@@ -1,0 +1,130 @@
+package userspace
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestEgressZoneWireKeyLockstepWithRust_7037 asserts the Go emitter and the Rust
+// consumer AGREE on the wire spelling of the #6722 egress-zone field.
+//
+// #7037 was filed against the version NUMBER, on the finding that reverting
+// ProtocolVersion left the suite green. That premise is no longer true — at
+// current master the revert reds three tests (TestMixedVersionMatrix_6691,
+// TestSnapshotProtocolVersionLockstepWithRust,
+// TestSecureTunnelFieldIsNotIgnorableByAPreV5Helper), because #6691's pins
+// landed after the issue was written. Adding the equality pin the issue asks
+// for would be a third copy of the same literal, and adding a per-feature floor
+// is ruled out by an explicit decision recorded in protocol.go: the acceptance
+// question is answered in EXACTLY ONE place (ensureEgressZoneProtocolLocked's
+// unconditional equality check), and a second gate would be the divergent copy
+// #6649 forbids.
+//
+// What the version pins do NOT cover is the wire KEY they exist to protect.
+// Both sides spell it independently:
+//
+//	Go    InterfaceSnapshot.EgressZone `json:"egress_zone"`
+//	Rust  #[serde(rename = "egress_zone", default)] pub egress_zone: String
+//
+// and `default` on the Rust side is what makes a disagreement SILENT rather
+// than loud: an absent key does not fail to decode, it fills the empty String.
+// So a one-sided rename ships a snapshot in which every interface resolves
+// egress zone "" while both planes still agree the version is 8 — the same
+// silent-transit outcome #7037 names, reached by a route its proposed fix does
+// not touch.
+//
+// This guard reads the Go side by REFLECTION rather than restating the literal.
+// Pinning one side to a literal encodes which side you trust; the property is
+// that the two AGREE. A consistent rename of BOTH sides passes here and is
+// correct — and is separately caught by
+// TestEgressZoneCrossesTheWireAndTheQuarantine_6722, which pins the Go literal
+// against the emitted blob. The two together are what bind the key: this test
+// says "the planes match", that one says "the match is the value we shipped".
+//
+// Parsed rather than mirrored, for the reason
+// TestSnapshotProtocolVersionLockstepWithRust parses control.rs for the version:
+// a constant restated in a comment is a copy that goes stale silently.
+func TestEgressZoneWireKeyLockstepWithRust_7037(t *testing.T) {
+	goKey := jsonKeyOf(t, reflect.TypeOf(InterfaceSnapshot{}), "EgressZone")
+
+	// Test cwd is pkg/dataplane/userspace.
+	path := filepath.Join("..", "..", "..", "userspace-dp", "src", "protocol", "snapshot.rs")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (the egress-zone wire-key lockstep guard cannot run)", path, err)
+	}
+
+	body := rustStructBody(t, string(src), "InterfaceSnapshot")
+	rustKey := rustSerdeRenameOf(t, body, "egress_zone")
+
+	if goKey != rustKey {
+		t.Fatalf("egress-zone wire key skew: Go InterfaceSnapshot.EgressZone emits %q, Rust "+
+			"InterfaceSnapshot reads %q. The Rust field carries #[serde(default)], so a "+
+			"disagreement does NOT fail to decode — the key is simply absent and serde fills "+
+			"the empty String. Every interface then resolves egress zone \"\" while both "+
+			"planes still agree ProtocolVersion is %d, so no version gate fires and transit "+
+			"fails closed silently. Rename BOTH sides or neither.",
+			goKey, rustKey, ProtocolVersion)
+	}
+}
+
+// jsonKeyOf returns the wire name a Go field serialises under, read off the
+// struct rather than restated, so this guard cannot drift from the type it
+// describes.
+func jsonKeyOf(t *testing.T, typ reflect.Type, field string) string {
+	t.Helper()
+	f, ok := typ.FieldByName(field)
+	if !ok {
+		t.Fatalf("%s has no field %q — if it was renamed, update this guard rather than "+
+			"deleting it; the wire key it binds is still on the wire", typ.Name(), field)
+	}
+	tag := f.Tag.Get("json")
+	if tag == "" {
+		t.Fatalf("%s.%s carries no json tag, so it serialises under its GO name. That is a "+
+			"wire change on its own", typ.Name(), field)
+	}
+	return strings.Split(tag, ",")[0]
+}
+
+// rustStructBody returns the body of a named Rust struct: from its declaration
+// to the first closing brace in column 0. Scoping matters — `egress_zone` also
+// appears in control.rs and binding.rs on different structs, and a file-wide
+// regex would bind whichever happened to come first.
+func rustStructBody(t *testing.T, src, name string) string {
+	t.Helper()
+	decl := regexp.MustCompile(`(?m)^(?:pub|pub\(crate\)) struct ` + regexp.QuoteMeta(name) + `\s*\{`)
+	loc := decl.FindStringIndex(src)
+	if loc == nil {
+		t.Fatalf("Rust struct %q not found — if it was renamed or moved, update this guard "+
+			"rather than deleting it", name)
+	}
+	rest := src[loc[1]:]
+	end := regexp.MustCompile(`(?m)^\}`).FindStringIndex(rest)
+	if end == nil {
+		t.Fatalf("Rust struct %q has no closing brace in column 0; the parse cannot be "+
+			"scoped and a file-wide match would bind the wrong struct", name)
+	}
+	return rest[:end[0]]
+}
+
+// rustSerdeRenameOf returns the serde wire name of a Rust field. It requires the
+// rename attribute: relying on serde's default (the field's own identifier)
+// would make this guard pass on a struct that had lost the attribute entirely,
+// which is one of the two ways the spellings can drift apart.
+func rustSerdeRenameOf(t *testing.T, structBody, field string) string {
+	t.Helper()
+	re := regexp.MustCompile(`#\[serde\(rename = "([^"]+)"[^\]]*\)\]\s*pub ` +
+		regexp.QuoteMeta(field) + `\s*:`)
+	m := re.FindStringSubmatch(structBody)
+	if m == nil {
+		t.Fatalf("no #[serde(rename = ...)] found on Rust field %q. Either the field is gone "+
+			"— in which case the Go emitter is writing a key nothing reads — or it now relies "+
+			"on serde's default naming, which this guard deliberately does not accept: the "+
+			"whole point is that the wire spelling is stated on both sides", field)
+	}
+	return m[1]
+}


### PR DESCRIPTION
Closes #7037

## The premise is stale, and the fix it asks for is already forbidden

#7037 reports that reverting `ProtocolVersion` leaves the whole suite green.
**Measured at head, it reds three tests** — `TestMixedVersionMatrix_6691`,
`TestSnapshotProtocolVersionLockstepWithRust`,
`TestSecureTunnelFieldIsNotIgnorableByAPreV5Helper` — because #6691's pins landed
*after* the issue was written.

So the equality pin the issue asks for would be a fourth copy of the same
literal. And the other obvious move, a per-feature `MinProtocolEgressZone` floor,
is ruled out by an explicit decision recorded in `protocol.go`: the acceptance
question is answered in **exactly one place** (`ensureEgressZoneProtocolLocked`'s
unconditional equality check), and a second gate would be the divergent copy
#6649 forbids.

Closing the issue on that alone would have been wrong, because there is a real
hole next to the one it describes.

## What is actually unbound: the wire KEY the version exists to protect

Both planes spell it independently:

```
Go    InterfaceSnapshot.EgressZone `json:"egress_zone"`
Rust  #[serde(rename = "egress_zone", default)]  (protocol/snapshot.rs)
```

The Rust `default` is what makes a disagreement **silent** rather than loud: an
absent key does not fail to decode, it fills the empty String. A one-sided rename
ships a snapshot in which every interface resolves egress zone `""` while both
planes still agree the version is 8 — so no version gate fires. That is exactly
the silent-transit outcome #7037 names, reached by a route its proposed fix does
not touch.

The guard reads the **Go side by reflection** rather than restating the literal.
Pinning one side to a literal encodes which side you trust; the property is that
the two AGREE. A consistent rename of both sides passes here and is caught
instead by `TestEgressZoneCrossesTheWireAndTheQuarantine_6722`, which pins the Go
literal against the emitted blob. The two together bind the key.

Two parse details that are deliberate: the Rust match is scoped to the
`InterfaceSnapshot` struct body (`egress_zone` also appears in `control.rs` and
`binding.rs` on different structs, and a file-wide regex would bind whichever
came first), and a missing `rename` attribute is **rejected** rather than falling
back to serde's default naming — a guard that accepted the default would pass on
a struct that had lost the attribute entirely, which is one of the two ways the
spellings drift apart.

## Mutation matrix

Full package, no `-run` filter, **0 build errors in every cell**.

| cell | mutation | reds |
|---|---|---|
| M0 | control | — (green) |
| M1 | Go `json:` tag renamed | `...CrossesTheWireAndTheQuarantine_6722` **and** the new guard |
| M2 | Rust `serde(rename)` renamed | the new guard **only** |
| M3 | Rust `rename` attribute dropped | the new guard **only** |

**M2 and M3 are the hole.** Before this change neither reddened anything in the
Go suite.

## A void cell, caught before it became a false report

The first wire-key mutation anchored on `json:"egress_zone,omitempty"`. The real
tag has no `,omitempty`, so the edit applied to nothing and the suite went green
against an unmodified tree — a green that read exactly like "the wire key is
unbound", and was one step from being written up as a serious defect.

The tell was already in the output: the post-mutation grep printed only comment
lines and never the struct-tag line. Every cell above asserts its anchor matches
**exactly once** before writing, and aborts otherwise. Recorded in
`docs/log/7037.md` rather than quietly dropped, because the failure mode is the
interesting part.

## Docs

`docs/userspace-dataplane-architecture.md` gains the wire-key section, including
what this is **not** — so the next reader does not re-file the version pin.

## Validation

- Matrix above.
- `gofmt` clean.
- Repo-wide `go test ./... -count=1` gating below.