### PR TITLE
docs: the zone-counter slot map creates blocks per SLOT-ASSIGNED zone

### DIFF
--- a/docs/log/7040.md
+++ b/docs/log/7040.md
@@ -1,0 +1,25 @@
+# docs/log/7040.md — #7040 (zone-counter slot map doc claim)
+
+- **Timestamp**: 2026-08-28
+- **Action**: Correct the Rejected-build safety (#5716) block: the slot map
+  get-or-creates a block per SLOT-ASSIGNED zone, not per configured zone.
+- **File(s)**: `docs/userspace-dataplane-gaps.md`
+
+## Why doc-only, stated per the CLAUDE.md contract
+
+No code change is needed and none was made. The behaviour is correct and already
+bound: `ZoneCounterSlotMap::build` filters zone 0 and `break`s once
+`ZONE_COUNTER_ASSIGNABLE_SLOTS` are taken, and the capacity stop plus
+`overflow_active` are asserted in `afxdp/flood_counters.rs`. Three code comments
+introduced by #6832 already carry the correct qualifier; only the doc was left
+behind by that PR.
+
+## One precision the issue did not make
+
+Correcting "per configured zone" to "per slot-assigned zone" bounds the
+get-or-create **per apply** by the slot capacity. It does NOT bound it across
+applies: the store is zone-id keyed, so successive rejected commits naming
+different candidate-only zone ids each add up to that many blocks. The
+accumulation the original paragraph warns about therefore stands — only its
+per-commit magnitude was overstated. Writing the correction without that
+sentence would have traded an overstatement for an understatement.

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -630,7 +630,8 @@ zone with no traffic / no flood events alike.
   carry-forward `clone()` in
   `build_forwarding_state_with_policy_counters_and_previous` is a handle on the
   LIVE map, not a copy. Binding a candidate to it mutates it **two** ways:
-  `ZoneCounterSlotMap::build` GET-OR-CREATES a block per configured zone, and
+  `ZoneCounterSlotMap::build` GET-OR-CREATES a block per SLOT-ASSIGNED zone —
+  a SUBSET of the configured set, not one per configured zone (#7040) — and
   `reconcile` DROPS the blocks for zones the candidate no longer configures. A
   snapshot the reconcile/refresh preflight REJECTS ("keeping previous forwarding
   state") must do neither — the prune would zero an operator's
@@ -638,6 +639,27 @@ zone with no traffic / no flood events alike.
   get-or-create would leave a zero-valued block behind for a candidate-only
   zone (invisible to the sparse status snapshot, but accumulating one block per
   rejected commit under ordinary config churn).
+
+  The SUBSET qualifier is load-bearing and was corrected in three code sites by
+  the same PR that introduced this block (#6832), which left the doc behind.
+  `build` filters zone id 0 out of its input and `break`s once
+  `ZONE_COUNTER_ASSIGNABLE_SLOTS` are taken, setting `overflow_active`; every
+  configured zone past that point is assigned no slot and therefore gets no
+  block. So the get-or-create half of the mutation is bounded PER APPLY by the
+  slot capacity rather than by the size of the candidate's zone set. It is not
+  bounded ACROSS applies — successive rejected commits naming different
+  candidate-only zone ids each add up to that many blocks to the zone-id-keyed
+  store — so the accumulation described above stands; only its per-commit
+  magnitude was overstated.
+
+  Code of record: `ZoneCounterSlotMap::build`
+  (`userspace-dp/src/afxdp/zone_counters.rs`), whose own doc comment states the
+  same qualifier, as do `attach_zone_counters`
+  (`afxdp/forwarding_build/mod.rs`) and `afxdp/coordinator/reconcile/snapshot.rs`.
+  The capacity stop and the `overflow_active` flag are already bound by tests in
+  `afxdp/flood_counters.rs` (`flood_and_traffic_slot_maps_cover_the_same_zones`
+  and the overflow assertions around it), so this correction needs no new test —
+  the code fact was never in doubt, only its restatement here.
 
   Both mutations therefore live in `attach_zone_counters`, which the public
   entry point calls **after** the fallible `build_fallible_forwarding_state`


### PR DESCRIPTION
Closes #7040

`docs/userspace-dataplane-gaps.md`'s **Rejected-build safety (#5716)** block said
`ZoneCounterSlotMap::build` "GET-OR-CREATES a block per configured zone". It does
not: `build()` filters zone id 0 out of its input and `break`s once
`ZONE_COUNTER_ASSIGNABLE_SLOTS` are taken, setting `overflow_active`. Every
configured zone past that point is assigned no slot and gets no block.

PR #6832 introduced this doc block **and** corrected the identical phrasing in
three code sites in the same change — `zone_counters.rs`,
`forwarding_build/mod.rs` (`attach_zone_counters` and its wrapper) and
`coordinator/reconcile/snapshot.rs` all say "SLOT-ASSIGNED … a SUBSET of the
configured set" — while leaving the doc behind.

## One precision the issue does not make

Correcting "per configured zone" to "per slot-assigned zone" bounds the
get-or-create **per apply** by the slot capacity. It does **not** bound it across
applies: the store is zone-id keyed, so successive rejected commits naming
different candidate-only zone ids each add up to that many blocks.

So the accumulation the original paragraph warns about **stands** — only its
per-commit magnitude was overstated. Writing the correction without that sentence
would have traded an overstatement for an understatement, which on a safety
argument is the worse direction.

## Why doc-only, stated per the CLAUDE.md review-notes contract

No code change and no new test. The behaviour is correct and already bound: the
capacity stop and `overflow_active` are asserted in `afxdp/flood_counters.rs`
(`flood_and_traffic_slot_maps_cover_the_same_zones` and the overflow assertions
around it). I checked for an existing doc-claim guard over this file before
adding one — `forwarding_build/tests.rs` only *references* the gaps doc in a
comment, it does not parse it — and concluded a prose-scanning guard is the wrong
instrument here: a grep for the qualifier is satisfied by a negated sentence
containing it. The property is bound where it belongs, in the code's own tests.

The doc now also cites those code sites and that test, so the next reader can
reach the fact rather than the restatement.