### PR TITLE
docs: the rejected-build belt set is a three-way split, not a partition

### DIFF
--- a/docs/log/7042.md
+++ b/docs/log/7042.md
@@ -1,0 +1,26 @@
+# docs/log/7042.md — #7042 (rejected-build belt enumeration)
+
+- **Timestamp**: 2026-08-28
+- **Action**: Replace the stale two-way partition of the rejection-belt set with
+  the three-way split that has been true since #6832 round 7.
+- **File(s)**: `docs/userspace-dataplane-gaps.md`
+
+## Why doc-only, per the CLAUDE.md review-notes contract
+
+No code change and no new test. The fifth row exists, is asserted, and carries
+its own explanation in `policy_parse_interior_rejection_row`
+(`userspace-dp/src/afxdp/forwarding_build/tests.rs`). The doc was simply not
+updated with it. Every claim in the new table was read out of that function and
+`zone_counter_rejection_rows`, not copied from the issue.
+
+## The correction is a partition change, not an added row
+
+The old sentence ("the dup-zone belt sits above both parses and leaves neither,
+the other three sit below and leave both") is not merely missing an entry — it
+asserts a TWO-way split of a set that now has three positions. Adding `#3402` to
+the "other three" would have kept the sentence wrong, because that row's residue
+pair is `present/absent` and the sentence's second half says `both`.
+
+The middle row is also the reason the fold was accepted: over the other four the
+two residue predicates collapse to one expression, so the set could not
+distinguish the policy-parse position from the NAT-parse position at all.

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -757,8 +757,35 @@ zone with no traffic / no flood events alike.
   It now seeds the policy store through the production path (a clean build,
   which get-or-creates the reserved default-policy counter), carries a
   candidate-only `probe-rule` so the residue is distinguishable from the seed,
-  and asserts both halves belt-by-belt — the dup-zone belt sits above both
-  parses and leaves neither, the other three sit below and leave both.
+  and asserts both halves belt-by-belt. The enumeration is by POSITION relative
+  to the two counter-binding call sites — the policy parse
+  (`parse_policy_state_with_counters`) and the source-NAT parse
+  (`parse_source_nat_rules_with_previous`, about sixty lines below it) — and
+  since #6832 round 7 it is a THREE-way split, not two (#7042):
+
+  | belt | position | policy residue | NAT residue |
+  |---|---|---|---|
+  | `#3719` duplicate zone id | above both parses | absent | absent |
+  | `#3402` unresolvable policy zone | **between** them | **present** | **absent** |
+  | `#2240` NPTv6 | below both | present | present |
+  | `#3367` filter | below both | present | present |
+  | `#2410` CoS queue id | below both | present | present |
+
+  The middle row is the point of the set, not an extra. Over the other four the
+  two residue predicates are the SAME expression — every one of them sits either
+  above both parses or below both — so the table could not tell them apart, and
+  that was true only by coincidence of the current builder layout. A belt landing
+  anywhere in the region BETWEEN the two parses makes one of the two assertions
+  wrong, and none of the four could detect it.
+
+  `#3402`'s `UnresolvableZoneReference` rejects INSIDE the policy parse's rule
+  loop — downstream of the per-rule `rule_hit_counter` that resolves the probe
+  rule's counter, upstream of the source-NAT parse — so it occupies that region
+  and the two predicates can no longer be written as one expression without a row
+  contradicting them. It lives in `policy_parse_interior_rejection_row` and is
+  deliberately NOT folded into `zone_counter_rejection_rows`, whose four rows are
+  chosen by a different argument (span over the fallible region) that this row
+  would blur.
 
 - **POPULATE flood (#3651) now ships too.** Per-zone SYN/ICMP/UDP flood-event
   attribution is NEW drop-path accounting, not a snapshot of existing state: the


### PR DESCRIPTION
Closes #7042

`docs/userspace-dataplane-gaps.md`'s **Rejected-build safety (#5716)** block
described the zone-store rejection rows as a clean two-way partition:

> …the dup-zone belt sits above both parses and leaves neither, **the other three
> sit below and leave both**.

PR #6832's round-7 fold added a **fifth** row — `policy_parse_interior_rejection_row`,
`#3402 UnresolvableZoneReference` — which rejects *inside* the policy parse's rule
loop, downstream of the per-rule `rule_hit_counter` and upstream of the source-NAT
parse. Its residue pair is policy **present** / NAT **absent**, so it fits neither
half. `grep -n 3402 docs/userspace-dataplane-gaps.md` had no match.

## This is a partition change, not a missing entry

Appending `#3402` to "the other three" would have left the sentence **wrong**,
because that half asserts "leave both". The set now has three positions, so the
doc carries a table:

| belt | position | policy residue | NAT residue |
|---|---|---|---|
| `#3719` duplicate zone id | above both parses | absent | absent |
| `#3402` unresolvable policy zone | **between** them | **present** | **absent** |
| `#2240` NPTv6 | below both | present | present |
| `#3367` filter | below both | present | present |
| `#2410` CoS queue id | below both | present | present |

## Why the middle row is the point, not an extra

Over the other four the two residue predicates are the **same expression** —
every one sits either above both parses or below both — so the table could not
distinguish the policy-parse position from the NAT-parse position at all. That
held only by coincidence of the current builder layout: a belt landing between
the two parses makes one of the two assertions wrong, and none of the four could
detect it. The doc now says this, because it is the reason the fold was accepted.

## Why doc-only, per the CLAUDE.md review-notes contract

No code change and no new test. The row exists, is asserted, and carries its own
explanation in `policy_parse_interior_rejection_row`
(`userspace-dp/src/afxdp/forwarding_build/tests.rs`) — which states the quadrant
in those words. **Every claim in the table was read out of that function and
`zone_counter_rejection_rows`, not copied from the issue**, so the doc is
re-derived from the code rather than from a second-hand description of it.