### PR TITLE
docs(api): unbound the drain gloss and scope close_notify to the HTTPS leg

### DIFF
--- a/docs/log/7047.md
+++ b/docs/log/7047.md
@@ -1,0 +1,43 @@
+# docs/log/7047.md — #7047 (api drain prose)
+
+- **Timestamp**: 2026-08-28
+- **Action**: Remove the surviving finite `legDrainTimeout` gloss and correct
+  `serveBound`'s doc, which attached the HTTPS close_notify deadline to both
+  servers.
+- **File(s)**: `pkg/api/README.md`, `pkg/api/server.go`
+
+## Two details of the issue were stale; both checked rather than assumed
+
+The issue's sweep predicate `grep -rn "up to .legDrainTimeout"` over `pkg/api/`
+and `pkg/daemon/` returned **two** hits at head `5deefb242`. At current master it
+returns **one** — `pkg/api/README.md`. It now returns zero.
+
+The issue also says the `serveBound` slip has a "README mirror". There is no
+mirror at current master: `grep -n "in each phase of each server"` over
+`pkg/api/README.md` has no match. Only the `server.go` doc needed the fix.
+
+The `listener.go:78` occurrence is deliberately left alone — it is the one the
+issue notes self-corrects six lines later, at `:85` ("no wall-clock bound either
+(legDrainTimeout is a poll deadline, not a ...)"), and it does not match the
+sweep predicate anyway (no backtick).
+
+## The scoping claim, verified in code rather than taken from the issue
+
+- `s.httpServer.Serve(httpLn)` — `server.go:1204`, plain `Serve`. Connections are
+  `*net.TCPConn`; `Close` sends no TLS alert, so no `close_notify` write deadline.
+- `s.httpsServer.ServeTLS(httpsLn, "", "")` — `server.go:1217`. Connections are
+  `*tls.Conn`; `Close` sends `close_notify` under its own five-second write
+  deadline (`crypto/tls` `conn.go closeNotify`).
+
+So "in each phase of each server" over-scoped by a factor of two. The HTTP leg is
+still unbounded — serial closes, no ceiling — but not by *that* five seconds, and
+saying so was claiming a bound the code does not have on that leg.
+
+## Phase 2 is not "in front of" a deadline
+
+`serveBound`'s doc said "both phases put serial per-connection closes in front of
+it", where "it" is `legDrainTimeout`. That is coherent for phase 1 only.
+`http.Server.Close` takes no context at all, so phase 2's serial closes sit ahead
+of *nothing*. `legDrainTimeout`'s own comment already separates the two phases
+("INSIDE Shutdown" / "AFTER it"); the summary had collapsed them, and now points
+at that comment as the authority instead of paraphrasing it.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1577,9 +1577,11 @@ the drop fails loudly instead of going quietly vacuous.
       drain arms (requested retirement AND root-context shutdown), before
       the drain, so it covers the leg from the moment the drain is decided
       through the goroutine's return (the listener closes an instant later, in
-      `Shutdown`, and already-accepted requests drain for up to `legDrainTimeout`
-      — `serving()` answers "is this the leg in front of clients", not "is every
-      byte done").
+      `Shutdown`, and already-accepted requests drain on the schedule
+      `legDrainTimeout`'s comment describes — which bounds NEITHER the drain nor
+      the `Shutdown` in wall-clock terms, being a POLL deadline with serial
+      per-connection closes in front of it. `serving()` answers "is this the leg
+      in front of clients", not "is every byte done").
       The same predicate now gates `ReconcileHTTPS`'s same-address no-op, so a
       dead leg is REBUILT rather than mistaken for a converged one (#6827 round
       6): before that, a self-terminated HTTPS leg could not be replaced by any

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1184,13 +1184,24 @@ func (s *Server) dynamicAuthMiddleware(metricsRequireAuth bool, slot *authSlot, 
 // code ran a bare Shutdown on each server under ONE shared 5s context and never
 // reached a Close phase at all; each server now gets its own legDrainTimeout
 // AND the severing Close behind it. That is not "5s for both" becoming "5s
-// each": legDrainTimeout is a POLL deadline, and both phases put serial
-// per-connection closes in front of it — on an HTTPS leg each close_notify
-// carries a five-second write deadline of its OWN, so one stalled peer costs up
-// to five seconds, then the next, in each phase of each server. The worst case
-// grows with the number of such connections and has no fixed ceiling;
-// legDrainTimeout's comment is the authority on why. legDrainTimeout is also
-// the knob a test can shorten.
+// each": legDrainTimeout is a POLL deadline, and each phase puts serial
+// per-connection closes ahead of any deadline being consulted — inside
+// Shutdown, ahead of the poll deadline itself; after it, ahead of nothing at
+// all, since http.Server.Close takes no context.
+//
+// The five seconds is the HTTPS leg's ALONE, not "each server" (#7047).
+// s.httpsServer runs through ServeTLS, so each connection is a *tls.Conn whose
+// Close sends close_notify under a five-second write deadline of its own; one
+// stalled peer costs up to five seconds, then the next, in both of that leg's
+// phases. s.httpServer runs through plain Serve, so its c.rwc is a *net.TCPConn
+// whose Close sends no TLS alert and carries no such deadline — the HTTP leg is
+// unbounded for other reasons (serial closes, no ceiling), but not by this
+// five-second one.
+//
+// Either way the worst case grows with the number of stalled connections and
+// has no fixed ceiling; legDrainTimeout's comment is the authority on why, and
+// states the two phases separately rather than collapsing them as this summary
+// once did. legDrainTimeout is also the knob a test can shorten.
 func (s *Server) serveBound(ctx context.Context, httpLn, httpsLn net.Listener) error {
 	// Both listeners are bound. Serve each in its own goroutine; a fatal
 	// Serve error is reported once on the buffered channel.


### PR DESCRIPTION
Closes #7047

Two prose slips, both in the direction of **more boundedness than the code has**.

## 1. The surviving finite gloss

`pkg/api/README.md` said already-accepted requests "drain for up to
`legDrainTimeout`". `legDrainTimeout`'s own comment is emphatic that it bounds
**neither** the drain nor the `Shutdown` in wall-clock terms — it is a POLL
deadline with serial per-connection closes in front of it — and that comment
already records "it bounds the Shutdown" as *the second wrong version of this
sentence* (#6827 round 9). This was the third.

## 2. The five seconds belongs to the HTTPS leg alone

`serveBound`'s doc attached the `close_notify` deadline to "each phase of each
server". Verified in the serve paths rather than taken from the issue:

- `s.httpServer.Serve(httpLn)` — `server.go:1204`, plain `Serve`. Connections are
  `*net.TCPConn`; `Close` sends no TLS alert, so **no** `close_notify` write
  deadline.
- `s.httpsServer.ServeTLS(httpsLn, "", "")` — `server.go:1217`. Connections are
  `*tls.Conn`; `Close` sends `close_notify` under its own five-second write
  deadline.

So the sentence over-scoped by a factor of two. The HTTP leg is still unbounded —
serial closes, no ceiling — but not by *that* five seconds, and saying otherwise
claimed a bound that leg does not have.

## 3. Phase 2 is not "in front of" a deadline

The same sentence said "both phases put serial per-connection closes in front of
it", where "it" is `legDrainTimeout`. Coherent for phase 1 only: `http.Server.Close`
takes **no context at all**, so phase 2's closes sit ahead of nothing.
`legDrainTimeout`'s comment already separates the two ("INSIDE Shutdown" / "AFTER
it"); the summary had collapsed them and now defers to it rather than
paraphrasing.

## Two details of the issue were stale — checked, not carried forward

- Its sweep predicate `grep -rn "up to .legDrainTimeout"` returned **two** hits at
  head `5deefb242`, **one** at current master, and **zero** after this change.
- It says the `serveBound` slip has a "README mirror". **There is none** at
  current master — `grep -n "in each phase of each server"` over
  `pkg/api/README.md` has no match. Only `server.go` needed the fix.

`listener.go:78`'s occurrence is deliberately untouched: it is the one the issue
notes self-corrects six lines later, and it does not match the sweep predicate
(no backtick).

## Validation

Prose only, no behaviour change. `go build ./pkg/api/` clean, `gofmt` clean.
Recorded in `docs/log/7047.md`.