### PR TITLE
userspace-dp: state the VLAN-child arming precondition in the README

### DIFF
--- a/pkg/dataplane/userspace/vlan_child_arming_precondition_7022_test.go
+++ b/pkg/dataplane/userspace/vlan_child_arming_precondition_7022_test.go
@@ -1,0 +1,106 @@
+package userspace
+
+import "testing"
+
+// #7022: the README claim that a VLAN child "DOES arm
+// `snapshotRequiresRefusalProtocol` even though it contributes nothing to any
+// `netdevOwnerTally`" is true only under a precondition the doc did not state —
+// the child's OWN netdev must be a live xfrm interface.
+//
+// This measures both sides of that precondition rather than transcribing it.
+// `snapshotSecureTunnel` is `secureTunnelOwned(cfg, ref) || liveXfrm[netdev]`,
+// so for a child the config does not own, the kernel half is the only way the
+// flag lands on the CHILD row. When it does not, the flag lands on the BASE row
+// instead — and a base row is not a VLAN child, so it is a counted contributor
+// to a tally. A reader reproducing the claim without the precondition sees that
+// second mechanism and concludes the doc is wrong when it is merely incomplete.
+//
+// Both rows are asserted in both directions in each case. Asserting only "the
+// child is armed" in case (a) would pass against an implementation that armed
+// every row, and only "the child is not armed" in case (b) would pass against
+// one that armed none.
+func TestVlanChildArmsOnlyWhenItsOwnNetdevIsLiveXfrm7022(t *testing.T) {
+	const (
+		lanIfindex   = 10
+		xfrmiIfindex = 11
+		childIfindex = 12
+	)
+	// Both the base and the VLAN child exist as netdevs, so which one the
+	// kernel calls an xfrmi is the ONLY variable between the two cases.
+	live := map[string]int{"ge-0-0-0": lanIfindex, "st10": xfrmiIfindex, "st10.100": childIfindex}
+
+	for _, tc := range []struct {
+		name string
+		// xfrmNames is the kernel's answer to "which netdevs are xfrm?".
+		xfrmNames []string
+		wantBase  bool
+		wantChild bool
+		why       string
+	}{
+		{
+			name:      "child is itself a live xfrmi (the README's shape)",
+			xfrmNames: []string{"st10.100"},
+			wantBase:  false,
+			wantChild: true,
+			why: "the VLAN child's own netdev is the xfrmi, so the child row " +
+				"carries SecureTunnel and arms the refusal protocol while casting " +
+				"no counted vote — which is the claim",
+		},
+		{
+			name:      "only the base is a live xfrmi (the shape a reader hits by default)",
+			xfrmNames: []string{"st10"},
+			wantBase:  true,
+			wantChild: false,
+			why: "the arming comes from the BASE row, which is not a VLAN child " +
+				"and DOES contribute to a netdevOwnerTally — a different mechanism " +
+				"than the claim describes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer stubLinkSnapshot5619(t, live)()
+			defer stubXfrmNetdevs(t, tc.xfrmNames...)()
+
+			cfg := compileForTest5619(t,
+				"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+				"set security zones security-zone trust interfaces ge-0/0/0.0",
+				"set interfaces st10 vlan-tagging",
+				"set interfaces st10 unit 5 vlan-id 100",
+				"set interfaces st10 unit 5 family inet address 192.0.2.1/24",
+				"set security zones security-zone trust interfaces st10.5",
+			)
+			rows := buildInterfaceSnapshots(cfg)
+			base, child := rowByName(t, rows, "st10"), rowByName(t, rows, "st10.5")
+
+			// PREMISE: no IPsec vpn binds either ref, so `secureTunnelOwned` is
+			// false for both and the kernel half is the only thing that can set
+			// the flag. Without this the case rows would not be distinguishable
+			// by the variable they claim to vary.
+			if secureTunnelOwned(cfg, "st10") || secureTunnelOwned(cfg, "st10.5") {
+				t.Fatal("premise broken: the config OWNS one of the refs, so the " +
+					"config half of snapshotSecureTunnel decides and the kernel half " +
+					"— the precondition under test — is not what varies")
+			}
+			// PREMISE: the child really is a VLAN child whose own netdev is
+			// `st10.100`, or `liveXfrm` is being keyed on a name this row never
+			// presents and case (a) would be vacuous.
+			if child.LinuxName != "st10.100" {
+				t.Fatalf("premise broken: the child's netdev is %q, want \"st10.100\" — "+
+					"the kernel half keys on this name", child.LinuxName)
+			}
+			if child.ParentLinuxName != "st10" {
+				t.Fatalf("premise broken: the child does not redirect onto the base "+
+					"(ParentLinuxName=%q), so it is not the abstaining VLAN child the "+
+					"claim is about", child.ParentLinuxName)
+			}
+
+			if base.SecureTunnel != tc.wantBase {
+				t.Errorf("base row st10 SecureTunnel=%v, want %v: %s",
+					base.SecureTunnel, tc.wantBase, tc.why)
+			}
+			if child.SecureTunnel != tc.wantChild {
+				t.Errorf("VLAN child st10.5 SecureTunnel=%v, want %v: %s",
+					child.SecureTunnel, tc.wantChild, tc.why)
+			}
+		})
+	}
+}

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -451,6 +451,22 @@ all", and that has been false since round 10):
   field on the row means an older helper plans a binding this control plane
   refuses, which is true whoever wins the tally — the protocol question is asked
   per contributor, the refusal question per netdev.
+
+  **Reproducing this needs a precondition the sentence above does not carry
+  (#7022): the CHILD's own netdev must be the secure tunnel.** `iface.SecureTunnel`
+  is `secureTunnelOwned(cfg, ref) || liveXfrm[netdev]`, and for `st0` with
+  `unit N vlan-id 100` the child's netdev is `st0.100` — so the flag lands on the
+  child only when a VPN binds that unit ref, or when `st0.100` is ITSELF a live
+  xfrmi. Point the kernel half at the base instead and the flag lands on `st0`,
+  which is not a VLAN child and DOES cast a counted vote: the arming is real but
+  it arrives by the ordinary contributor path, not by the abstaining one this
+  bullet describes. A reader who reproduces it that way sees a different
+  mechanism and concludes the doc is wrong when it is merely incomplete.
+  Measured both ways by
+  `TestVlanChildArmsOnlyWhenItsOwnNetdevIsLiveXfrm7022`
+  (`pkg/dataplane/userspace`), which asserts BOTH rows in BOTH directions —
+  asserting only "the child is armed" would pass against an implementation that
+  armed every row.
 - A **fabric parent** speaks for its netdev only where NO row does. A fabric
   MEMBER needs no `set interfaces` stanza, so a fabric parent routinely has no
   `InterfaceSnapshot` at all — and the round-9 rule, tallying over rows alone,


### PR DESCRIPTION
Closes #7022

## What the claim is, and where

The issue's "claim F3" is the review leg's own finding label, not a heading in
the README — the text is the **VLAN child** bullet under *Who speaks for a
netdev*:

> An abstaining row still carries its own `verdictNeedsProtocol`
> (`iface.SecureTunnel`), so a VLAN child that is a secure tunnel **DOES arm**
> `snapshotRequiresRefusalProtocol` even though it contributes nothing to any
> `netdevOwnerTally`.

True — under a precondition the sentence does not carry.

## Measured both ways, not transcribed

The whole reason this issue exists is that someone reproduced the claim under
the wrong shape, so the precondition had to be *measured* rather than copied
from the issue. `snapshotSecureTunnel` is
`secureTunnelOwned(cfg, ref) || liveXfrm[netdev]`, and for `st10` with
`unit 5 vlan-id 100` the child's netdev is `st10.100`. With no VPN binding
either ref, the kernel's answer is the only variable:

| kernel says this is xfrm | base `st10` | VLAN child `st10.5` | mechanism |
|---|---|---|---|
| `st10.100` (the child's own netdev) | false | **true** | the claim's shape: an abstaining row arms |
| `st10` (the base) | **true** | false | the base row arms — and it **is** a counted contributor |

The second row is the shape a reader hits by default. The arming is real, but it
arrives by the ordinary contributor path rather than the abstaining one the
bullet describes — which is exactly how a correct-but-incomplete claim reads as
wrong.

`TestVlanChildArmsOnlyWhenItsOwnNetdevIsLiveXfrm7022` asserts **both rows in
both directions**. Asserting only "the child is armed" in the first case would
pass against an implementation that armed every row; only "the child is not
armed" in the second would pass against one that armed none. Neither would be
measuring the variable the precondition names.

Two premises are asserted before the comparison: that the config owns **neither**
ref (so the kernel half is what varies at all — otherwise `secureTunnelOwned`
short-circuits and the cases are not distinguished by what they claim to vary),
and that the child's netdev really is `st10.100` (so the stub is keyed on a name
this row actually presents, rather than making the first case vacuous).

## Deliberately not changed

Both re-verified by the same review leg and named in the issue:

- **README F4 is correct** — the regenerating grep run verbatim yields exactly
  the 5 sites it names.
- **`netdevOwnerTally.refused`'s `t.owners > 0` conjunct** going green when
  deleted is documented as deliberate at `ingress_exclusions.go:564-572`: an
  unreachable fall-through, not a coverage gap.

## Gates

Docs plus one test; no behaviour change.

`go test -count=1 ./...`: **67 packages ok**. `pkg/cluster` is **flaky on this
box and unrelated** — two different timing tests failed in two different runs
(`TestStartHeartbeatDoesNotRaceStopHeartbeat7257` at its 30 s timeout, then
`TestReceiveLoopKeepsConnectionAliveWithHeartbeatAck` at 2 s), and on identical
code the package went **FAIL then ok** back to back. That non-determinism is the
proof it is not caused by a static change; `pkg/cluster` imports neither the
README nor `pkg/dataplane/userspace`.

One environment note worth recording rather than hiding: an earlier run of the
same gate failed to **link** 50-odd packages with
`cannot open file /home/ps/.cache/go-build/...: no such file or directory` — the
shared GOCACHE was pruned mid-run while the disk was at 100%. Loud, not silent,
and it cleared on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
