### PR TITLE
config: reject a `then` block naming two NAT pools (#7013)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5196,6 +5196,33 @@ rejection message names it rather than claiming the block-level case is
 covered. `TestNATTerminalActionPackedContradictionCommits_7034` pins each
 spelling, so closing #7033 has to update this text too.
 
+*One authored token IS counted now, and only one (#7013).* The sentence above
+still holds for MODES — a packed `off pool P` collapses to one field and
+commits, and #7033 is still open. But a block naming the SAME mode twice is no
+longer invisible: `then destination-nat pool PD pool PD2` and
+`then { destination-nat { pool PD; pool PD2; } }` are rejected at strict commit
+by an occurrence check that runs BEFORE the mode count, reading a per-container
+record of the authored pool NAMES (`natThenAuthored`, unexported on `NATRule`,
+built by `natThenAuthoredOccurrences` at both lowering sites). Where the collapse
+happens the FIRST authored pool is the one that takes effect, in both spellings.
+
+Three neighbouring shapes stay legal, and the distinction is the whole of why
+this does not disturb #3850 or #7035:
+
+- **Duplicate `then` CONTAINERS** — last-container-wins, unchanged. The record is
+  scoped to ONE container precisely so summing cannot false-reject them.
+- **Two separate `set … then destination-nat pool X` lines** — NOT a collapse.
+  The second REPLACES the leaf in the candidate tree, as a single-value leaf
+  should, so only one pool ever reaches the compiler and `show configuration`
+  displays what will be enforced. #7013's body described this as the same defect;
+  it is ordinary leaf replacement at a different layer.
+- **The same pool named twice in one block** — nothing is discarded, so it is a
+  redundancy rather than an error.
+
+`off` and `interface` are not recorded at all: they carry no value, so repeating
+either discards nothing. `compiler_nat_then_occurrences_7013_test.go` pins every
+row above, including the three legal ones.
+
 *What the tolerant path actually does (#5717).* Only a malformed rule reaches
 the lenient arm — the strict commit path rejects it — but the two arities land
 there very differently, and the difference is load-bearing:

--- a/docs/log/7013.md
+++ b/docs/log/7013.md
@@ -1,0 +1,106 @@
+# #7013 — a `then` block naming two pools commits silently under strict
+
+## Timestamp
+2026-08-28
+
+## Action
+Reject, at strict commit, a NAT rule whose single `then` container names two
+different pools. `NATThen.PoolName` is a scalar, so the second name is discarded
+during lowering and `validateNATTerminalActionCardinalityStrict` — which counts
+MODES — sees `n == 1` and does not fire. The config commits, the firewall
+translates through a pool the operator did not intend, and nothing says so.
+
+Implemented as #7013's option 1: a per-container occurrence record kept beside
+the resolved `NATThen`, read only by the strict gate. The resolved type and the
+dataplane contract are unchanged.
+
+## Files
+- `pkg/config/compiler_nat_then_occurrences_7013.go` (new) — the record and the
+  three-shape walk
+- `pkg/config/compiler_nat_then_occurrences_7013_test.go` (new) — rejections,
+  boundaries, and the shape table
+- `pkg/config/types_security.go` — `NATRule.thenAuthored` (unexported)
+- `pkg/config/compiler_nat_source.go`, `compiler_nat_destination.go` — populate
+  the record at both lowering sites
+- `pkg/config/compiler_validate_strict_nat.go` — the occurrence gate
+- `pkg/config/nat_source_axis_sweep_6812_test.go` — register the new column
+
+## What the issue got wrong, measured rather than assumed
+
+The issue body says the LAST authored pool survives; a later correction says the
+FIRST. Both describe a single mechanism, and there are two. Measured at this
+head:
+
+| spelling | tree carries | survivor | is it the defect? |
+|---|---|---|---|
+| `then destination-nat pool PD pool PD2` (packed run) | both | `PD` (first) | YES |
+| `then { destination-nat { pool PD; pool PD2; } }` (braces) | both | `PD` (first) | YES |
+| two separate `set ... pool X` lines | ONE (`PD2`) | `PD2` | NO |
+
+The third row is not a collapse at all. A second `set` on a single-value leaf
+REPLACES it in the candidate tree, which is how a single-value leaf is meant to
+behave: only one pool ever reaches the compiler, and `show configuration`
+displays exactly what will be enforced. Nothing is hidden, so there is nothing
+for a commit gate to report — and rejecting it would break the ordinary way an
+operator edits a pool. `TestSeparateSetLinesReplaceAndCommit_7013` pins that,
+asserting the TREE and not just the compile result so the cell says WHY the
+spelling is legal.
+
+Where the collapse does happen the FIRST authored value wins, in both shapes.
+The tests still assert REJECTION rather than the survivor: a fixture built on
+the survivor reds against a correct compiler and a buggy one alike, for opposite
+reasons, and the instinct on seeing that red is to "fix" the assertion.
+
+## Scope, and the three things deliberately left legal
+
+The record is scoped to ONE `then` container. Everything below is a config the
+gate could plausibly have been "completed" into rejecting, and the first two
+were in fact rejected by the first version of this change:
+
+- **Duplicate `then` CONTAINERS** — #3850 last-wins, already legal, whether they
+  name the same pool or different actions. The first version summed occurrences
+  across containers and false-rejected
+  `TestNATTerminalActionDupIdenticalPool3850_5628`.
+- **Two separate `set` lines** — leaf replacement, per the table above.
+- **The same pool named twice in one block** — `pool PD pool PD` discards
+  nothing, so `distinctPools` makes it a redundancy rather than an error.
+
+`off` and `interface` are not recorded at all: they carry no value, so writing
+either twice discards nothing. A rule mixing DIFFERENT modes is still caught, by
+the mode count that follows.
+
+## The record is unexported, and that was not cosmetic
+
+`ThenAuthored` started exported. That put compile-time diagnostic state into the
+typed Config's JSON: it changed `TestCompileGolden4406` across 19 cases and
+appeared as an unregistered column in the #6812 axis sweep, and it would have
+travelled in config-sync payloads to a peer. Unexported, it stays inside the
+compiler where its only reader lives, the golden is untouched, and only the
+sweep — which reflects over unexported fields too — still sees it.
+
+## What the suite caught that review would not have
+
+Three defects in this change were found by existing gates, not by reading it:
+
+1. `TestNATTerminalActionDupIdenticalPool3850_5628` — the across-container
+   summing described above.
+2. `TestDualASTDifferential/security-nat` — the same config recorded DIFFERENTLY
+   depending on spelling. The hierarchical fixtures write `pool { snat-pool; }`,
+   with the name BELOW the node; a Keys-only walk counted zero pools there and
+   one for the flat-set spelling. The compiler resolves that name with `nodeVal`
+   (Keys[1], else `Children[0].Name()`), so the walk now does the same — which
+   also keeps Junos's `pool { P; persistent-nat { ... } }` at one authored pool
+   instead of two.
+3. `TestSourceNatRepeatedModeRejected_7013` (mine) — the flat-set path builds a
+   repeat as a CHILD of the first pool node, not a sibling, because the second
+   `pool` token opens a further path. A sibling-only walk missed the packed
+   source-NAT spelling entirely.
+
+The #6812 registry then rejected the first registration as OVER-REACH: the pool
+NAMES vary rule to rule, so only the LENGTH columns are unguarded and only they
+belong in the table.
+
+## Validation
+- `go test -count=1 ./pkg/config/` — ok
+- `go test -count=1 ./...` — see PR body
+- full-suite mutation matrix with a control — see PR body

--- a/pkg/config/compiler_nat_destination.go
+++ b/pkg/config/compiler_nat_destination.go
@@ -241,6 +241,17 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 				}
 			}
 
+			// #7013: record what ONE `then` container authored, so a block that
+			// named the same pool twice is still visible after NATThen's scalar
+			// collapsed it. Kept PER CONTAINER, not summed: duplicate `then`
+			// containers are #3850's accepted last-wins, and summing across them
+			// false-rejects a config the suite already pins as legal. The worst
+			// single container is the one worth reporting.
+			for _, thenNode := range ruleInst.node.FindChildren("then") {
+				if c := natThenAuthoredOccurrences(thenNode, "destination-nat"); len(c.distinctPools()) > len(rule.thenAuthored.distinctPools()) {
+					rule.thenAuthored = c
+				}
+			}
 			rules = append(rules, rule)
 		}
 

--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -1050,6 +1050,17 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 				}
 			}
 
+			// #7013: record what ONE `then` container authored, so a block that
+			// named the same pool twice is still visible after NATThen's scalar
+			// collapsed it. Kept PER CONTAINER, not summed: duplicate `then`
+			// containers are #3850's accepted last-wins, and summing across them
+			// false-rejects a config the suite already pins as legal. The worst
+			// single container is the one worth reporting.
+			for _, thenNode := range ruleInst.node.FindChildren("then") {
+				if c := natThenAuthoredOccurrences(thenNode, "source-nat"); len(c.distinctPools()) > len(rule.thenAuthored.distinctPools()) {
+					rule.thenAuthored = c
+				}
+			}
 			rules = append(rules, rule)
 		}
 

--- a/pkg/config/compiler_nat_then_occurrences_7013.go
+++ b/pkg/config/compiler_nat_then_occurrences_7013.go
@@ -1,0 +1,169 @@
+package config
+
+// compiler_nat_then_occurrences_7013.go — #7013.
+//
+// `NATThen.PoolName` is a scalar, so ONE `then` block that names two pools —
+//
+//	then destination-nat pool PD pool PD2
+//	then destination-nat { pool PD; pool PD2; }
+//
+// — lowers to a single pool and the other is gone before any validation runs.
+// validateNATTerminalActionCardinalityStrict counts MODES (`n == 1` here), so it
+// does not fire and the config commits under STRICT with an operator-authored
+// action silently discarded. This records what one block AUTHORED, alongside the
+// resolved NATThen, so the gate can reject on occurrences instead of modes. It
+// is #7013's option 1: the resolved type keeps its shape and the dataplane
+// contract is untouched.
+//
+// SCOPE IS ONE `then` CONTAINER, and that is the whole of the correctness
+// argument for not breaking #3850. Two duplicate `then` containers are ALREADY
+// decided: they are last-container-wins and legal, pinned by
+// TestNATTerminalActionDupIdentical3850_5628 (same pool twice) and by the
+// interface-then-poolB case beside it (different actions, last wins). Summing
+// across containers false-rejects both. What #7013 describes is narrower — one
+// block naming the mode twice — and that is the only shape counted here.
+//
+// WHICH SPELLINGS ARE ACTUALLY THIS DEFECT, measured at this head rather than
+// taken from the issue, because the issue is wrong about one of them:
+//
+//   - `then destination-nat pool PD pool PD2` (one packed run) — the tree
+//     carries both, the compiler keeps PD, PD2 vanishes. THE DEFECT.
+//   - `then { destination-nat { pool PD; pool PD2; } }` (hierarchical braces,
+//     the spelling in #7013's acceptance criterion) — the tree carries both,
+//     the compiler keeps PD. THE DEFECT.
+//   - two separate `set ... then destination-nat pool X` lines — NOT the
+//     defect. The second REPLACES the leaf in the candidate tree, which is how
+//     a single-value leaf is supposed to behave; only `pool PD2` ever reaches
+//     the compiler, `show configuration` displays it, and nothing is hidden.
+//     Rejecting it would break the ordinary way an operator edits a pool.
+//
+// So the survivor is the FIRST wherever the collapse actually happens — the
+// issue body's "last wins" was describing leaf replacement, a different
+// mechanism at a different layer. The tests still assert REJECTION rather than
+// the survivor: rejection is the acceptance criterion, and a fixture built on
+// the survivor reds against a correct compiler and a buggy one alike, for
+// opposite reasons, which invites "fixing" the assertion.
+//
+// ONLY POOLS ARE RECORDED. `off` and `interface` carry no value, so writing
+// either twice discards nothing — the config means what it says and there is
+// nothing to report. Counting them would reject an idempotent typo. A rule
+// mixing DIFFERENT modes is still caught, by the mode count that follows this
+// check.
+
+// natThenAuthored is what ONE `then` container authored, before NATThen's
+// scalar collapsed it.
+type natThenAuthored struct {
+	// Pools is every authored pool NAME in encounter order, so the diagnostic
+	// can name the discarded one rather than only the survivor.
+	Pools []string
+}
+
+// distinctPools returns the authored pool names with repeats removed, in
+// encounter order.
+//
+// DISTINCT, not raw: `pool p1 pool p1` discards nothing — both spellings mean
+// p1 — and rejecting it would be a diagnostic about a redundancy rather than
+// about a lost action. Two DIFFERENT names is the case where the configuration
+// as written and the configuration as enforced disagree.
+func (a natThenAuthored) distinctPools() []string {
+	if len(a.Pools) < 2 {
+		return a.Pools
+	}
+	seen := make(map[string]struct{}, len(a.Pools))
+	out := make([]string, 0, len(a.Pools))
+	for _, p := range a.Pools {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+// natThenAuthoredOccurrences records every pool of `kind` that thenNode
+// authored.
+//
+// THREE SHAPES, and all three have to be walked here or the gate is blind to
+// one spelling of the same defect:
+//
+//  1. PACKED ONTO THE `then` NODE ITSELF — `then source-nat pool P` arrives as
+//     Keys on the `then` node (the #7014 shape, applyPackedNATThenTokens7014).
+//  2. PACKED ONTO THE KIND CHILD — `then { source-nat pool P pool Q; }` arrives
+//     as Keys on the `source-nat` child, and a repeated value collapses onto
+//     that one leaf's Keys (#2419) rather than producing two nodes.
+//  3. HIERARCHICAL — `then { source-nat { pool P; pool Q; } }` arrives as
+//     children of the `source-nat` child, one node each.
+func natThenAuthoredOccurrences(thenNode *Node, kind string) natThenAuthored {
+	var a natThenAuthored
+	if thenNode == nil {
+		return a
+	}
+	// Shape 1: `then <kind> <action> ...` — the kind sits at Keys[1].
+	if len(thenNode.Keys) > 1 && thenNode.Keys[1] == kind {
+		a.scanKeys(thenNode.Keys, 2)
+	}
+	for _, t := range thenNode.Children {
+		if t == nil || t.Name() != kind {
+			continue
+		}
+		// Shape 2: the run continues on the kind child, after Keys[0].
+		a.scanKeys(t.Keys, 1)
+		// Shape 3: one node per action below the kind node.
+		for _, c := range t.Children {
+			if c == nil || c.Name() != "pool" {
+				continue
+			}
+			a.addPoolNode(c)
+		}
+	}
+	return a
+}
+
+// scanKeys records each `pool <name>` pair in a flat token run from index from.
+//
+// A trailing bare `pool` is malformed rather than a second authored pool: other
+// gates report it, and counting it here would answer a syntax error with a
+// duplicate-pool message.
+func (a *natThenAuthored) scanKeys(keys []string, from int) {
+	for i := from; i < len(keys); i++ {
+		if keys[i] == "pool" && i+1 < len(keys) {
+			a.Pools = append(a.Pools, keys[i+1])
+			i++
+		}
+	}
+}
+
+// addPoolNode records the pool(s) a `pool` NODE authored.
+//
+// The name may sit on the node (`pool P;` → Keys=["pool","P"]) or below it
+// (`pool { P; }` → one child), and the second shape is the one the hierarchical
+// fixtures in dual_ast_differential_test.go actually use.
+//
+// EXACTLY ONE NAME COMES FROM THE CHILDREN, taken from the FIRST child, because
+// that is what nodeVal does and therefore what the compiler resolves. Counting
+// every child would count Junos's `pool { P; persistent-nat { ... } }` as two
+// authored pools and reject a valid config. Whatever the compiler treats as the
+// name is what this has to treat as the occurrence, or the record describes a
+// config the compiler never saw.
+//
+// A REPEAT MAY ARRIVE NESTED, not as a sibling: the flat-set path for
+// `then source-nat pool PS pool PS2` builds `pool PS` with `pool PS2` as its
+// CHILD, because the second `pool` token opens a further path rather than
+// extending the leaf. So the walk descends — but only into children NAMED
+// `pool`, which is what keeps the descent from swallowing `persistent-nat` and
+// the pool-name node itself.
+func (a *natThenAuthored) addPoolNode(c *Node) {
+	if len(c.Keys) > 1 {
+		// Repeats can also collapse onto this leaf's Keys (#2419), so scan the
+		// whole run rather than reading Keys[1].
+		a.scanKeys(c.Keys, 0)
+	} else if name := nodeVal(c); name != "" {
+		a.Pools = append(a.Pools, name)
+	}
+	for _, g := range c.Children {
+		if g != nil && g.Name() == "pool" {
+			a.addPoolNode(g)
+		}
+	}
+}

--- a/pkg/config/compiler_nat_then_occurrences_7013_test.go
+++ b/pkg/config/compiler_nat_then_occurrences_7013_test.go
@@ -1,0 +1,414 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// compiler_nat_then_occurrences_7013_test.go — #7013.
+//
+// A rule that authors the SAME mode twice loses one of them before anything
+// validates it: NATThen's `PoolName` is a scalar, so
+// `then destination-nat pool PD pool PD2` resolves to one pool and
+// validateNATTerminalActionCardinalityStrict — which counts MODES — sees n == 1
+// and does not fire. The config commits under STRICT with an operator-authored
+// action discarded and no diagnostic.
+//
+// THE FIXTURES ASSERT REJECTION, NOT WHICH POOL SURVIVES. Measured at this head
+// the FIRST authored value is the one that takes effect, in both spellings that
+// carry two occurrences into the tree — but a fixture built on the survivor reds
+// against a correct compiler and a buggy one alike, for opposite reasons, and
+// the instinct on seeing that red is to "fix" the assertion. Rejection is the
+// acceptance criterion and is invariant to it.
+//
+// THE BOUNDARY CASES ARE AS LOAD-BEARING AS THE REJECTIONS, because every one of
+// them is a config the gate could plausibly be "completed" into rejecting, and
+// two of them were rejected by the first version of this change:
+//
+//   - two separate `set ... pool X` lines — the second REPLACES the leaf, so
+//     only one pool reaches the compiler and `show configuration` displays what
+//     will be enforced. The issue body called this a collapse; it is ordinary
+//     single-value-leaf behaviour at a different layer.
+//   - duplicate `then` CONTAINERS — #3850 last-wins, already legal.
+//     TestNATTerminalActionDupIdentical3850_5628 caught the summing version of
+//     this change; the scope is now one container.
+//   - `pool { P; persistent-nat { ... } }` — one authored pool with a
+//     sub-stanza, not two. dual_ast_differential_test.go caught the version
+//     that read the name from Keys only.
+
+func natDupPoolSet7013(thenLines ...string) []string {
+	return append([]string{
+		"set security zones security-zone untrust",
+		"set security nat destination pool PD address 10.0.0.5",
+		"set security nat destination pool PD2 address 10.0.0.6",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 203.0.113.10",
+	}, thenLines...)
+}
+
+// TestRepeatedSameModePoolRejected_7013 is the acceptance criterion, in both
+// spellings and both orders.
+//
+// Both orders matter for the reason above: an implementation that counted only
+// the DISCARDED occurrence rather than the authored ones would pass one order
+// and fail the other, and a single-order fixture could not tell.
+func TestRepeatedSameModePoolRejected_7013(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		then  []string
+		pools [2]string
+	}{
+		{
+			name:  "packed_run_PD_then_PD2",
+			then:  []string{"set security nat destination rule-set rs1 rule r1 then destination-nat pool PD pool PD2"},
+			pools: [2]string{"PD", "PD2"},
+		},
+		{
+			name:  "packed_run_PD2_then_PD",
+			then:  []string{"set security nat destination rule-set rs1 rule r1 then destination-nat pool PD2 pool PD"},
+			pools: [2]string{"PD2", "PD"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, natDupPoolSet7013(tc.then...))
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatal("a rule authoring TWO destination-nat pools committed under strict. " +
+					"One of them is silently discarded before validation runs — NATThen's " +
+					"PoolName is a scalar — so the firewall translates differently from the " +
+					"configuration as written, with no diagnostic (#7013)")
+			}
+			msg := err.Error()
+			// The acceptance criterion names BOTH authored pools: a message that
+			// named only the survivor would tell the operator the opposite of
+			// what happened — that the pool they can see is the problem.
+			for _, p := range tc.pools {
+				if !strings.Contains(msg, p) {
+					t.Fatalf("the rejection does not name authored pool %q: %q. The operator "+
+						"has to be told WHICH pool was discarded, and the survivor alone does "+
+						"not say that", p, msg)
+				}
+			}
+			if !strings.Contains(msg, "pool") {
+				t.Fatalf("the rejection does not name the repeated MODE: %q", msg)
+			}
+		})
+	}
+}
+
+// TestSingleActionStillCompiles_7013 is the negative control, and without it
+// every case above is satisfied by a gate that rejects all NAT.
+func TestSingleActionStillCompiles_7013(t *testing.T) {
+	for _, tc := range []struct{ name, then string }{
+		{"one_pool_packed", "set security nat destination rule-set rs1 rule r1 then destination-nat pool PD"},
+		{"one_off", "set security nat destination rule-set rs1 rule r1 then destination-nat off"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, natDupPoolSet7013(tc.then))
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("a rule authoring ONE action must still commit, got: %v.\n"+
+					"The occurrence gate must reject a REPEAT, not a mode — rejecting the "+
+					"single case would make the cases above pass for the wrong reason", err)
+			}
+		})
+	}
+}
+
+// TestSourceNatRepeatedModeRejected_7013 covers the other kind. The gate runs
+// over both, and the occurrence record is populated at two separate lowering
+// sites, so a fix applied to one is a fix applied to half the defect.
+func TestSourceNatRepeatedModeRejected_7013(t *testing.T) {
+	lines := []string{
+		"set security zones security-zone untrust",
+		"set security nat source pool PS address 10.0.0.5",
+		"set security nat source pool PS2 address 10.0.0.6",
+		"set security nat source rule-set rs1 from zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address 10.0.1.0/24",
+		"set security nat source rule-set rs1 rule r1 then source-nat pool PS pool PS2",
+	}
+	tree := buildTree(t, lines)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a source-nat rule authoring TWO pools committed under strict. The " +
+			"occurrence record is populated at the source and destination lowering sites " +
+			"separately, so a gate wired to only one covers half the defect (#7013)")
+	}
+	for _, p := range []string{"PS", "PS2"} {
+		if !strings.Contains(err.Error(), p) {
+			t.Fatalf("the source-nat rejection does not name authored pool %q: %q", p, err)
+		}
+	}
+}
+
+// TestOccurrenceCounterSeesEveryShape_7013 pins the walk directly.
+//
+// The gate is only as complete as the shapes the counter reads, and a spelling
+// it misses is a spelling that still commits silently. Driving the counter
+// rather than the compiler is what makes an uncounted shape fail HERE, by name,
+// instead of surfacing as one accepted case in the table above.
+func TestOccurrenceCounterSeesEveryShape_7013(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		node      *Node
+		wantPools int
+	}{
+		{
+			name:      "packed_onto_the_then_node",
+			node:      &Node{Keys: []string{"then", "destination-nat", "pool", "PD", "pool", "PD2"}},
+			wantPools: 2,
+		},
+		{
+			name: "packed_onto_the_kind_child",
+			node: &Node{Keys: []string{"then"}, Children: []*Node{
+				{Keys: []string{"destination-nat", "pool", "PD", "pool", "PD2"}},
+			}},
+			wantPools: 2,
+		},
+		{
+			name: "hierarchical_children",
+			node: &Node{Keys: []string{"then"}, Children: []*Node{
+				{Keys: []string{"destination-nat"}, Children: []*Node{
+					{Keys: []string{"pool", "PD"}},
+					{Keys: []string{"pool", "PD2"}},
+				}},
+			}},
+			wantPools: 2,
+		},
+		{
+			// The name below the `pool` node — the shape the hierarchical
+			// fixtures in dual_ast_differential_test.go use. A counter that read
+			// Keys only saw ZERO pools here, which is what made the same config
+			// record differently depending on how it was spelled.
+			name: "pool_name_as_child",
+			node: &Node{Keys: []string{"then"}, Children: []*Node{
+				{Keys: []string{"destination-nat"}, Children: []*Node{
+					{Keys: []string{"pool"}, Children: []*Node{{Keys: []string{"PD"}}}},
+				}},
+			}},
+			wantPools: 1,
+		},
+		{
+			// The flat-set path for `then source-nat pool PS pool PS2` builds the
+			// repeat as a CHILD of the first pool node, not a sibling: the second
+			// `pool` token opens a further path instead of extending the leaf. A
+			// walk that reads siblings only sees one pool here and the packed
+			// source-nat spelling commits silently.
+			name: "nested_pool_repeat",
+			node: &Node{Keys: []string{"then"}, Children: []*Node{
+				{Keys: []string{"destination-nat"}, Children: []*Node{
+					{Keys: []string{"pool", "PD"}, Children: []*Node{
+						{Keys: []string{"pool", "PD2"}},
+					}},
+				}},
+			}},
+			wantPools: 2,
+		},
+		{
+			// Junos nests `persistent-nat` under `pool`. Counting every child as
+			// a pool name makes this read as two authored pools and rejects a
+			// valid config; the compiler takes the FIRST child (nodeVal), so
+			// this must too.
+			name: "pool_with_persistent_nat_substanza_is_one_pool",
+			node: &Node{Keys: []string{"then"}, Children: []*Node{
+				{Keys: []string{"source-nat"}, Children: []*Node{
+					{Keys: []string{"pool"}, Children: []*Node{
+						{Keys: []string{"PS"}},
+						{Keys: []string{"persistent-nat"}, Children: []*Node{{Keys: []string{"permit", "any-remote-host"}}}},
+					}},
+				}},
+			}},
+			wantPools: 1,
+		},
+		{
+			// A DIFFERENT kind's actions must not be counted, or a rule with one
+			// source-nat pool and one destination-nat pool reads as a duplicate.
+			name: "other_kind_is_not_counted",
+			node: &Node{Keys: []string{"then"}, Children: []*Node{
+				{Keys: []string{"destination-nat", "pool", "PD"}},
+				{Keys: []string{"source-nat", "pool", "PS"}},
+			}},
+			wantPools: 1,
+		},
+		{
+			// A trailing bare `pool` is malformed, not a second authored pool;
+			// counting it would report a duplicate for a syntax error.
+			name:      "trailing_bare_pool_is_not_an_occurrence",
+			node:      &Node{Keys: []string{"then", "destination-nat", "pool", "PD", "pool"}},
+			wantPools: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			kind := "destination-nat"
+			if len(tc.node.Children) > 0 && tc.node.Children[0].Name() == "source-nat" {
+				kind = "source-nat"
+			}
+			got := natThenAuthoredOccurrences(tc.node, kind)
+			if len(got.Pools) != tc.wantPools {
+				t.Fatalf("counted %d authored pools %v, want %d — a shape the counter cannot "+
+					"see is a spelling that still commits silently (#7013)",
+					len(got.Pools), got.Pools, tc.wantPools)
+			}
+		})
+	}
+}
+
+// TestHierarchicalRepeatedPoolRejected_7013 is the spelling #7013's acceptance
+// criterion names literally — `destination-nat { pool PD; pool PD2; }` — and it
+// reaches the compiler by a different route from the packed cases above: the
+// real parser, not ParseSetCommand, and two sibling children rather than one
+// token run. A counter wired only to packed runs passes every case above and
+// still lets this commit.
+func TestHierarchicalRepeatedPoolRejected_7013(t *testing.T) {
+	txt := `security {
+  zones { security-zone untrust; }
+  nat {
+    destination {
+      pool PD { address 10.0.0.5; }
+      pool PD2 { address 10.0.0.6; }
+      rule-set rs1 {
+        from zone untrust;
+        rule r1 {
+          match { destination-address 203.0.113.10; }
+          then { destination-nat { pool PD; pool PD2; } }
+        }
+      }
+    }
+  }
+}`
+	tree, perr := NewParser(txt).Parse()
+	if len(perr) != 0 {
+		t.Fatalf("fixture did not parse: %v", perr)
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("`then { destination-nat { pool PD; pool PD2; } }` committed under strict. " +
+			"Both pools are in the tree and only the first reaches the dataplane, so the " +
+			"config as displayed is not the config as enforced (#7013)")
+	}
+	for _, p := range []string{"PD", "PD2"} {
+		if !strings.Contains(err.Error(), p) {
+			t.Fatalf("the rejection does not name authored pool %q: %q", p, err)
+		}
+	}
+}
+
+// TestSeparateSetLinesReplaceAndCommit_7013 pins the boundary: this spelling is
+// NOT the defect and must keep committing.
+//
+// It is the cell that stops the gate from being "completed" into rejecting a
+// legal edit, and it also records the measurement that corrects the issue body —
+// the tree after both lines holds ONE pool, so there is no discarded action for
+// a commit gate to report.
+func TestSeparateSetLinesReplaceAndCommit_7013(t *testing.T) {
+	tree := buildTree(t, natDupPoolSet7013(
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool PD",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool PD2",
+	))
+
+	// The tree itself carries one pool: the discard happened at `set`, visibly,
+	// not at commit, silently. Asserting the TREE and not just the compile
+	// result is what makes this cell say WHY the spelling is legal — a later
+	// change that started carrying both occurrences forward would flip this,
+	// and the rejection below it would then be correct rather than a break.
+	authored := natThenAuthoredOccurrences(natThenNode7013(t, tree), "destination-nat")
+	if len(authored.Pools) != 1 {
+		t.Fatalf("the candidate tree carries %d pools %v after two `set` lines; expected the "+
+			"second to REPLACE the first. If the tree now carries both, this spelling has "+
+			"become the #7013 defect and belongs with the rejections above", len(authored.Pools), authored.Pools)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("re-`set`ting a pool must commit — it is how an operator edits one — got: %v", err)
+	}
+	got := cfg.Security.NAT.Destination.RuleSets[0].Rules[0].Then.PoolName
+	if got != "PD2" {
+		t.Fatalf("the surviving pool is %q, want the re-`set` value PD2: a second `set` on a "+
+			"single-value leaf replaces it, and `show configuration` shows PD2", got)
+	}
+}
+
+// natThenNode7013 digs out rule r1's `then` node so a case can assert on the
+// tree the compiler will read rather than on a reconstruction of it.
+func natThenNode7013(t *testing.T, tree *ConfigTree) *Node {
+	t.Helper()
+	sec := tree.FindChild("security")
+	if sec == nil {
+		t.Fatal("fixture has no `security` node")
+	}
+	var found *Node
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil || found != nil {
+			return
+		}
+		if len(n.Keys) > 0 && n.Keys[0] == "then" {
+			found = n
+			return
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(sec)
+	if found == nil {
+		t.Fatal("fixture has no `then` node")
+	}
+	return found
+}
+
+// TestDuplicateThenContainersStillCommit_7013 is the #3850 boundary, restated
+// here in #7013's terms because the first version of this change broke it.
+//
+// Two `then` containers are last-container-wins and legal — whether they name
+// the same pool or different actions — and summing occurrences across them
+// reports a duplicate for a config the suite already pins as valid. The scope of
+// the occurrence record is ONE container, and this is the cell that says so from
+// #7013's side; TestNATTerminalActionDupIdentical3850_5628 says it from #3850's.
+func TestDuplicateThenContainersStillCommit_7013(t *testing.T) {
+	for _, tc := range []struct{ name, thens string }{
+		{"same_pool_twice", "then { destination-nat pool PD; }\n          then { destination-nat pool PD; }"},
+		{"different_pools_last_wins", "then { destination-nat pool PD; }\n          then { destination-nat pool PD2; }"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			txt := `security {
+  zones { security-zone untrust; }
+  nat {
+    destination {
+      pool PD { address 10.0.0.5; }
+      pool PD2 { address 10.0.0.6; }
+      rule-set rs1 {
+        from zone untrust;
+        rule r1 {
+          match { destination-address 203.0.113.10; }
+          ` + tc.thens + `
+        }
+      }
+    }
+  }
+}`
+			tree, perr := NewParser(txt).Parse()
+			if len(perr) != 0 {
+				t.Fatalf("fixture did not parse: %v", perr)
+			}
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("duplicate `then` containers must still commit (#3850 last-wins), got: %v.\n"+
+					"The #7013 record is scoped to ONE container for exactly this reason", err)
+			}
+		})
+	}
+}
+
+// TestSamePoolTwiceInOneBlockCommits_7013 is the redundancy boundary: naming the
+// SAME pool twice in one block discards nothing, so there is nothing to report.
+//
+// Without this cell the gate could count raw occurrences instead of distinct
+// names and every case above would still pass — it would just also reject a
+// config whose meaning is unambiguous.
+func TestSamePoolTwiceInOneBlockCommits_7013(t *testing.T) {
+	tree := buildTree(t, natDupPoolSet7013(
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool PD pool PD"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("`pool PD pool PD` names one pool twice — nothing is discarded and the "+
+			"config is unambiguous — but it was rejected: %v", err)
+	}
+}

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -3208,6 +3208,47 @@ func validateNATTerminalActionCardinalityStrict(cfg *Config) error {
 				if rule == nil {
 					continue
 				}
+				// #7013: ONE `then` BLOCK NAMING TWO POOLS, which the mode count
+				// below cannot see. NATThen resolves a single pool name, so
+				// `pool PD pool PD2` arrives here as n == 1. The per-container
+				// occurrence record kept at lowering is what makes the discarded
+				// pool checkable.
+				//
+				// Checked BEFORE the mode count so the message names the actual
+				// defect: a rule that authored two pools AND an `off` is
+				// reported as the duplicate first, because "you wrote pool
+				// twice" is the more specific and more actionable of the two.
+				//
+				// This fires only where ONE container carries both occurrences:
+				// a packed run (`pool PD pool PD2`) or hierarchical braces
+				// (`destination-nat { pool PD; pool PD2; }`), measured at this
+				// head to keep the FIRST in both. Three shapes deliberately stay
+				// legal, and each of them is already pinned elsewhere in the
+				// suite:
+				//
+				//   - DUPLICATE `then` CONTAINERS — #3850 last-wins, whether
+				//     they name the same pool or different actions. Summing
+				//     across containers false-rejects both, so the record is
+				//     kept per container.
+				//   - TWO SEPARATE `set ... pool X` LINES — the second REPLACES
+				//     the leaf in the candidate tree, exactly as a single-value
+				//     leaf is meant to behave, so only one pool ever reaches the
+				//     compiler and `show configuration` displays what will be
+				//     enforced. Rejecting it would break the ordinary way an
+				//     operator edits a pool.
+				//   - THE SAME POOL NAMED TWICE in one block — nothing is
+				//     discarded, so there is nothing to report; distinctPools
+				//     is what makes that a redundancy rather than an error.
+				if names := rule.thenAuthored.distinctPools(); len(names) >= 2 {
+					return fmt.Errorf(
+						"%s-nat rule-set %q rule %q: one `then` block names %d different pools "+
+							"(%s), but a rule carries ONE translation action per mode — the FIRST "+
+							"is the one that takes effect and the rest are silently discarded "+
+							"before anything validates them, so the firewall translates "+
+							"differently from the configuration as written and nothing says so. "+
+							"Name one, or split them into separate rules",
+						kind, rs.Name, rule.Name, len(names), strings.Join(names, ", "))
+				}
 				switch n := natThenTerminalActionCount(rule.Then); {
 				case n == 0:
 					return fmt.Errorf(

--- a/pkg/config/nat_source_axis_sweep_6812_test.go
+++ b/pkg/config/nat_source_axis_sweep_6812_test.go
@@ -964,6 +964,20 @@ var walkRuleAxisExemptions6812 = mergeAxisExemptions6812(
 		"Rule.Then.Interface", "Rule.Then.Off",
 	),
 	fixtureConstantAxes6812(
+		"#7013 compile-time diagnostic state: what ONE `then` container authored, kept "+
+			"so validateNATTerminalActionCardinalityStrict can see a pool the resolved "+
+			"NATThen scalar already discarded. Constant at exactly one authored pool "+
+			"here because every rule in this fixture is plain pool-mode source NAT — in "+
+			"production it is 0 for an `interface` or `off` rule, so this is a real blind "+
+			"spot and NOT production-constant. It is registered rather than varied "+
+			"because nothing sorts or compares on it: it is read once by the strict gate "+
+			"and never reaches the dataplane. If that ever changes, vary it instead.\n"+
+			"Only the LENGTH columns are registered: the pool NAMES vary rule to rule "+
+			"here, so `.all`/`[0]` are guarded and registering them was rejected as "+
+			"over-reach by this table's own stale-entry check.",
+		"Rule.thenAuthored.Pools.len", "Rule.thenAuthored.Pools.nil",
+	),
+	fixtureConstantAxes6812(
 		"pool fields this fixture never configures. Address/Port/PortRaw are the DNAT "+
 			"compatibility scalars, PortRangeInvalidSpec is the #5457 rejected-range "+
 			"marker (every range here is valid), and no pool is routing-instance-scoped, "+

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -823,6 +823,20 @@ type NATRule struct {
 	Name  string
 	Match NATMatch
 	Then  NATThen
+	// thenAuthored is what ONE `then` container AUTHORED, before NATThen's
+	// scalar collapsed a repeat (#7013). NATThen carries the RESOLVED action —
+	// one pool name, one Off, one Interface — so by validation time a second
+	// authored pool is already gone and a gate that counts modes sees one. This
+	// is the occurrence state that makes the discard checkable.
+	//
+	// UNEXPORTED DELIBERATELY. It is compile-time diagnostic state, read only by
+	// validateNATTerminalActionCardinalityStrict, and it is not part of the
+	// dataplane contract. Exported, it joined the typed Config's JSON — it
+	// showed up as a golden diff across 19 cases and as an unregistered column
+	// in the #6812 axis sweep — and would have travelled in config-sync
+	// payloads. Unexported it stays inside the compiler, where the only thing
+	// that reads it lives.
+	thenAuthored natThenAuthored
 }
 
 // NATMatch defines what traffic a NAT rule matches.


### PR DESCRIPTION
Closes #7013

## The defect

`NATThen.PoolName` is a scalar, so a rule whose single `then` container names
two pools loses one during lowering. `validateNATTerminalActionCardinalityStrict`
counts **modes**, so it sees `n == 1` and does not fire: the config commits under
strict, the firewall translates through a pool the operator did not choose, and
nothing says so.

Implemented as the issue's **option 1** — a per-container record of what the
`then` block AUTHORED, kept beside the resolved `NATThen` and read only by the
strict gate. The resolved type and the dataplane contract are unchanged.

## What I measured before writing a fixture, and what it corrected

The issue body says the LAST pool survives; the correction on the issue says the
FIRST. Both describe one mechanism and there are two:

| spelling | tree carries | survivor | the defect? |
|---|---|---|---|
| `then destination-nat pool PD pool PD2` (packed run) | both | `PD` (first) | **yes** |
| `then { destination-nat { pool PD; pool PD2; } }` (braces) | both | `PD` (first) | **yes** |
| two separate `set … pool X` lines | **one** (`PD2`) | `PD2` | **no** |

The third row is not a collapse. A second `set` on a single-value leaf REPLACES
it in the candidate tree — only one pool ever reaches the compiler, and
`show configuration` displays exactly what will be enforced. Nothing is hidden,
so there is nothing for a commit gate to report, and rejecting it would break the
ordinary way an operator edits a pool. `TestSeparateSetLinesReplaceAndCommit_7013`
pins that by asserting the **tree**, not just the compile result, so the cell
records *why* the spelling is legal and flips if that ever stops being true.

Where the collapse does happen the FIRST authored pool wins, in both shapes. The
tests still assert **rejection**, never the survivor: a fixture built on the
survivor reds against a correct compiler and a buggy one alike, for opposite
reasons, and the instinct on seeing that red is to "fix" the assertion.

## Scope, and the three shapes deliberately left legal

The record is scoped to **one** `then` container, and that is the whole
correctness argument for not disturbing #3850/#7035:

- **Duplicate `then` CONTAINERS** — #3850 last-wins, whether they name the same
  pool or different actions.
- **Two separate `set` lines** — leaf replacement, per the table above.
- **The same pool named twice in one block** — `pool PD pool PD` discards
  nothing, so `distinctPools` makes it a redundancy rather than an error.

`off` and `interface` are not recorded at all: they carry no value, so repeating
either discards nothing. A rule mixing DIFFERENT modes is still caught by the
mode count that follows. **This does not close #7033** (packed *cross-mode*
contradictions still collapse to one field); `docs/config-schema.md` now says so
explicitly, because its standing claim that the gate counts only resolved fields
had become half-true.

## The record is unexported, and that was not cosmetic

`ThenAuthored` started exported. That put compile-time diagnostic state into the
typed Config's JSON — it changed `TestCompileGolden4406` across 19 cases and
appeared as an unregistered column in the #6812 axis sweep — and it would have
travelled in config-sync payloads to a peer, for state that is read once by the
strict gate and never reaches the dataplane. Unexported, the golden is untouched
and only the sweep (which reflects over unexported fields) still sees it.

## Three defects in this change were found by existing gates, not by review

1. `TestNATTerminalActionDupIdenticalPool3850_5628` — the first version summed
   occurrences **across** containers and false-rejected #3850's accepted
   last-wins config. Scope is now one container.
2. `TestDualASTDifferential/security-nat` — the same config recorded
   **differently depending on spelling**. Hierarchical fixtures write
   `pool { snat-pool; }`, with the name *below* the node; a Keys-only walk
   counted zero pools there and one for the flat-set spelling. The walk now
   resolves the name exactly as the compiler does (`nodeVal`: `Keys[1]`, else the
   FIRST child) — which also keeps Junos's `pool { P; persistent-nat { … } }` at
   one authored pool instead of two.
3. `TestSourceNatRepeatedModeRejected_7013` (mine) — the flat-set path builds a
   repeat as a **child** of the first pool node, not a sibling, because the
   second `pool` token opens a further path. A sibling-only walk missed the
   packed source-NAT spelling entirely.

The #6812 registry then rejected my first registration as **over-reach**: pool
NAMES vary rule to rule, so `.all`/`[0]` are guarded and only the LENGTH columns
belong in the table. Registered as `fixtureConstant` (**not** production-constant)
because the column varies in production — zero authored pools for an `interface`
or `off` rule — so the honest record is an admitted blind spot.

## Property vs precondition

Every assertion added here is the **property** (`CompileConfig` rejects / accepts,
and the message names both authored pools). The one precondition assertion is in
`TestSeparateSetLinesReplaceAndCommit_7013`, which checks the candidate tree
carries one pool before asserting the commit succeeds — labelled as such in the
test, because if that precondition ever inverts the case becomes a rejection.

## Validation

- `go test -count=1 ./pkg/config/` — ok
- `go test -count=1 ./...` — clean under a private `GOCACHE`: 68 packages ok, 0 failures
- **Mutation matrix, full-suite (no `-run` filter), control first.** Every cell
  restored from a backup and verified clean before the next.

| cell | mutation | named failing tests |
|---|---|---|
| CONTROL | none | 0 (green) |
| M1 | gate reverts to a mode count | `TestRepeatedSameModePoolRejected_7013`, `TestSourceNatRepeatedModeRejected_7013`, `TestHierarchicalRepeatedPoolRejected_7013` |
| M2 | count RAW occurrences, not distinct | `TestSamePoolTwiceInOneBlockCommits_7013` |
| M3 | sum the record ACROSS containers | `TestDuplicateThenContainersStillCommit_7013` |
| M4 | drop the nested-repeat descent | `TestRepeatedSameModePoolRejected_7013`, `TestSourceNatRepeatedModeRejected_7013`, `TestOccurrenceCounterSeesEveryShape_7013` |
| M5 | read the pool name from Keys only | `TestOccurrenceCounterSeesEveryShape_7013`, `TestDualASTDifferential` |
| M6 | count every child of a `pool` node | `TestOccurrenceCounterSeesEveryShape_7013` |
| M7 | wire the record at the DNAT site only | `TestSourceNatRepeatedModeRejected_7013`, `TestAggregateChargeOrderFollowsWithinRuleSetRuleOrder_6812` |
| M8 | name only the surviving pool | `TestRepeatedSameModePoolRejected_7013`, `TestSourceNatRepeatedModeRejected_7013`, `TestHierarchicalRepeatedPoolRejected_7013` |

No cell was a build break, and every cell collected tests.

**On a transient red I chased rather than reported.** A whole-repo `./...` run
showed reds in `pkg/cluster`, `pkg/daemon` and `pkg/rpm`. They were **not**
attributable to this change. At the time I recorded the cause as GOCACHE eviction
under lane contention; the actual cause was worse and is worth naming correctly:
the root filesystem hit **100% full** (`/home/ps/.cache/go-build` at 222 G across
all lanes' parallel gates), and the cache clean that recovered it landed
mid-run — which is why the errors read `could not import internal/abi: no such
file or directory`. Named failures in packages nowhere near the change is the
tell, and it is also exactly what a real cross-package regression looks like, so
the tell is not sufficient on its own. Under a private `GOCACHE` those three
packages are green **both** at pristine `origin/master` and on this branch, in
isolation and at package scope.

I chased it rather than dropping it because this change *could* plausibly have
caused it: a new strict rejection would fail any fixture elsewhere that authors
two pools in one block. None does.

**The whole matrix was then re-run (R2) after the incident** — fresh log paths,
never overwriting the first run's, and a private `GOCACHE` so another lane's
cache clean cannot void a cell. Every R2 cell reproduces the table above exactly,
cell for cell and test for test, with `no space left` = 0, build breaks = 0 and
tests-collected > 0 in all nine. The R1 logs also scan clean on the same
discriminators, so the first matrix was not itself an artifact — but the window
overlapped, so it was re-run rather than argued for.

No cluster smoke: this change is confined to the config compiler and touches no
forwarding, HA, session-sync or failover code.
