### PR TITLE
userspace-dp: document EgressInterface::zone_id as a debug-only mirror

### DIFF
--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -3037,6 +3037,101 @@ fn ifindex_to_zone_id_populated_from_snapshot_at_build_time() {
     assert_eq!(state.ifindex_to_zone_id.get(&42).copied(), Some(7));
 }
 
+/// #7025: `EgressInterface::zone_id` is a MIRROR of
+/// `ifindex_unambiguous_zone_id`, and must stay one.
+///
+/// The field has no production reader in a default build — deleting it yields
+/// seven `E0609` reads, all in test files; `--features debug-log` adds exactly
+/// one, the `FWD_STATE: egress[..]` dump. It is retained so that debug line is
+/// self-describing, and this cell is what stops it from becoming the "stale
+/// copy that looks like a second opinion" #7025 was filed about: a future edit
+/// that sources it from anywhere but the ledger reds here.
+///
+/// THE TABLE NEEDS BOTH ROWS. A fixture whose interfaces all resolve to zone 0
+/// cannot distinguish a correct mirror from a field hardcoded to 0 — every
+/// comparison passes. So the snapshot carries a ZONED interface (non-zero) and
+/// an UNZONED one (zero), and the cell asserts both cases occur before
+/// comparing.
+///
+/// WHAT IT CATCHES, MEASURED — and what it does NOT, which matters more.
+///
+/// Severing the mirror (`zone_id` hardcoded to 0) reds this cell. It also reds
+/// FOUR pre-existing tests, so on that mutation this cell is not the only guard.
+///
+/// Re-pointing `populate_egress` at the row-derived `ifindex_to_zone_id` — the
+/// map #6722 replaced, and the realistic regression — reds two pre-existing
+/// tests (`unzoned_iface_tunnel_unit_does_not_inherit_a_siblings_zone_via_egress_row_6722`
+/// and `unzoned_interface_with_egress_row_stays_zone_zero_6713`) and does NOT
+/// red this one. That is a property of the FIXTURE: the two maps agree for both
+/// interfaces here, so the mutation is a no-op on this input. An earlier
+/// revision of this comment claimed the opposite; it was measured and was
+/// wrong, and it is recorded rather than quietly corrected because a guard's
+/// stated scope is a claim like any other.
+///
+/// So what this cell adds is not extra coverage of those two mutations — it is
+/// the STRUCTURAL invariant, asserted over every egress row rather than over a
+/// fixture's expected zone values. The pre-existing tests pin what specific
+/// interfaces should resolve to; this pins that the field and
+/// `egress_zone_id()` can never disagree, which is the property the doc on the
+/// field promises a reader.
+#[test]
+fn egress_zone_id_mirrors_the_unambiguous_ledger_7025() {
+    use crate::ZoneSnapshot;
+    let snapshot = ConfigSnapshot {
+        zones: vec![ZoneSnapshot {
+            name: "wan".into(),
+            id: 11,
+            ..Default::default()
+        }],
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "ge-0/0/1".into(),
+                zone: "wan".into(),
+                egress_zone: "wan".into(),
+                ifindex: 99,
+                hardware_addr: "02:00:00:00:00:99".into(),
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "ge-0/0/2".into(),
+                ifindex: 77,
+                hardware_addr: "02:00:00:00:00:77".into(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+
+    // Precondition: BOTH cases are present, or the comparison below is
+    // satisfied by everything being zero.
+    let zoned = state.egress.get(&99).expect("zoned egress row");
+    let unzoned = state.egress.get(&77).expect("unzoned egress row");
+    assert_ne!(
+        zoned.zone_id, 0,
+        "fixture invalid: the zoned interface resolved to zone 0, so this cell \
+         would compare 0 against 0 for every row and pass against a field \
+         hardcoded to 0 (#7025)"
+    );
+    assert_eq!(
+        unzoned.zone_id, 0,
+        "fixture invalid: the unzoned interface must resolve to 0, so the table \
+         covers both sides of the mirror"
+    );
+
+    for (ifidx, eg) in &state.egress {
+        assert_eq!(
+            eg.zone_id,
+            state.egress_zone_id(*ifidx),
+            "EgressInterface::zone_id for ifindex {ifidx} disagrees with \
+             ForwardingState::egress_zone_id. The field is a DEBUG-ONLY MIRROR of \
+             ifindex_unambiguous_zone_id (#7025) and the debug dump renders a \
+             zone name from it — a divergence prints a zone the dataplane is not \
+             using, which is worse than printing nothing"
+        );
+    }
+}
+
 /// #921: EgressInterface.zone_id is set from the snapshot at
 /// config build time.
 #[test]

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -966,10 +966,38 @@ pub(in crate::afxdp) struct EgressInterface {
     pub(in crate::afxdp) vlan_id: u16,
     pub(in crate::afxdp) mtu: usize,
     pub(in crate::afxdp) src_mac: [u8; 6],
-    /// #921: u16 zone ID (was `zone: String`). Resolved at config
-    /// build time via `zone_name_to_id`; `0` means "unknown" (the
-    /// zone wasn't in the snapshot's zones list, or had a reserved
-    /// id and was dropped).
+    /// #921: u16 zone ID (was `zone: String`). `0` means "unknown".
+    ///
+    /// #7025: THIS IS A DEBUG-ONLY MIRROR OF
+    /// [`ForwardingState::ifindex_unambiguous_zone_id`], NOT a second opinion on
+    /// the egress zone. Do not reach for it when you want the egress zone —
+    /// call [`ForwardingState::egress_zone_id`], which reads the ledger.
+    ///
+    /// Before #6722 this field WAS the answer: `egress_zone_id` was
+    /// `state.egress.get(&ifx).map(|i| i.zone_id)`. #6722 moved the answer into
+    /// the ledger and pointed both `egress_zone_id` and `populate_egress` at it,
+    /// so the two are equal by construction — `populate_egress` writes this
+    /// field with the identical `ifindex_unambiguous_zone_id.get(..).unwrap_or(0)`
+    /// expression `egress_zone_id` evaluates.
+    ///
+    /// The reader census is the COMPILER's, not a grep's: deleting this field
+    /// and building the crate yields, in a DEFAULT build, seven `E0609` field
+    /// reads and every one of them is in a test file — zero production readers.
+    /// Building `--features debug-log` adds exactly one,
+    /// `forwarding_build/mod.rs`'s `FWD_STATE: egress[..]` dump, which is
+    /// compiled out of a normal build. That is why the field is retained with
+    /// this note rather than dropped: the only thing it does is make one debug
+    /// line self-describing, and removing it would rewrite 66 struct literals,
+    /// 63 of them in unrelated test fixtures, to delete a value that cannot
+    /// currently be wrong.
+    ///
+    /// "Cannot currently be wrong" is enforced, not asserted:
+    /// `egress_zone_id_mirrors_the_unambiguous_ledger_7025` fails if the two
+    /// ever diverge, so the drift this note warns a reader about cannot be
+    /// introduced silently. That cell pins the INVARIANT over every egress row;
+    /// specific expected zone values for specific shapes are pinned separately
+    /// by the #6713/#6722 cells, and its own doc records which mutations each
+    /// of them catches rather than assuming the new one is the only guard.
     pub(in crate::afxdp) zone_id: u16,
     pub(in crate::afxdp) redundancy_group: i32,
     pub(in crate::afxdp) primary_v4: Option<Ipv4Addr>,


### PR DESCRIPTION
Closes #7025

## The census is the COMPILER's, not a grep's

The issue's enumeration was taken at `413c6818c` and names eleven files. A
twelfth caller added since would be invisible to re-checking that list, so the
predicate was re-derived by **deleting the field and letting the compiler
enumerate every reader**:

```
default build          7 E0609 field reads — every one in a test file
                       -> ZERO production readers
--features debug-log   8 reads; the one addition is forwarding_build/mod.rs's
                       `FWD_STATE: egress[..]` dump, compiled out of a normal build
```

That confirms the issue by a method that cannot miss a caller, and it is why the
`debug-log` build had to be run at all: the sole production reader does not exist
in a default one.

**RE-RUN after the box hit 100% disk**, on fresh log paths with 231 G free,
because a `rustc` that dies mid-compile truncates its own error list — and an
under-counted census would have understated the readers, which is the direction
that would make this PR wrong:

```
default_r2     space_errors=0  reads=10  NON-test=0
debug-log_r2   space_errors=0  reads=11  NON-test=1  [forwarding_build/mod.rs:841]
```

The counts moved 7→10 and 8→11 for a reason that is not drift: the re-run
includes this PR's own new test, which reads the field three times. The
load-bearing figures — **zero** production readers by default, **exactly one**
under `debug-log`, and its identity — are unchanged. Both original logs were
also checked directly and carry `space_errors=0` and a complete rustc
terminator, so neither was truncated.

## Keep, not drop — argued on measured cost

The debug dump *does* read naturally from the ledger (it already holds `ifidx` in
the same loop), so dropping is viable. What decides it is the other side:
removing the field rewrites **66 struct literals, 63 of them in unrelated test
fixtures** — `EgressInterface` derives no `Default`, so every literal names every
field — to delete a value that cannot currently be wrong. `populate_egress`
writes it with the identical `ifindex_unambiguous_zone_id.get(..).unwrap_or(0)`
expression `egress_zone_id` evaluates.

## What neither option in the issue had

A doc line asks the next reader to believe the field is a mirror; it does not
stop the drift it warns about. `egress_zone_id_mirrors_the_unambiguous_ledger_7025`
pins the invariant `eg.zone_id == state.egress_zone_id(ifidx)` over **every**
egress row.

The cell carries both rows: a fixture whose interfaces all resolve to zone 0
cannot distinguish a correct mirror from a field hardcoded to 0, so the snapshot
carries a zoned interface and an unzoned one and both cases are asserted present
before the comparison runs.

## Mutation matrix — whole crate, `--test-threads=1`

| cell | rc | tests passed | named failing | which |
|---|---|---|---|---|
| control | 0 | **4885** | 0 | — |
| J1 field stops mirroring the ledger (hardcoded 0) | 101 | 4811 | 5 | this cell **+ 4 pre-existing** |
| J2 sourced from the row-derived `ifindex_to_zone_id` | 101 | 4814 | 2 | **neither is this cell** — `unzoned_iface_tunnel_unit_does_not_inherit_a_siblings_zone_via_egress_row_6722`, `unzoned_interface_with_egress_row_stays_zone_zero_6713` |

### J2 falsified a claim I had already written, and the correction is in the tree

The first revision of the cell's doc said it reds on exactly that mutation — "the
row-order-dependent lookup #6722 replaced is the realistic regression". **It does
not.** The two maps agree for both interfaces in this fixture, so J2 is a no-op
on this input, and two pre-existing tests catch it instead. The doc comment now
records that, including the fact that an earlier revision claimed the opposite —
a guard's stated scope is a claim like any other, and quietly correcting it would
have left the next reader with the same wrong impression the field itself gave.

So this cell's contribution is **not** extra coverage of those mutations; it is
the structural invariant over all rows, where the pre-existing cells pin expected
values for specific shapes. Stated that way rather than as novelty I did not
measure.

### Two cells were VOID before this table

The first J1/J2 run came back `tests_passed=0`, classified **BUILD-BREAK** by the
gate rather than scored: `No space left on device (os error 28)` — the per-cell
`CARGO_TARGET_DIR`s had filled the disk. Re-run on a shared target dir after
reclaiming ~16G of my own scratch. The gate's tests-collected discriminator is
what kept those from being read as greens.

## Gates

Rust whole crate `rc=0`, 4755 passed. `--features debug-log` build clean — the
one production reader is only compiled there. Modularity gate
(`pkg/refactoraudit`) ok. Non-runtime: no behaviour change in either feature
configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
