### PR TITLE
nat64: validate the frag authority's ingress zone override

### DIFF
--- a/docs/log/7050.md
+++ b/docs/log/7050.md
@@ -1,0 +1,39 @@
+# docs/log/7050.md — #7050 (frag_ingress_authority zone-override validation)
+
+- **Timestamp**: 2026-08-28
+- **Action**: Validate `ingress_zone_override` against `zone_id_to_name` in
+  `frag_ingress_authority`, matching both sibling consumers.
+- **File(s)**:
+  - `userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs`
+  - `userspace-dp/src/afxdp/tests_fabric_zone_stamp.rs`
+
+## Why fix an unreachable divergence
+
+The issue refutes its own reachability: the sole production binding of
+`ingress_zone_override` comes from
+`parse_zone_encoded_fabric_ingress_from_frame`, which already rejects an id
+absent from `zone_id_to_name`, and every later shadow can only narrow
+`Some -> None`.
+
+So this is not a bug fix. It makes the three consumers agree **by construction**
+rather than by a property of one producer — a property a fourth producer would
+not have to share, and which nothing states as a contract.
+
+## The over-suppression guard already existed
+
+The fix is a filter, so the cell that matters is the one proving it does not drop
+every override. `fabric_frag_association_is_scoped_by_the_stamped_zone` already
+asserts exactly that, in those words: *"RED when the override stops reaching
+frag_ingress_authority, because both authorities then fall back to the fabric
+interface's own zone and compare EQUAL."* The new test restates it locally so the
+failure localises, but the pre-existing guard is what made this change safe to
+make at all.
+
+## Both premises are asserted
+
+That the two ids really are unknown (otherwise the test compares two honored
+overrides and passes for the wrong reason), and that `TEST_LAN_ZONE_ID` really is
+configured (otherwise the positive control is vacuous and the test degenerates
+into "nothing is ever honored"). The final `assert_ne!` guards the case where the
+fixture's own ingress zone equals the control zone, which would make the control
+unable to tell an honored override from the fallback.

--- a/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
@@ -41,7 +41,25 @@ pub(in crate::afxdp) fn frag_ingress_authority(
     // override wins, else the LOGICAL unit's configured zone (#5802). An
     // unzoned ingress resolves to 0, which is itself a distinct authority —
     // an unzoned interface must not inherit a zoned interface's permit.
+    //
+    // The override is VALIDATED against zone_id_to_name before it wins (#7050),
+    // the same way both sibling consumers of this value do it —
+    // prerouting_ingress_scope resolves id->name and falls through on a miss,
+    // filter_log_ingress_zone_id applies this exact `contains_key` filter. Taking
+    // it raw made the association key and enforcement disagree: enforcement
+    // normalizes an unknown id away and uses the logical unit's configured zone,
+    // while this stamped the raw id, so two fragments of ONE datagram carrying
+    // two DIFFERENT unknown ids built two different keys — an over-scope whose
+    // miss is a fail-closed drop — for a datagram enforcement treats as one
+    // domain.
+    //
+    // Not reachable today: the sole production binding of ingress_zone_override
+    // comes from parse_zone_encoded_fabric_ingress_from_frame, which already
+    // rejects an id absent from zone_id_to_name, and every later shadow can only
+    // narrow Some -> None. This closes the gap at the consumer so the three
+    // consumers agree by construction rather than by a property of one producer.
     let zone = ingress_zone_override
+        .filter(|id| forwarding.zone_id_to_name.contains_key(id))
         .or_else(|| forwarding.ifindex_to_zone_id.get(&logical).copied())
         .unwrap_or(0);
     crate::nat64::FragAuthority {

--- a/userspace-dp/src/afxdp/tests_fabric_zone_stamp.rs
+++ b/userspace-dp/src/afxdp/tests_fabric_zone_stamp.rs
@@ -745,3 +745,95 @@ fn frag_assoc_authority_binds_the_fabric_zone_stamp_5798() {
          one of their own"
     );
 }
+
+/// #7050: an ingress_zone_override that names a zone the snapshot does not
+/// carry must NOT reach `FragAuthority.ingress_zone` raw.
+///
+/// The defect was a disagreement between the association key and enforcement.
+/// Both sibling consumers of this value validate the override against
+/// `zone_id_to_name` — `prerouting_ingress_scope` resolves id->name and falls
+/// through on a miss, `filter_log_ingress_zone_id` applies a `contains_key`
+/// filter — so for an unknown id enforcement normalizes it away and uses the
+/// logical unit's configured zone. `frag_ingress_authority` took it verbatim, so
+/// two fragments of ONE datagram carrying two DIFFERENT unknown ids built two
+/// DIFFERENT keys. That over-scopes: the second fragment misses the association
+/// and is dropped fail-closed, for a datagram enforcement treats as one domain.
+///
+/// Not reachable in production today — the sole binding of the override comes
+/// from `parse_zone_encoded_fabric_ingress_from_frame`, which already rejects an
+/// unknown id, and every later shadow can only narrow `Some -> None`. This test
+/// therefore guards the CONSUMER's own contract, so the three consumers agree by
+/// construction rather than by a property of one producer that a fourth producer
+/// would not have to share.
+///
+/// Both directions are asserted. Checking only that two unknown ids now agree
+/// would pass against an implementation that ignored the override entirely, and
+/// checking only that a known override still wins would pass against the
+/// unvalidated code this replaces.
+#[test]
+fn unknown_zone_override_does_not_reach_the_frag_authority_7050() {
+    let forwarding = build_forwarding_state(&frag_stamp_snapshot());
+    let meta = stamped_fabric_frag_meta();
+
+    const UNKNOWN_A: u16 = 65000;
+    const UNKNOWN_B: u16 = 65001;
+
+    // PREMISE. If either id were configured this test would be comparing two
+    // honored overrides and would pass for the wrong reason.
+    assert!(
+        !forwarding.zone_id_to_name.contains_key(&UNKNOWN_A)
+            && !forwarding.zone_id_to_name.contains_key(&UNKNOWN_B),
+        "premise broken: the fixture now configures one of the ids this test needs to be \
+         UNKNOWN, so it can no longer distinguish a validated override from a raw one"
+    );
+    // PREMISE. A known id must be present, or the positive control below is
+    // vacuous and this test degenerates into "nothing is ever honored".
+    assert!(
+        forwarding.zone_id_to_name.contains_key(&TEST_LAN_ZONE_ID),
+        "premise broken: TEST_LAN_ZONE_ID is not configured in this fixture, so the \
+         positive control cannot show that a VALID override still wins"
+    );
+
+    let authority = |o: Option<u16>| {
+        crate::afxdp::poll_descriptor::frag_assoc::frag_ingress_authority(&forwarding, meta, o)
+    };
+
+    let none = authority(None);
+    let a = authority(Some(UNKNOWN_A));
+    let b = authority(Some(UNKNOWN_B));
+
+    // THE DEFECT: two fragments of one datagram, two unknown ids, one authority.
+    assert_eq!(
+        a, b,
+        "two DIFFERENT unknown zone overrides still build DIFFERENT frag authorities, so the \
+         second fragment of a datagram misses the association the first installed and is \
+         dropped fail-closed — while enforcement, which normalizes both ids away, treats the \
+         two as the same domain (a={a:?} b={b:?})"
+    );
+    // And the value they collapse ONTO is the fallback, not some third answer:
+    // an unknown override must be indistinguishable from no override at all.
+    assert_eq!(
+        a, none,
+        "an unknown override produced an authority differing from the no-override one, so it \
+         is still contributing to the key. It must fall through to the LOGICAL unit's \
+         configured zone, which is what enforcement does with it (a={a:?} none={none:?})"
+    );
+
+    // POSITIVE CONTROL, and the reason this is not simply `override.take()`: a
+    // CONFIGURED override must still win. Without this row the assertions above
+    // are satisfied by ignoring the parameter, which would silently undo the
+    // fabric zone stamp that
+    // `fabric_frag_association_is_scoped_by_the_stamped_zone` exists to protect.
+    let known = authority(Some(TEST_LAN_ZONE_ID));
+    assert_eq!(
+        known.ingress_zone, TEST_LAN_ZONE_ID,
+        "a VALID zone override no longer reaches the frag authority: the validation went too \
+         far and now drops every override, collapsing the fabric zone stamp"
+    );
+    assert_ne!(
+        known.ingress_zone, none.ingress_zone,
+        "the fixture's configured ingress zone equals TEST_LAN_ZONE_ID, so the positive \
+         control cannot tell an honored override from the fallback. Pick an override zone the \
+         fabric interface does not already resolve to"
+    );
+}


### PR DESCRIPTION
Closes #7050

`frag_ingress_authority` took `ingress_zone_override` verbatim while **both**
sibling consumers of the same value validate it against `zone_id_to_name` —
`prerouting_ingress_scope` resolves id→name and falls through on a miss,
`filter_log_ingress_zone_id` applies a `contains_key` filter.

For an id absent from `zone_id_to_name` that made the association key and
enforcement disagree: enforcement normalizes the unknown id away and uses the
logical unit's configured zone, while `frag_ingress_authority` stamped the raw
id. Two fragments of **one** datagram carrying two **different** unknown ids
therefore built two different keys — an over-scope whose miss is a fail-closed
drop — for a datagram enforcement treats as a single domain.

## Why fix something the issue itself proves unreachable

The issue refutes its own reachability, and it is right: the sole production
binding of the override comes from `parse_zone_encoded_fabric_ingress_from_frame`,
which already rejects an unknown id, and every later shadow can only narrow
`Some -> None`.

So this is not a bug fix. It makes the three consumers agree **by construction**
rather than by a property of one producer — a property nothing states as a
contract and that a fourth producer would not inherit.

## The over-suppression guard already existed, which is what made this safe

The fix is a filter, so the cell that matters is the one proving it does not drop
*every* override. `frag_assoc_authority_binds_the_fabric_zone_stamp_5798` already
asserts exactly that, in those words:

> RED when the override stops reaching `frag_ingress_authority`, because both
> authorities then fall back to the fabric interface's own zone and compare EQUAL

## Mutation matrix

`--test-threads=1`, per-cell `CARGO_TARGET_DIR` under `/var/tmp`.

| cell | mutation | collected | reds |
|---|---|---|---|
| M1 | revert the filter (**under**-suppress) | 1 | `unknown_zone_override_does_not_reach_the_frag_authority_7050` only |
| M2 | `.filter(\|_\| false)` (**over**-suppress) | 4758 | `frag_assoc_authority_binds_the_fabric_zone_stamp_5798` **and** the new test's positive control |

M1's failure message carries the defect verbatim:

```
a=FragAuthority { ..., ingress_zone: 65000, ... }
b=FragAuthority { ..., ingress_zone: 65001, ... }
```

The two cells together are what prove the filter is necessary **and** sufficient:
a lone delete-the-guard cell shows only correlation.

## Both premises are asserted, for reasons

- The two ids really are **unknown** — otherwise the test compares two honored
  overrides and passes for the wrong reason.
- `TEST_LAN_ZONE_ID` really is **configured** — otherwise the positive control is
  vacuous and the test degenerates into "nothing is ever honored".
- The fixture's own ingress zone **differs** from the control zone — otherwise the
  control cannot tell an honored override from the fallback.

The test also asserts that the value two unknown ids collapse *onto* is the
no-override fallback, not some third answer — an unknown override must be
indistinguishable from no override at all, which is what enforcement does.