### PR TITLE
api: stop the rename stale-cert WARN firing on a loopback-only bind

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1636,7 +1636,27 @@ the drop fails loudly instead of going quietly vacuous.
         domain-qualified SAN next to a short kernel name means the TLS identity
         is independent of it — stay quiet. The RENAME entry point skips that
         heuristic: the operator just chose the name, which is direct evidence
-        rather than inference. **Accepted residual:** a rename that CROSSES the
+        rather than inference.
+        **BOTH entry points are gated on the listener being remotely reachable
+        (`bindIsLoopbackOnly`, #7039).** On a loopback-only HTTPS bind — which is
+        what `set system services web-management https` with no `interface`
+        resolves to, `127.0.0.1:443` — there is no remote client, so nothing can
+        verify by host name and a re-mint would fix nothing. The bind-host half
+        above already declined there (`bindHostWarnable("127.0.0.1")` is false);
+        the host-name half had no equivalent gate, so every `set system
+        host-name` on a loopback-bound management plane warned about clients that
+        cannot exist. That is the failure mode this whole heuristic exists to
+        prevent, arriving through the door it left open. The gate is a property
+        of the BIND, not of the name, so it composes with the rename path's
+        direct evidence rather than contradicting it.
+        **It is deliberately NOT `!bindHostWarnable`.** Those two answer
+        different questions and disagree on the wildcard binds: `0.0.0.0` and
+        `::` are `bindHostWarnable == false` — because they name no single host,
+        not because they are unreachable — so suppressing on the complement would
+        silence the diagnostic on the most remotely-reachable listener there is.
+        `TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039` pins the
+        divergence, and the wildcard binds appear as MUST-STILL-WARN cells beside
+        the loopback silence cells so the suppression cannot widen unnoticed. **Accepted residual:** a rename that CROSSES the
         qualified/unqualified boundary is diagnosed at the commit but not on any
         later boot, so it is never diagnosed at all in the two states that had
         no commit-time diagnosis behind them — a box already drifted before this

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1351,6 +1351,44 @@ func bindHostWarnable(bindHost string) bool {
 	return true
 }
 
+// bindIsLoopbackOnly reports whether the HTTPS management listener can be
+// reached ONLY from this host, so no REMOTE client exists to verify anything by
+// host name (#7039).
+//
+// NOT `!bindHostWarnable(bindHost)`. That is the obvious drop-in and it is
+// wrong, because the two functions answer different questions and disagree on
+// the most remote-reachable bind there is:
+//
+//	bindHost        bindHostWarnable   bindIsLoopbackOnly
+//	""              false              false
+//	"localhost"     false              TRUE
+//	"127.0.0.1"     false              TRUE
+//	"::1"           false              TRUE
+//	"0.0.0.0"       false              false   <-- reachable from everywhere
+//	"::"            false              false   <-- reachable from everywhere
+//	"10.0.0.1"      TRUE               false
+//
+// `bindHostWarnable` asks "is there a single concrete host here worth warning
+// about if the cert misses it" — a WILDCARD bind answers no, because it names no
+// one host, not because it is unreachable. Suppressing the host-name diagnostic
+// on `!bindHostWarnable` would therefore silence it on `0.0.0.0`, where remote
+// clients certainly do exist and the host name certainly is an access identity.
+// That is over-suppression of exactly the case the diagnostic is FOR.
+// `TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039` pins the divergence.
+//
+// An empty bindHost is NOT treated as loopback: the listener address could not
+// be parsed, and suppressing a diagnostic on unknown state is the wrong
+// direction to fail.
+func bindIsLoopbackOnly(bindHost string) bool {
+	if bindHost == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(bindHost); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 // hostnameSANWarnable reports whether the CURRENT kernel host name is an
 // identity worth warning about when a loaded on-disk cert does not cover it.
 //
@@ -1591,6 +1629,23 @@ func warnStaleBindHost(leaf *x509.Certificate, bindHost string) {
 func warnStaleHostName(leaf *x509.Certificate, hostName, bindHost string, ev hostNameEvidence) {
 	if !hostnameSANWarnable(hostName) || hostName == bindHost {
 		return // uncoverable by any re-mint, or already reported as the bind host
+	}
+	// #7039: a loopback-only listener has no remote client, so nothing can
+	// verify by host name and a re-mint would fix nothing. The bind-host half of
+	// this same diagnostic already declines here — bindHostWarnable("127.0.0.1")
+	// is false — and the host-name half had no equivalent gate, so every
+	// `set system host-name` on a loopback-bound management plane warned about
+	// clients that cannot exist. That is the failure mode
+	// hostNameLikelyAccessIdentity's own doc block exists to prevent: a
+	// diagnostic that fires on a healthy box gets muted, and the true positive
+	// dies with it.
+	//
+	// Placed BEFORE the evidence gate on purpose. This is a property of the
+	// BIND, not of the name, so it composes with hostNameOperatorSet rather than
+	// contradicting it: an operator who deliberately renames a loopback-only
+	// device still has no remote client to break.
+	if bindIsLoopbackOnly(bindHost) {
+		return
 	}
 	if ev == hostNameInferred && !hostNameLikelyAccessIdentity(leaf, hostName) {
 		return

--- a/pkg/api/tls_stale_cert_6827_test.go
+++ b/pkg/api/tls_stale_cert_6827_test.go
@@ -1497,22 +1497,28 @@ func TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039(t *testing.T) {
 		{"10.0.0.1", true, false},
 		{"fw.example.com", true, false},
 	}
-	diverged := false
+	// Anti-vacuity backstop. It is NOT enough that SOME row has both predicates
+	// false: the empty bindHost does too, and that row is a parse FAILURE, not a
+	// reachable listener. The claim this table exists to support is specifically
+	// that a WILDCARD bind — reachable from everywhere — is suppressed by the
+	// `!bindHostWarnable` drop-in and not by this predicate. So the backstop
+	// requires a row that actually parses as an unspecified address.
+	divergedOnWildcard := false
 	for _, tc := range cases {
 		gotW, gotL := bindHostWarnable(tc.bindHost), bindIsLoopbackOnly(tc.bindHost)
 		if gotW != tc.wantWarnable || gotL != tc.wantLoopbackOnly {
 			t.Errorf("bindHost %q: bindHostWarnable=%v (want %v) bindIsLoopbackOnly=%v (want %v)",
 				tc.bindHost, gotW, tc.wantWarnable, gotL, tc.wantLoopbackOnly)
 		}
-		// A bind where BOTH are false is one the drop-in would suppress and this
-		// predicate does not — the over-suppression the pairing above catches.
-		if !gotW && !gotL {
-			diverged = true
+		ip := net.ParseIP(tc.bindHost)
+		if ip != nil && ip.IsUnspecified() && !gotW && !gotL {
+			divergedOnWildcard = true
 		}
 	}
-	if !diverged {
-		t.Fatal("no case had bindHostWarnable=false AND bindIsLoopbackOnly=false, so " +
-			"this table no longer demonstrates that `!bindHostWarnable` would " +
-			"over-suppress — the wildcard binds are the point of it (#7039)")
+	if !divergedOnWildcard {
+		t.Fatal("no WILDCARD bind (an address that parses and is unspecified) had " +
+			"bindHostWarnable=false AND bindIsLoopbackOnly=false, so this table no " +
+			"longer demonstrates that the `!bindHostWarnable` drop-in would " +
+			"over-suppress the most remote-reachable listener there is (#7039)")
 	}
 }

--- a/pkg/api/tls_stale_cert_6827_test.go
+++ b/pkg/api/tls_stale_cert_6827_test.go
@@ -1403,3 +1403,116 @@ func TestServeBoundSeversInFlightResponses_6827(t *testing.T) {
 	// one statement to a bare Shutdown left both packages green.
 	assertConnSevered(t, tlsConn, "HTTPS leg: "+severed)
 }
+
+// #7039: the rename-path host-name WARN fired on a loopback-only HTTPS bind,
+// where the BIND-HOST half of the same diagnostic already declines
+// (`bindHostWarnable("127.0.0.1")` is false). On that plane no remote client
+// exists, so nothing can verify by host name and a re-mint would fix nothing.
+//
+// THE FIX IS A SUPPRESSION, so the cells that matter are the ones proving it did
+// not over-suppress. A test showing only "loopback no longer warns" is satisfied
+// by deleting the warning outright, so every silence cell below is paired with a
+// bind on which the warning MUST still fire, through the same call, with every
+// other condition held identical.
+func TestLoopbackOnlyBindSuppressesTheRenameHostNameWarn_7039(t *testing.T) {
+	// A cert covering the OLD name plus the loopback SANs the mint path always
+	// adds — the shape a loopback-bound appliance actually serves.
+	for _, bind := range []string{"127.0.0.1:443", "[::1]:443", "localhost:443"} {
+		t.Run("silent_on_"+bind, func(t *testing.T) {
+			s := legServing(mintCert(t, "old-fw", "127.0.0.1"), bind)
+			out := captureWarn(t, func() { s.WarnStaleMgmtCertForHostName("new-fw") })
+			if strings.Contains(out, hostNameMsg) {
+				t.Fatalf("a rename on a LOOPBACK-only management bind warned about "+
+					"clients verifying by host-name, but no remote client exists on "+
+					"that plane — this is the diagnostic firing on a healthy box, "+
+					"which is how the true positive gets muted (#7039); got %q", out)
+			}
+		})
+	}
+
+	// THE PAIRED CELLS. Same call, same cert shape, same rename — only the bind
+	// differs, and on each of these the warning MUST still fire.
+	for _, tc := range []struct {
+		name, bind, why string
+	}{
+		{
+			"routable_ip", "10.0.0.1:8443",
+			"a routable management bind has remote clients, and the host name is " +
+				"exactly the identity they would verify",
+		},
+		{
+			// The cell that separates this fix from the obvious drop-in.
+			// bindHostWarnable("0.0.0.0") is FALSE, so suppressing on
+			// !bindHostWarnable would silence the diagnostic on the most
+			// remote-reachable bind there is.
+			"wildcard_v4", "0.0.0.0:8443",
+			"a WILDCARD bind is reachable from every interface. bindHostWarnable " +
+				"answers false for it — because it names no single host, not because " +
+				"it is unreachable — so a fix written as !bindHostWarnable would " +
+				"suppress precisely the case the diagnostic exists for",
+		},
+		{
+			"wildcard_v6", "[::]:8443",
+			"the v6 wildcard, same reasoning as 0.0.0.0",
+		},
+	} {
+		t.Run("still_warns_on_"+tc.name, func(t *testing.T) {
+			s := legServing(mintCert(t, "old-fw", "127.0.0.1"), tc.bind)
+			out := captureWarn(t, func() { s.WarnStaleMgmtCertForHostName("new-fw") })
+			if !strings.Contains(out, hostNameMsg) {
+				t.Fatalf("OVER-SUPPRESSED: a rename on %s must still warn — %s. "+
+					"got %q", tc.bind, tc.why, out)
+			}
+			if !strings.Contains(out, "new-fw") {
+				t.Fatalf("the surviving warning must still name the NEW host name; got %q", out)
+			}
+		})
+	}
+}
+
+// #7039: `bindIsLoopbackOnly` is NOT the complement of `bindHostWarnable`, and
+// this pins the divergence rather than leaving it to a comment.
+//
+// The two answer different questions — "can only this host reach the listener"
+// versus "is there a single concrete host worth warning about" — and they
+// disagree on the wildcard binds, which is the disagreement that matters: a fix
+// written as `!bindHostWarnable(bindHost)` would silence the host-name
+// diagnostic on `0.0.0.0`.
+//
+// If someone later makes them coincide, this fails and they have to decide
+// deliberately rather than discovering it through a muted warning.
+func TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039(t *testing.T) {
+	cases := []struct {
+		bindHost         string
+		wantWarnable     bool
+		wantLoopbackOnly bool
+	}{
+		{"", false, false},
+		{"localhost", false, true},
+		{"127.0.0.1", false, true},
+		{"127.0.0.53", false, true},
+		{"::1", false, true},
+		{"0.0.0.0", false, false},
+		{"::", false, false},
+		{"10.0.0.1", true, false},
+		{"fw.example.com", true, false},
+	}
+	diverged := false
+	for _, tc := range cases {
+		gotW, gotL := bindHostWarnable(tc.bindHost), bindIsLoopbackOnly(tc.bindHost)
+		if gotW != tc.wantWarnable || gotL != tc.wantLoopbackOnly {
+			t.Errorf("bindHost %q: bindHostWarnable=%v (want %v) bindIsLoopbackOnly=%v (want %v)",
+				tc.bindHost, gotW, tc.wantWarnable, gotL, tc.wantLoopbackOnly)
+		}
+		// A bind where BOTH are false is one the drop-in would suppress and this
+		// predicate does not — the over-suppression the pairing above catches.
+		if !gotW && !gotL {
+			diverged = true
+		}
+	}
+	if !diverged {
+		t.Fatal("no case had bindHostWarnable=false AND bindIsLoopbackOnly=false, so " +
+			"this table no longer demonstrates that `!bindHostWarnable` would " +
+			"over-suppress — the wildcard binds are the point of it (#7039)")
+	}
+}

--- a/pkg/daemon/hostname_stale_cert_6827_test.go
+++ b/pkg/daemon/hostname_stale_cert_6827_test.go
@@ -983,14 +983,23 @@ func TestDebtClearIsGenerationSafe_6827(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		want := m.committedDesired(nil)
-		httpOnly := want
-		httpOnly.TLS, httpOnly.HTTPSAddr = false, ""
+		// #7039: bind the management plane to a ROUTABLE address.
+		//
+		// This subtest is about GENERATION SAFETY, and it uses the stale-cert
+		// WARN as its observable for "the outstanding debt settled". That
+		// diagnostic is now correctly SILENT on a loopback-only listener — no
+		// remote client exists there to verify by host name — and
+		// `web-management https` with no `interface` resolves to 127.0.0.1:443,
+		// so this fixture was measuring the generation property THROUGH the very
+		// defect #7039 fixes. A routable bind restores the observable without
+		// weakening what the cell asserts.
+		want := cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)
+		httpOnly := cfgFor(reg, "10.0.0.1:8080", false, "", nil)
 		if err := m.startTo(ctx, httpOnly); err != nil {
 			t.Fatalf("start HTTP leg: %v", err)
 		}
 		dir := t.TempDir()
-		seedDurableCert(t, dir, "old-fw-6827", "127.0.0.1")
+		seedDurableCert(t, dir, "old-fw-6827", "10.0.0.1")
 		m.srv.SetTLSCertDirForTest(dir)
 
 		// Debt #1, incurred while nothing serves a certificate.


### PR DESCRIPTION
Closes #7039

Opened by the orchestrator: close-6949 completed and pushed this branch but went
idle before raising the PR. The work and the reasoning below are the lane's; the
gate result at the bottom is mine, re-run at current `origin/master`.

## The defect

`warnStaleHostName` had no listener gate. `set system services web-management
https` with no `interface` resolves to `127.0.0.1:443`, and on that plane no
remote client exists — so nothing can verify by host name and a re-mint would fix
nothing. Every `set system host-name` on a loopback-bound management plane
nevertheless warned about clients that cannot exist.

The **bind-host** half of this same diagnostic already knew:
`bindHostWarnable("127.0.0.1")` is false, so `warnStaleBindHost` stays silent
there by design. The host-name half checked `hostnameSANWarnable`,
`hostName == bindHost`, and — only for `hostNameInferred` —
`hostNameLikelyAccessIdentity`; `WarnStaleMgmtCertForHostName` passes
`hostNameOperatorSet`, which skips that third gate entirely.

Log-only, but it is precisely the failure mode `hostNameLikelyAccessIdentity`'s
own doc block exists to prevent: *"A diagnostic that fires on a healthy box gets
muted, and the true positive dies with it."*

## Not `!bindHostWarnable` — the obvious drop-in, and it is wrong

| bindHost | `bindHostWarnable` | `bindIsLoopbackOnly` | |
|---|---|---|---|
| `0.0.0.0` | false | false | reachable from everywhere |
| `::` | false | false | reachable from everywhere |
| `127.0.0.1` | false | **true** | |
| `10.0.0.1` | **true** | false | |

The two answer different questions. `bindHostWarnable` asks whether there is a
single concrete host worth warning about; a **wildcard** bind answers no because
it names no one host, not because it is unreachable. Suppressing on the
complement would silence the diagnostic on `0.0.0.0` — the most remotely
reachable listener there is, and exactly the case the diagnostic exists for.

An empty `bindHost` is likewise **not** treated as loopback: the listener address
could not be parsed, and suppressing on unknown state fails the wrong way.

## The suppression is paired, cell by cell

Because the fix is a suppression, the cells that matter are the ones proving it
did not over-suppress. Each of the three loopback silence cells (`127.0.0.1`,
`::1`, `localhost`) is paired with a bind on which the warning **must still
fire**, through the same call with every other condition identical: a routable
IP, and **both** wildcards. The wildcard cells are what separate this fix from
the drop-in. `TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039` pins the
divergence directly and fails if the two predicates ever coincide, so that has to
be *decided* rather than discovered through a muted warning.

## A pre-existing test was pinning the defect, and was re-decided

`TestDebtClearIsGenerationSafe_6827/a_real_rename_mid_delivery_advances_the_generation`
asserted a WARN on a fixture whose HTTPS bind is `127.0.0.1:443` — measured, not
assumed. Its subject is **generation safety**; it used the warn text merely as the
observable for "the debt settled", so it was measuring that property *through* the
defect this change fixes. Rebound to `10.0.0.1:8443` via the existing `cfgFor`
helper, which restores the observable without weakening what the cell asserts.

**Verified RED at master:** the three loopback cells fail there and the three
paired cells PASS there — the correct shape, since an over-suppression guard must
hold before and after.

## Docs

`pkg/api/README.md` records the gate, why it is not the complement of
`bindHostWarnable`, and the wildcard cells.

Refs #6827