### PR TITLE
docs: retarget the #5831 citations and condition its recovery procedure

### DIFF
--- a/docs/log/7057.md
+++ b/docs/log/7057.md
@@ -1,0 +1,55 @@
+# docs/log/7057.md — #7057 + #7058 (#5831 citations and recovery claim)
+
+- **Timestamp**: 2026-08-28
+- **Action**: Retarget the stale `daemon_run.go` inline-loop citations at their
+  three live sites, correct the one `resolveClassPerms` citation that states the
+  mechanism in the wrong place, and make the recovery procedure conditional.
+- **File(s)**: `pkg/config/compiler_login_deny.go`,
+  `pkg/config/login_class_deny_5831_test.go`,
+  `pkg/cli/permissions_login_deny_fold_5831_test.go`, `docs/system-login.md`
+
+## Why one change
+
+Both are #5831 and both touch `docs/system-login.md`; #7057's sweep passes
+through the section #7058 rewrites.
+
+## #7057: four cited sites, only three are wrong
+
+The issue lists four places quoting `if u.Name == osUser`. Two of them —
+`pkg/daemon/cli_rbac.go:26` and `pkg/cli/identity.go:16` — present it explicitly
+as **historical** ("Before this, ..."), which is correct and was left alone.
+Only the three that state it as the current mechanism were retargeted.
+
+The premise the repair floor rests on survives the retarget: `configuredClass` is
+not a bare equality but walks `candidateNames(id)` including passwd aliases, and
+gives a root listed with no class `ClassRootDefault`. The console operator can
+still be bound to a custom class — if anything more readily.
+
+## #7057: the issue over-enumerated the doc citations
+
+It names six `docs/system-login.md` line numbers as stale. Checked individually,
+five are still accurate: `resolveClassPerms` **exists**
+(`pkg/cli/permissions.go:32`) as a store-bound adapter, and sentences describing
+it as the runtime call site, or as reading `ActiveConfig()` on every check, are
+true. Exactly one states the **mechanism** as living there — "walks the class
+list and returns the first entry whose name matches" — and that walk moved to
+`config.ResolveClassPermissions` in #5561. Only that one was rewritten; the
+correction names the split so the other five read correctly in context.
+
+Churning five accurate sentences to satisfy an enumeration would have made the
+page worse and the next reviewer's diff unreadable.
+
+## #7058: measured, not reasoned from the fold
+
+```
+maint+clear    -> fold=[]    (len 0)
+clear+control  -> fold=[]    (len 0)
+view           -> fold=[view]
+configure      -> fold=[configure]
+all            -> fold=[view configure]
+```
+
+Run against `repairableFloorFold` directly. The first probe was a **build break**
+(`PermMaintenance` does not exist; the constant is `PermMaint`) and produced no
+result at all — recorded because a build break in a probe reads as a data point
+if you only check the exit code.

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -483,8 +483,13 @@ system {
 ```
 
 The reason is that the runtime resolves a **name**, not a block:
-`pkg/cli/permissions.go` `resolveClassPerms` walks the class list and returns
-the **first** entry whose name matches. Folding only the offending block leaves
+`config.ResolveClassPermissions` (`pkg/config/login_perms.go`) consults the
+system-defined table first and then walks the configured classes, returning the
+**first** entry whose name matches. Since #5561 that walk is no longer in
+`resolveClassPerms` (`pkg/cli/permissions.go`), which is now a five-line
+store-bound adapter reading `store.ActiveConfig()` and delegating (#7057) —
+elsewhere on this page `resolveClassPerms` names the runtime *call site*, which
+is still accurate, but the lookup itself lives one layer down. Folding only the offending block leaves
 whichever *other* block the reader happens to pick holding its full permission
 set — `permissions all` above — so the deny statement is again attached to a
 class the box does not enforce. Both orderings failed open before this was
@@ -564,12 +569,36 @@ for a class *name*, not that any actual login is bound to a built-in.
 #### Recovery if you already committed such a config
 
 An upgraded box that loads a persisted config carrying these statements emits
-the warning above and keeps the class usable for repair:
+the warning above. **If the class already held `configure` (or `all`)**, it
+stays usable for repair:
 
 1. Log in and run `configure` (retained by the fold).
 2. `delete system login class <name> deny-configuration` (and/or
    `deny-commands`).
 3. `commit` — this is the first commit the strict gate lets through.
+
+**If it did not, this procedure is unavailable and you need the out-of-band
+shell** (#7058). The fold is an INTERSECTION — `{view, configure} ∩ what the
+class already held` — and per the "Never widens" rule above it does not grant a
+bucket the class lacked. A class whose Junos permission tokens map to neither
+`view` nor `configure` therefore folds to the **empty set**, and step 1 cannot
+run. Measured against `repairableFloorFold`
+(`pkg/config/compiler_login_deny.go`):
+
+| class holds | folds to |
+|---|---|
+| `maintenance`, `clear` | **empty** — no repair path |
+| `clear`, `control` | **empty** — no repair path |
+| `view` | `view` — can look, cannot repair |
+| `configure` | `configure` — repair path holds |
+| `all` | `view` + `configure` |
+
+The preceding paragraph and this one are each correct and were jointly
+inconsistent until #7058: "keeps the class usable for repair" was stated
+unconditionally, while the design deliberately never widens. The forcing
+function below is unchanged — but on a box in the empty-fold case the forcing
+function has nothing to force *with*, which is the situation the out-of-band
+shell exists for.
 
 Nothing else about the box can be committed until that statement is gone; that
 is the forcing function, not an accident.

--- a/pkg/cli/permissions_login_deny_fold_5831_test.go
+++ b/pkg/cli/permissions_login_deny_fold_5831_test.go
@@ -20,10 +20,12 @@ import (
 // repair floor. Before #5831 the deny leaf was inert, so this committed
 // cleanly and `noc-admin` held view + configure.
 //
-// pkg/daemon/daemon_run.go assigns the CONFIGURED class to any OS user whose
-// name matches a `system login user` (`if u.Name == osUser {
-// shell.SetUserClass(u.Class) }`). Account provisioning skips root; that
-// assignment does not. So `user root class noc-admin` binds the CONSOLE
+// pkg/daemon/daemon_run.go:742 -> applyCLILoginClass (pkg/daemon/cli_rbac.go)
+// -> cli.ResolveLoginClass (pkg/cli/identity.go) -> configuredClass assigns the
+// CONFIGURED class to the invoking OS credential, and `root` is a name the
+// username validator accepts.
+// Account provisioning skips root; that assignment does not. (The inline
+// `if u.Name == osUser` loop this used to quote is gone since #6701 — #7057.) So `user root class noc-admin` binds the CONSOLE
 // operator to a custom class, and whatever the fold leaves that class holding
 // is the total access available to repair the box.
 const syncedLoginConfig = `

--- a/pkg/config/compiler_login_deny.go
+++ b/pkg/config/compiler_login_deny.go
@@ -220,11 +220,18 @@ func validateLoginClassDenyStrict(cfg *Config) error {
 //	set system login class noc-admin deny-configuration "security policies"
 //	set system login user root class noc-admin
 //
-// pkg/daemon/daemon_run.go assigns the CONFIGURED class to any OS user whose
-// name matches a `system login user` (`if u.Name == osUser {
-// shell.SetUserClass(u.Class) }`), and `root` is a name the username validator
-// accepts. Account PROVISIONING skips root (daemon_system.go); the CLI class
-// assignment does not. So the console operator above runs as `noc-admin`, and
+// pkg/daemon/daemon_run.go:742 -> applyCLILoginClass (pkg/daemon/cli_rbac.go)
+// -> cli.ResolveLoginClass (pkg/cli/identity.go) -> configuredClass assigns the
+// CONFIGURED class to the invoking OS credential, and `root` is a name the
+// username validator accepts.
+// Account PROVISIONING skips root (daemon_system.go); the CLI class assignment
+// does not. The old inline `if u.Name == osUser` loop this comment used to quote
+// has not existed since #6701 and survives only as a historical quote in
+// cli_rbac.go and identity.go (#7057); configuredClass is not a bare equality —
+// it walks candidateNames(id) including passwd aliases, returns the FIRST user
+// block carrying a NON-EMPTY class, and gives a root listed with no class
+// ClassRootDefault ("super-user") rather than an empty one. The premise the
+// repair floor rests on is unchanged and, if anything, broader. So the console operator above runs as `noc-admin`, and
 // a view-only collapse takes `configure` away from the only login that could
 // delete the offending stanza — while validateLoginClassDenyStrict rejects
 // every commit until it IS deleted. A configure-only class collapses to the

--- a/pkg/config/login_class_deny_5831_test.go
+++ b/pkg/config/login_class_deny_5831_test.go
@@ -298,10 +298,12 @@ func TestLoginClassDenyFoldNeverWidens(t *testing.T) {
 // TestLoginClassDenyFoldKeepsTheRepairPath is the counter-example to
 // "the fold cannot lock an operator out".
 //
-// pkg/daemon/daemon_run.go assigns the CONFIGURED login class to any OS user
-// whose name matches a `system login user` entry, and `root` is a name the
+// pkg/daemon/daemon_run.go:742 -> applyCLILoginClass (pkg/daemon/cli_rbac.go)
+// -> cli.ResolveLoginClass (pkg/cli/identity.go) -> configuredClass assigns the
+// CONFIGURED login class to the invoking OS credential, and `root` is a name the
 // username validator accepts (account PROVISIONING skips root; the CLI class
-// assignment does not). So the config below binds the CONSOLE operator to a
+// assignment does not). The inline loop this comment used to describe is gone
+// since #6701 (#7057). So the config below binds the CONSOLE operator to a
 // custom class. If the tolerant fold collapsed that class to view-only, the
 // only login that can delete the offending statement would lose `configure` —
 // while validateLoginClassDenyStrict rejects every commit until it IS deleted.


### PR DESCRIPTION
Closes #7057
Closes #7058

Both are #5831 documentation defects and both touch `docs/system-login.md`;
#7057's sweep passes through the section #7058 rewrites, so they are one change.

## #7057 — the premise was stated by quoting code that no longer exists

The repair-floor design rests on one load-bearing premise: the **console `root`
operator can be bound to a custom login class**, so a view-only collapse would
strand the box. Three live sites stated that premise by quoting an inline loop
gone since #6701:

```go
if u.Name == osUser { shell.SetUserClass(u.Class) }
```

The live path is `daemon_run.go:742` → `applyCLILoginClass` (`cli_rbac.go`) →
`cli.ResolveLoginClass` (`identity.go`) → `configuredClass`, which is **not** a
bare equality: it walks `candidateNames(id)` including passwd aliases, returns
the first user block carrying a **non-empty** class, and gives a root listed with
no class `ClassRootDefault`. **The premise survives the retarget** — if anything
it is broader.

### Two of the four cited sites were already correct

`pkg/daemon/cli_rbac.go:26` and `pkg/cli/identity.go:16` present the loop
explicitly as **historical** ("Before this, …"). That is exactly right and they
are left alone. Only the three stating it as the current mechanism were changed.

### The issue over-enumerated the doc citations, and I did not follow it

It names **six** `docs/system-login.md` `resolveClassPerms` citations as stale.
Checked one at a time, **five are accurate**: `resolveClassPerms` still exists
(`pkg/cli/permissions.go:32`) as a store-bound adapter, and sentences calling it
the runtime call site, or saying it reads `ActiveConfig()` on every check, are
true of it.

Exactly **one** states the *mechanism* as living there — "walks the class list and
returns the first entry whose name matches" — and that walk moved to
`config.ResolveClassPermissions` in #5561. Only that one is rewritten, and it now
names the split so the other five read correctly in context.

Churning five accurate sentences to satisfy an enumeration would have made the
page worse and the next reviewer's diff unreadable. An enumeration in an issue is
a floor, not a census, and it is also not a warrant.

## #7058 — measured, not reasoned from the fold

The recovery section claimed **unconditionally** that the fold "keeps the class
usable for repair". The fold is an intersection, `{view, configure} ∩ what the
class already held`, and per its own "Never widens" rule does not grant a bucket
the class lacked. The two statements were individually correct and jointly
inconsistent.

Run directly against `repairableFloorFold`:

| class holds | folds to |
|---|---|
| `maintenance`, `clear` | **empty** — no repair path |
| `clear`, `control` | **empty** — no repair path |
| `view` | `view` |
| `configure` | `configure` |
| `all` | `view` + `configure` |

The recovery is now conditional and names the out-of-band shell for the
empty-fold case — the same answer the paragraph immediately above already gives
for its own scenario.

**A note on the probe:** my first run of it was a **build break** —
`PermMaintenance` does not exist, the constant is `PermMaint` — and produced no
result at all. Recorded in `docs/log/7057.md` because a build break in a probe
reads as a data point if you check only the exit code.

## Validation

Comments and docs only, no behaviour change. `go build ./...` clean; the three
edited Go files are `gofmt`-clean (the files `gofmt -l` reports under
`pkg/config/` are pre-existing and untouched here).