### PR TITLE
api: correct the empty-bind-host rationale, and rewrap the 7039 README break

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1656,7 +1656,8 @@ the drop fails loudly instead of going quietly vacuous.
         silence the diagnostic on the most remotely-reachable listener there is.
         `TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039` pins the
         divergence, and the wildcard binds appear as MUST-STILL-WARN cells beside
-        the loopback silence cells so the suppression cannot widen unnoticed. **Accepted residual:** a rename that CROSSES the
+        the loopback silence cells so the suppression cannot widen unnoticed.
+        **Accepted residual:** a rename that CROSSES the
         qualified/unqualified boundary is diagnosed at the commit but not on any
         later boot, so it is never diagnosed at all in the two states that had
         no commit-time diagnosis behind them — a box already drifted before this

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1657,6 +1657,10 @@ the drop fails loudly instead of going quietly vacuous.
         `TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039` pins the
         divergence, and the wildcard binds appear as MUST-STILL-WARN cells beside
         the loopback silence cells so the suppression cannot widen unnoticed.
+        An **empty** bind host is likewise not loopback: `":8443"` splits to an
+        empty host, so `""` usually means WILDCARD (the same reading the bind-host
+        bullet above already uses), and suppressing there would silence the
+        diagnostic on a listener reachable from every interface.
         **Accepted residual:** a rename that CROSSES the
         qualified/unqualified boundary is diagnosed at the commit but not on any
         later boot, so it is never diagnosed at all in the two states that had

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1376,9 +1376,17 @@ func bindHostWarnable(bindHost string) bool {
 // That is over-suppression of exactly the case the diagnostic is FOR.
 // `TestLoopbackOnlyIsNotTheComplementOfBindHostWarnable_7039` pins the divergence.
 //
-// An empty bindHost is NOT treated as loopback: the listener address could not
-// be parsed, and suppressing a diagnostic on unknown state is the wrong
-// direction to fail.
+// An empty bindHost is NOT treated as loopback, and the reason is stronger than
+// "suppressing on unknown state fails the wrong way". `":8443"` — the bare-port
+// form, an ordinary way to spell a listener on every interface — splits to an
+// EMPTY host, so `""` most often means WILDCARD rather than unparseable. This
+// module's own README already records that reading for the bind-host half:
+// "wildcard (`:8443` → empty) / non-encodable bind host is skipped". Treating
+// `""` as loopback would therefore suppress the diagnostic on a maximally
+// reachable listener — the same error as the `!bindHostWarnable` drop-in,
+// reached from a different direction.
+// `TestWarnStaleMgmtCertForHostName_6827/wildcard_bind_host_still_diagnoses_the_name`
+// binds that shape; it uses exactly a `":8443"` listener.
 func bindIsLoopbackOnly(bindHost string) bool {
 	if bindHost == "localhost" {
 		return true


### PR DESCRIPTION
Two follow-ups to #7876, which merged while this lane was still running its
mutation matrix. Both touch only comments and Markdown — no code path changes.

## 1. The empty bind host is a WILDCARD, not an unknown state

The `bindIsLoopbackOnly` doc block declined the empty `bindHost` for this reason:

> the listener address could not be parsed, and suppressing a diagnostic on
> unknown state is the wrong direction to fail

That is weaker than the truth, and it contradicts this module's own README.
`":8443"` — the bare-port form, an ordinary way to spell a listener on every
interface — splits to an **empty** host. So `""` most often means **wildcard**,
not unparseable, which is already the reading `pkg/api/README.md` uses for the
bind-host half of the same diagnostic:

> wildcard (`:8443` → empty) / non-encodable bind host is skipped

Treating `""` as loopback would therefore suppress the diagnostic on a maximally
reachable listener — the same over-suppression as the `!bindHostWarnable`
drop-in, reached from a different direction — rather than merely erring on
unknown state.

**The behaviour was already correct.** This corrects the stated reason and cites
the test that binds the shape,
`TestWarnStaleMgmtCertForHostName_6827/wildcard_bind_host_still_diagnoses_the_name`,
which serves exactly a `":8443"` listener.

### How it was found

Mutation cell **M4** of the #7039 matrix ([posted on
#7876](https://github.com/psaab/xpf/pull/7876#issuecomment-5459001798)) flipped
the empty bind to loopback. It was caught — but by the #6827 wildcard test, which
was not obviously in scope until the cell named it. Reading *why* that test
reddened is what made the real rationale visible. The matrix caught 5 of 5
mutations with no survivors; this was its one substantive finding.

The README quote is verbatim — asserted against the source, arrow glyph included.

## 2. Paragraph rewrap

The `bindIsLoopbackOnly` note added to `pkg/api/README.md` ended mid-line,
leaving the pre-existing `**Accepted residual:**` sentence glued to the end of
the new paragraph on a single 126-character line; the surrounding block wraps at
roughly 80.

## Validation

- `gofmt -l pkg/api/server.go` — clean
- `go build ./pkg/api/` — ok
- `go test -count=1 ./pkg/api/ ./pkg/daemon/` — **ok, ok**

Refs #7039