### PR TITLE
cos: mark a class-of-service block whose interface is not configured

### DIFF
--- a/docs/log/7065.md
+++ b/docs/log/7065.md
@@ -1,0 +1,27 @@
+# docs/log/7065.md — #7065 (phantom CoS interface)
+
+- **Timestamp**: 2026-08-29
+- **Action**: Mark a `class-of-service interfaces` block whose interface has no
+  `interfaces` counterpart as not applied, quoting the dangling reference.
+- **File(s)**: `pkg/dataplane/userspace/format/cos.go`,
+  `pkg/dataplane/userspace/format/cos_sections.go`,
+  `pkg/dataplane/userspace/format/cos_phantom_interface_7065_test.go`
+
+## Annotate, not drop
+
+Hiding the row would make the operator's own committed stanza invisible from the
+command that exists to show it. The likeliest cause of a phantom block is a typo
+in the interface name, and an empty output sends the operator looking for the
+wrong thing. The reference is quoted for the reason `cosRewriteRuleEnforcement`
+quotes its own: a bare "not applied" reads as "you forgot to configure it" to
+someone who did configure it, just under a misspelled name.
+
+## The second polarity is the one that matters
+
+A fix that printed the advisory unconditionally satisfies the phantom case and is
+useless — every real interface would carry a "not applied" line. The two table
+rows differ in exactly one thing: whether `interfaces ge-9-9-9 unit 0` exists.
+
+`cos_summary.golden` is unchanged, which is the right outcome and a second
+witness: its fixture configures real interfaces, so the advisory must not appear
+there. A golden that had changed would have meant the condition was wrong.

--- a/pkg/dataplane/userspace/format/cos.go
+++ b/pkg/dataplane/userspace/format/cos.go
@@ -10,7 +10,12 @@ import (
 )
 
 type cosInterfaceView struct {
-	name           string
+	name string
+	// ifName is the PHYSICAL interface the class-of-service stanza names, kept
+	// alongside the rendered logical `name` so the #7065 advisory can quote the
+	// operator's own `interfaces <ifName> unit <unit>` path rather than making
+	// them re-derive it from "ge-9-9-9.0".
+	ifName         string
 	unit           int
 	cosUnit        *config.CoSInterfaceUnit
 	interfaceUnit  *config.InterfaceUnit

--- a/pkg/dataplane/userspace/format/cos_phantom_interface_7065_test.go
+++ b/pkg/dataplane/userspace/format/cos_phantom_interface_7065_test.go
@@ -1,0 +1,81 @@
+package format
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7065: a `class-of-service interfaces` stanza whose interface has no
+// counterpart under `interfaces` renders a fully-fledged block, indistinguishable
+// from a real interface whose CoS is live. It commits clean, and
+// buildInterfaceSnapshots walks cfg.Interfaces.Interfaces — so nothing in that
+// block reaches the dataplane.
+//
+// This is the #6858 failure class one command over: an unanswered question
+// rendered as a confident answer. cosRewriteRuleEnforcement already refuses to
+// do it for rewrite rules and names the dangling reference when it declines;
+// this brings the interface block to the same standard.
+//
+// BOTH polarities are asserted, and the second is the one that matters. A fix
+// that printed the advisory unconditionally would satisfy the phantom case and
+// be useless — every real interface would carry a "not applied" line. The two
+// rows differ in EXACTLY one thing: whether `interfaces ge-9-9-9 unit 0` exists.
+func TestPhantomCoSInterfaceIsMarkedNotApplied_7065(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		interfaceUnit *config.InterfaceUnit
+		wantAdvisory  bool
+	}{
+		{"phantom: no interfaces stanza", nil, true},
+		{"real: interfaces stanza present", &config.InterfaceUnit{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b strings.Builder
+			writeCoSInterfaceHeader(&b, cosInterfaceView{
+				name:          "ge-9-9-9.0",
+				ifName:        "ge-9-9-9",
+				unit:          0,
+				interfaceUnit: tc.interfaceUnit,
+				cosUnit: &config.CoSInterfaceUnit{
+					SchedulerMap:     "sm",
+					ShapingRateBytes: 1875000,
+				},
+			})
+			out := b.String()
+			got := strings.Contains(out, "not applied")
+
+			if got != tc.wantAdvisory {
+				if tc.wantAdvisory {
+					t.Errorf("a class-of-service stanza for an interface that is NOT configured "+
+						"rendered with no advisory, so it is indistinguishable from a live one. "+
+						"buildInterfaceSnapshots walks cfg.Interfaces.Interfaces, so none of "+
+						"these bindings reach the dataplane:\n%s", out)
+				} else {
+					t.Errorf("a class-of-service stanza for a CONFIGURED interface was marked "+
+						"not applied. The advisory is unconditional, which makes it noise on "+
+						"every real interface and tells an operator nothing:\n%s", out)
+				}
+			}
+			if !tc.wantAdvisory {
+				return
+			}
+			// The REFERENCE must be named, for the reason cosRewriteRuleEnforcement
+			// names its own: a bare "not applied" reads as "you forgot to configure
+			// it" to an operator who did configure it, just under a name with a typo
+			// in it. Quoting `interfaces <name> unit <n>` points at the stanza to fix.
+			if !strings.Contains(out, "interfaces ge-9-9-9 unit 0") {
+				t.Errorf("the advisory does not quote the dangling reference, so it does not "+
+					"say WHICH stanza is missing:\n%s", out)
+			}
+			// And the bindings must still print. The advisory qualifies the block;
+			// suppressing the block would hide the operator's own committed config
+			// from the command that exists to show it.
+			if !strings.Contains(out, "sm") {
+				t.Errorf("the advisory suppressed the configured bindings; it must qualify "+
+					"them, not replace them:\n%s", out)
+			}
+		})
+	}
+}

--- a/pkg/dataplane/userspace/format/cos_sections.go
+++ b/pkg/dataplane/userspace/format/cos_sections.go
@@ -31,6 +31,28 @@ import (
 // runtime worker/queue/timer/waterfill lines from the snapshot. When the
 // interface has no runtime state it emits the single "unavailable" line.
 func writeCoSInterfaceHeader(b *strings.Builder, view cosInterfaceView) {
+	// #7065: a `class-of-service interfaces` stanza whose interface/unit has no
+	// counterpart under `interfaces` commits clean, and buildInterfaceSnapshots
+	// walks cfg.Interfaces.Interfaces — so NOTHING below reaches the dataplane.
+	// Rendered as a fully-fledged block it was indistinguishable from a live
+	// one, which is the #6858 failure class (an unanswered question turned into
+	// a confidently wrong answer) inside a second command.
+	//
+	// The row is annotated rather than DROPPED. Hiding it would make the
+	// operator's own committed stanza invisible from the command that exists to
+	// show it — the likeliest cause here is a typo in the interface name, and an
+	// empty output sends them looking for the wrong thing. The reference is
+	// quoted for the reason cosRewriteRuleEnforcement quotes its own: a bare
+	// "not applied" reads as "you forgot to configure it" to an operator who did
+	// configure it, just under a name with a typo in it.
+	//
+	// Placed FIRST so it qualifies the bindings printed beneath it. A reader who
+	// stops after the first line has still been told the block is inert.
+	if view.interfaceUnit == nil {
+		fmt.Fprintf(b, "  %-26s%s\n", "Dataplane:",
+			fmt.Sprintf("not applied (interfaces %s unit %d is not configured, so none of "+
+				"the bindings below reach the dataplane)", view.ifName, view.unit))
+	}
 	if view.cosUnit != nil {
 		fmt.Fprintf(b, "  Scheduler map:            %s\n", emptyDash(view.cosUnit.SchedulerMap))
 		fmt.Fprintf(b, "  DSCP classifier:          %s\n", emptyDash(view.cosUnit.DSCPClassifier))
@@ -408,6 +430,7 @@ func configuredCoSInterfaceViews(cfg *config.Config, status *userspace.ProcessSt
 			}
 			views = append(views, cosInterfaceView{
 				name:           logicalName,
+				ifName:         ifName,
 				unit:           unitNum,
 				cosUnit:        cosUnit,
 				interfaceUnit:  interfaceUnit,


### PR DESCRIPTION
Closes #7065

`configuredCoSInterfaceViews` computed `interfaceUnit` and **never used it** to
qualify the row. An interface existing only as a `class-of-service interfaces`
stanza — no `interfaces` stanza at all, which commits clean — rendered as a
fully-fledged block with its shaping rate, scheduler-map and classifier
bindings, indistinguishable from a real interface whose CoS is live.
`buildInterfaceSnapshots` walks `cfg.Interfaces.Interfaces`, so the dataplane
never sees any of it.

That is the #6858 failure class one command over: an unanswered question turned
into a confidently wrong answer. `cosRewriteRuleEnforcement` already refuses to
do this for rewrite rules and names the dangling reference when it declines; the
interface block now meets the same standard.

## Annotated, not dropped

Hiding the row would make the operator's own committed stanza invisible from the
command that exists to show it. The likeliest cause of a phantom block is a
**typo in the interface name**, and an empty output sends them looking for the
wrong thing. The reference is quoted for the reason `cosRewriteRuleEnforcement`
quotes its own — a bare "not applied" reads as "you forgot to configure it" to an
operator who did configure it, just under a misspelled name:

```
Interface: ge-9-9-9.0
  Dataplane:                not applied (interfaces ge-9-9-9 unit 0 is not
                            configured, so none of the bindings below reach the
                            dataplane)
  Scheduler map:            sm
  ...
```

Placed **first** so it qualifies the bindings beneath it: a reader who stops
after one line has still been told the block is inert.

## Mutation matrix

Full package, no `-run` filter. **111 collected, 0 build errors in every cell.**

| cell | mutation | FAIL cells | named |
|---|---|---|---|
| M0 | control | 0 | — |
| M1 | delete the advisory (revert) | 2 | `.../phantom:_no_interfaces_stanza` **only** |
| M2 | make it unconditional | 3 | `.../real:_interfaces_stanza_present` **and `TestFormatCoSInterfaceSummaryGolden`** |

**M2 is the cell that matters.** A fix printing the advisory unconditionally
satisfies the phantom case and is useless — every real interface would carry a
"not applied" line. That it also reds the **pre-existing golden** is independent
confirmation from a fixture I did not write: `cos_summary.golden` configures real
interfaces, so the advisory must not appear there.

Correspondingly, the golden is **unchanged** by this PR, which is the correct
outcome and the second witness. A changed golden would have meant the condition
was wrong.

## Validation

- Matrix above; `go build ./...` clean, `gofmt` clean.
- Repo-wide `go test ./... -count=1` gating below.