### PR TITLE
docs: record the 7032 re-gate after the disk-full incident

### DIFF
--- a/docs/log/7032.md
+++ b/docs/log/7032.md
@@ -111,6 +111,31 @@ cells re-run against the new path:
 Same localisation, new file layout. The witnesses bind the boundary, not the
 path.
 
+## Re-gated after the disk-full incident
+
+The root filesystem hit 100% during this campaign (`go-build` cache at 222 G),
+and the failure mode is worth recording because **a disk-full gate does not look
+like a disk-full gate**: it presents as named test failures and rustc exits, not
+as an obvious infrastructure error.
+
+Every gate log for this issue was swept and **none contains `no space left`**.
+More usefully, none of the cells could have been silently voided: the harness
+scores `collected == 0` as **BUILD BREAK, not a red**, and every cell in both
+matrices reported a non-zero, *consistent* collected count — 4817 before the
+witnesses, 4819 after, 4820 after merging master. That progression is itself an
+integrity check: a truncated or aborted run would not land on the expected count.
+
+The load-bearing cells were nonetheless re-run on fresh `_r2` log paths, since a
+result is cheaper to re-take than to argue about:
+
+| cell | log | rc | named | collected | ENOSPC |
+|---|---|---|---|---|---|
+| full suite | `g7032_suite_r2.log` | 0 | — | 4820 | 0 |
+| addresses `<=` -> `<` | `r2-addresses_r2.log` | 101 | `exact_fit_on_the_addresses_budget_installs_7032` — only | 4820 | 0 |
+| port_capacity `<=` -> `<` | `r2-port_capacity_r2.log` | 101 | `exact_fit_on_the_port_capacity_budget_installs_7032` — only | 4820 | 0 |
+
+Same localisation as before the incident.
+
 ## Classification
 
 **Test-binding only.** The production comparison is correct and agrees with the


### PR DESCRIPTION
Docs-only. Rescues a commit stranded by timing: #7881 merged at 00:19:49Z at head
`3ff8281f4`, and this commit landed on the branch moments after, so it is not in
master.

It records the disk-full re-gate for #7032 in `docs/log/7032.md`, which is worth
keeping because of what the incident showed: **a disk-full gate does not look
like a disk-full gate.** It presents as named test failures and rustc exits, not
as an obvious infrastructure error — five named Go failures and a rustc 101 in
this campaign were all artifacts of a full root filesystem.

What the entry records:

- Every #7032 gate log was swept; **none contains `no space left`**.
- None of the cells could have been silently voided, because the harness scores
  `collected == 0` as **BUILD BREAK, not a red**. Every cell reported a non-zero
  and *consistent* collected count — **4817** before the witnesses, **4819**
  after, **4820** after merging master. That progression is itself an integrity
  check: a truncated or aborted run would not land on the expected number.
- The load-bearing cells were re-run on fresh `_r2` log paths anyway, with the
  same localisation:

| cell | log | rc | named | collected | ENOSPC |
|---|---|---|---|---|---|
| full suite | `g7032_suite_r2.log` | 0 | — | 4820 | 0 |
| addresses `<=` -> `<` | `r2-addresses_r2.log` | 101 | `exact_fit_on_the_addresses_budget_installs_7032` — only | 4820 | 0 |
| port_capacity `<=` -> `<` | `r2-port_capacity_r2.log` | 101 | `exact_fit_on_the_port_capacity_budget_installs_7032` — only | 4820 | 0 |

The generalisable part, and the reason it goes in the log rather than a chat
message: **a failure count from a run that hit ENOSPC measures the disk, not the
code** — and the defence that actually worked here was not noticing the disk, it
was gating every cell on a NAMED failing test with tests-collected > 0 rather
than on `rc != 0`.

No code change; `docs/log/7032.md` only.