### PR TITLE
cos: honour the helper's admission gate in rewrite-rule enforcement

### DIFF
--- a/docs/log/7063.md
+++ b/docs/log/7063.md
@@ -46,3 +46,24 @@ A rule bound usefully on one interface and pointlessly on another was reported
 not enforced — a false negative manufactured by the fix for a false positive.
 Enforcement is a property of the rule across the box, not of its least useful
 binding; `TestRewriteRuleBoundUsefullySomewhereIsEnforced_7063` pins it.
+
+## The showaudit census caught a hand-rolled copy of a single-sourced predicate
+
+The first version of `cosUnitMaterializedClasses` tested
+`cfg.ClassOfService.ForwardingClasses[className] != nil` directly.
+`TestSurfaceAnnotationCensusIsExact6534` (`pkg/showaudit`) red:
+
+```
+cosRuleTargetsUnitClass renders an object the snapshot builder can REFUSE TO
+INSTALL and never consults [CoSForwardingClassUndefined], so a dropped object
+prints as enforced.
+```
+
+That is the same defect class this issue is about, one level down, and the guard
+found it in code written to fix it. `cos_exclusion_reason.go` states the rule —
+the builder and the renderer share ONE predicate rather than keeping a copy each
+— and `config.CoSForwardingClassUndefined` is that predicate. Now called.
+
+Worth recording because the census is *exact*: it does not merely permit
+annotation, it fails when a render function that iterates these entries does not
+consult the shared predicate. A new renderer cannot quietly opt out.

--- a/docs/log/7063.md
+++ b/docs/log/7063.md
@@ -1,0 +1,48 @@
+# docs/log/7063.md — #7063 (rewrite-rule enforcement vs the helper's admission gate)
+
+- **Timestamp**: 2026-08-29
+- **Action**: Report a dscp rewrite rule as NOT enforced when none of its
+  forwarding-classes are materialized on the interface that binds it.
+- **File(s)**: `pkg/dataplane/userspace/format/cos_show.go`,
+  `pkg/dataplane/userspace/format/cos_rewrite_admission_7063_test.go`
+
+## The issue's premise was wrong, and that is the whole finding
+
+#7063 says closing the gap "needs state the config alone does not carry", and
+`FormatCoSRewriteRules(cfg, nameFilter, typeFilter)` indeed takes no
+`ProcessStatus`. But the helper's own predicate is pure config:
+
+`iface_classes` (`build_cos_iface_config`, `forwarding_build/cos.rs:1021`) is the
+scheduler-map's resolved classes when any resolve, and `vec!["best-effort"]` when
+none do. Both are derivable in Go — `buildCoSQueueViews` already derives the
+first from `schedulerMap.Entries` → `ForwardingClasses[...]`.
+
+## Why ONE mirrored predicate is sufficient
+
+`dscp_rewrite_targets_iface_class` is itself one of the disjuncts of
+`contributes_usable_cos_state`. So a rule targeting a materialized class admits
+the interface **by that fact alone**, and the matrix loop then finds an entry for
+that class's queue. A rule targeting none is inert either way — the interface is
+dropped, or the matrix comes out empty. Mirroring the second predicate would have
+been redundant surface with its own drift risk.
+
+## Where the drift risk actually is, and what binds it
+
+The synthetic default class is one wire fact spelled in two languages.
+`TestCoSSyntheticDefaultClassMatchesRust_7063` parses `cos.rs` for it rather than
+restating it, the way `TestSnapshotProtocolVersionLockstepWithRust` parses
+`control.rs`. A silent divergence there would make this command confidently wrong
+for exactly the interfaces with no scheduler-map — the case with no other signal.
+
+## The row that kills the plausible wrong fix
+
+"No scheduler-map + rule targets best-effort → **ENFORCED**". A fix treating "no
+scheduler-map" as "materializes nothing" reports that inert, which is wrong in
+the opposite direction and is invisible to both of the first two rows.
+
+## A false-negative the first draft would have introduced
+
+A rule bound usefully on one interface and pointlessly on another was reported
+not enforced — a false negative manufactured by the fix for a false positive.
+Enforcement is a property of the rule across the box, not of its least useful
+binding; `TestRewriteRuleBoundUsefullySomewhereIsEnforced_7063` pins it.

--- a/pkg/dataplane/userspace/format/cos_rewrite_admission_7063_test.go
+++ b/pkg/dataplane/userspace/format/cos_rewrite_admission_7063_test.go
@@ -1,0 +1,168 @@
+package format
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// cosCfg7063 builds a config with one dscp rewrite rule targeting `voice`, bound
+// on one unit. schedClass controls which forwarding class the unit's
+// scheduler-map materializes; "" means no scheduler-map at all, which is the
+// synthetic-default case.
+func cosCfg7063(t *testing.T, schedClass string) *config.Config {
+	t.Helper()
+	cos := &config.ClassOfServiceConfig{
+		ForwardingClasses: map[string]*config.CoSForwardingClass{
+			"voice":       {Name: "voice", Queue: 5},
+			"best-effort": {Name: "best-effort", Queue: 0},
+		},
+		Schedulers:    map[string]*config.CoSScheduler{"s": {Name: "s"}},
+		SchedulerMaps: map[string]*config.CoSSchedulerMap{},
+		DSCPRewriteRules: map[string]*config.CoSDSCPRewriteRule{
+			"rw": {Name: "rw", Entries: []*config.CoSDSCPRewriteRuleEntry{
+				{ForwardingClass: "voice", LossPriority: "low", DSCPValue: 46},
+			}},
+		},
+		Interfaces: map[string]*config.CoSInterface{},
+	}
+	unit := &config.CoSInterfaceUnit{DSCPRewriteRule: "rw"}
+	if schedClass != "" {
+		cos.SchedulerMaps["sm"] = &config.CoSSchedulerMap{
+			Name:    "sm",
+			Entries: map[string]*config.CoSSchedulerMapEntry{schedClass: {Scheduler: "s"}},
+		}
+		unit.SchedulerMap = "sm"
+	}
+	cos.Interfaces["ge-0-0-0"] = &config.CoSInterface{
+		Units: map[int]*config.CoSInterfaceUnit{0: unit},
+	}
+	return &config.Config{
+		ClassOfService: cos,
+		Interfaces: config.InterfacesConfig{Interfaces: map[string]*config.InterfaceConfig{
+			"ge-0-0-0": {Units: map[int]*config.InterfaceUnit{0: {}}},
+		}},
+	}
+}
+
+// #7063: `Enforced: yes` was answered from the BINDING alone. The helper builds
+// the rewrite matrix only over the queues the interface materializes
+// (build_cos_iface_config), so a rule whose forwarding-classes do not intersect
+// them rewrites nothing while the command claimed it was enforced.
+//
+// The issue says closing this needs "state the config alone does not carry".
+// It does not, and this table is the evidence: `iface_classes` is the
+// scheduler-map's resolved classes, or the synthetic `best-effort` queue when
+// none resolve. Both are config.
+//
+// All four rows are required and each kills a different wrong fix:
+//
+//   - intersects -> enforced. Without it, "report inert whenever bound" passes.
+//   - disjoint -> inert. The defect itself.
+//   - no scheduler-map + rule targets best-effort -> ENFORCED. A fix that treated
+//     "no scheduler-map" as "materializes nothing" would report this inert, which
+//     is wrong in the opposite direction and invisible to the first two rows.
+//   - no scheduler-map + rule targets voice -> inert. The synthetic default is
+//     best-effort ALONE, so it must not excuse every class.
+func TestRewriteRuleEnforcementHonoursTheAdmissionGate_7063(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		schedClass  string
+		ruleClass   string
+		wantEnforce bool
+	}{
+		{"scheduler-map materializes the rule's class", "voice", "voice", true},
+		{"scheduler-map materializes a DIFFERENT class", "best-effort", "voice", false},
+		{"no scheduler-map, rule targets best-effort", "", "best-effort", true},
+		{"no scheduler-map, rule targets voice", "", "voice", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := cosCfg7063(t, tc.schedClass)
+			cfg.ClassOfService.DSCPRewriteRules["rw"].Entries[0].ForwardingClass = tc.ruleClass
+
+			out := FormatCoSRewriteRules(cfg, "", "")
+			enforced := strings.Contains(out, "Enforced: yes")
+			if enforced != tc.wantEnforce {
+				if tc.wantEnforce {
+					t.Errorf("a rule the helper WILL materialize was reported not enforced — the "+
+						"gate is over-tight and now under-reports working rewrites:\n%s", out)
+				} else {
+					t.Errorf("a rule whose forwarding-classes the interface does not materialize "+
+						"was reported Enforced: yes. The helper builds no rewrite entry for it, so "+
+						"this converts an unanswered question into a confidently wrong answer — "+
+						"the #6858 failure class inside the command written to expose it:\n%s", out)
+				}
+			}
+			if tc.wantEnforce {
+				return
+			}
+			// Name the reference, for the reason the dangling arm names its own:
+			// a bare "not enforced" reads as "you forgot to bind it" to an
+			// operator who did bind it, just where it cannot act.
+			if !strings.Contains(out, "ge-0-0-0 unit 0") {
+				t.Errorf("the inert reason does not say WHERE the rule is bound:\n%s", out)
+			}
+			// And it must not be reported as the DANGLING case: the unit exists.
+			if strings.Contains(out, "is not a configured logical interface unit") {
+				t.Errorf("an inert-but-real binding was reported as a dangling reference, which "+
+					"sends the operator to check a name that is correct:\n%s", out)
+			}
+		})
+	}
+}
+
+// A rule bound where it DOES apply is enforced, whatever another interface does
+// with it. Without the reconciling delete an operator who bound the rule
+// correctly on one interface and pointlessly on another would be told it is not
+// enforced — a false negative produced by the fix for a false positive.
+func TestRewriteRuleBoundUsefullySomewhereIsEnforced_7063(t *testing.T) {
+	cfg := cosCfg7063(t, "voice")
+	cfg.ClassOfService.SchedulerMaps["other"] = &config.CoSSchedulerMap{
+		Name:    "other",
+		Entries: map[string]*config.CoSSchedulerMapEntry{"best-effort": {Scheduler: "s"}},
+	}
+	cfg.ClassOfService.Interfaces["ge-0-0-1"] = &config.CoSInterface{
+		Units: map[int]*config.CoSInterfaceUnit{0: {SchedulerMap: "other", DSCPRewriteRule: "rw"}},
+	}
+	cfg.Interfaces.Interfaces["ge-0-0-1"] = &config.InterfaceConfig{
+		Units: map[int]*config.InterfaceUnit{0: {}},
+	}
+	out := FormatCoSRewriteRules(cfg, "", "")
+	if !strings.Contains(out, "Enforced: yes") {
+		t.Errorf("a rule that applies on ge-0-0-0 was reported not enforced because a SECOND "+
+			"interface binds it where it cannot act. Enforcement is a property of the rule "+
+			"across the box, not of the least useful binding:\n%s", out)
+	}
+}
+
+// The synthetic default class is one wire fact spelled in two languages. A
+// silent divergence would make this command confidently wrong for exactly the
+// interfaces that have no scheduler-map — the case with no other signal.
+//
+// Parsed rather than mirrored in a comment, the same way
+// TestSnapshotProtocolVersionLockstepWithRust parses control.rs.
+func TestCoSSyntheticDefaultClassMatchesRust_7063(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..",
+		"userspace-dp", "src", "afxdp", "forwarding_build", "cos.rs")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (the synthetic-default lockstep guard cannot run)", path, err)
+	}
+	re := regexp.MustCompile(`\(vec!\[0\],\s*vec!\["([^"]+)"\]\)`)
+	m := re.FindSubmatch(src)
+	if m == nil {
+		t.Fatalf("the synthetic default queue literal was not found in %s. If it was "+
+			"reshaped, update this guard rather than deleting it — the class it names is "+
+			"what this package assumes for a unit whose scheduler-map resolves nothing", path)
+	}
+	if got := string(m[1]); got != cosSyntheticDefaultForwardingClass {
+		t.Fatalf("synthetic default forwarding class skew: Go says %q, "+
+			"forwarding_build/cos.rs says %q. A unit with no scheduler-map materializes the "+
+			"Rust one, so this command would report enforcement against a class the helper "+
+			"never creates", cosSyntheticDefaultForwardingClass, got)
+	}
+}

--- a/pkg/dataplane/userspace/format/cos_show.go
+++ b/pkg/dataplane/userspace/format/cos_show.go
@@ -514,7 +514,13 @@ func cosUnitMaterializedClasses(cfg *config.Config, cosUnit *config.CoSInterface
 	out := map[string]bool{}
 	if sm := cfg.ClassOfService.SchedulerMaps[cosUnit.SchedulerMap]; sm != nil {
 		for className := range sm.Entries {
-			if cfg.ClassOfService.ForwardingClasses[className] != nil {
+			// The SHARED #6534 predicate, not a hand-rolled map lookup. The
+			// builder skips a scheduler-map entry naming an undefined class at
+			// the same call, so a copy here could drift and this command would
+			// claim enforcement against a queue the builder never materializes
+			// — the exact class of defect #7063 is about. cos_exclusion_reason.go
+			// states the one-predicate rule; pkg/showaudit's census enforces it.
+			if !config.CoSForwardingClassUndefined(cfg.ClassOfService, className) {
 				out[className] = true
 			}
 		}

--- a/pkg/dataplane/userspace/format/cos_show.go
+++ b/pkg/dataplane/userspace/format/cos_show.go
@@ -343,10 +343,10 @@ var CoSRewriteRuleTypes = []string{"dscp", "ieee-802.1", "inet-precedence", "exp
 // (applyCoSInterfaceLevelBindings), and its own doc records that an interface
 // with an interface-level binding but NO configured logical unit contributes no
 // unit — which is precisely the case that must not report as enforced.
-func cosBoundDSCPRewriteRules(cfg *config.Config) (bound map[string]bool, danglingRef map[string]string) {
-	bound, danglingRef = map[string]bool{}, map[string]string{}
+func cosBoundDSCPRewriteRules(cfg *config.Config) (bound map[string]bool, danglingRef, inertRef map[string]string) {
+	bound, danglingRef, inertRef = map[string]bool{}, map[string]string{}, map[string]string{}
 	if cfg == nil || cfg.ClassOfService == nil {
-		return bound, danglingRef
+		return bound, danglingRef, inertRef
 	}
 	for name, iface := range cfg.Interfaces.Interfaces {
 		if iface == nil {
@@ -364,8 +364,26 @@ func cosBoundDSCPRewriteRules(cfg *config.Config) (bound map[string]bool, dangli
 			if cosUnit == nil || cosUnit.DSCPRewriteRule == "" {
 				continue
 			}
+			// #7063: a binding is not enough. The helper builds the rewrite
+			// matrix only over the queues THIS interface materializes
+			// (build_cos_iface_config, forwarding_build/cos.rs), so a rule whose
+			// forwarding-classes do not intersect them rewrites nothing.
+			if !cosRuleTargetsUnitClass(cfg, cosUnit) {
+				if _, ok := inertRef[cosUnit.DSCPRewriteRule]; !ok {
+					inertRef[cosUnit.DSCPRewriteRule] = fmt.Sprintf("%s unit %d", name, unitNum)
+				}
+				continue
+			}
 			bound[cosUnit.DSCPRewriteRule] = true
 		}
+	}
+	// A rule bound anywhere it actually applies is enforced, whatever other
+	// interfaces do with it — so a real binding clears an inert note recorded
+	// from a different unit. Without this an operator who bound the rule
+	// correctly on one interface and pointlessly on another would be told it is
+	// not enforced.
+	for ruleName := range bound {
+		delete(inertRef, ruleName)
 	}
 	// Second pass: every CoS reference the snapshot builder will NOT read.
 	// Recorded so the operator is told WHERE the dead binding is rather than
@@ -390,7 +408,7 @@ func cosBoundDSCPRewriteRules(cfg *config.Config) (bound map[string]bool, dangli
 			}
 		}
 	}
-	return bound, danglingRef
+	return bound, danglingRef, inertRef
 }
 
 // cosRewriteRuleEnforcement renders the `Enforced:` value for one rewrite rule.
@@ -431,7 +449,7 @@ func cosBoundDSCPRewriteRules(cfg *config.Config) (bound map[string]bool, dangli
 // accepted-but-inert advisory if and only if this function returns the
 // unsupported-TYPE reason. Deleting an advisory without flipping this function
 // reds, and flipping this function without dropping the advisory reds too.
-func cosRewriteRuleEnforcement(cpType string, bound bool, danglingRef string) string {
+func cosRewriteRuleEnforcement(cpType string, bound bool, danglingRef, inertRef string) string {
 	if cpType != "dscp" {
 		return "no (accepted for Junos compatibility; the dataplane rewrites dscp only)"
 	}
@@ -442,7 +460,71 @@ func cosRewriteRuleEnforcement(cpType string, bound bool, danglingRef string) st
 		return fmt.Sprintf("no (not bound — class-of-service interfaces %s is not a "+
 			"configured logical interface unit)", danglingRef)
 	}
+	if inertRef != "" {
+		return fmt.Sprintf("no (bound on %s, but none of this rule's forwarding-classes "+
+			"are materialized there, so the helper builds no rewrite entry)", inertRef)
+	}
 	return "no (not bound — no interface unit references this rule)"
+}
+
+// cosRuleTargetsUnitClass reports whether the unit's DSCP rewrite rule names at
+// least one forwarding class the unit will actually materialize.
+//
+// This MIRRORS `dscp_rewrite_targets_iface_class` in `build_cos_iface_config`
+// (`userspace-dp/src/afxdp/forwarding_build/cos.rs`) and must keep agreeing with
+// it. #7063 filed this as needing "state the config alone does not carry"; it
+// does not. The helper's `iface_classes` is the scheduler-map's resolved classes
+// when any resolve, and the synthetic `best-effort` queue when none do — both
+// derivable here.
+//
+// The intersection is SUFFICIENT on its own, which is why no second predicate is
+// mirrored. `dscp_rewrite_targets_iface_class` is itself one of the disjuncts of
+// `contributes_usable_cos_state`, so a rule that targets a materialized class
+// admits the interface by that fact alone; and the matrix loop then finds an
+// entry for that class's queue. A rule that targets none is inert either way —
+// the interface is dropped, or the matrix comes out empty.
+func cosRuleTargetsUnitClass(cfg *config.Config, cosUnit *config.CoSInterfaceUnit) bool {
+	rule := cfg.ClassOfService.DSCPRewriteRules[cosUnit.DSCPRewriteRule]
+	if rule == nil {
+		// An undefined rule name. Not this function's question — the caller's
+		// existing dangling/unbound reporting owns it, and answering false here
+		// would relabel an undefined rule as an inert one.
+		return true
+	}
+	classes := cosUnitMaterializedClasses(cfg, cosUnit)
+	for _, e := range rule.Entries {
+		if e != nil && classes[e.ForwardingClass] {
+			return true
+		}
+	}
+	return false
+}
+
+// cosSyntheticDefaultForwardingClass is the class the helper materializes when a
+// unit's scheduler-map resolves no queues (`vec!["best-effort"]`,
+// forwarding_build/cos.rs). Named rather than inlined because
+// TestCoSSyntheticDefaultClassMatchesRust_7063 parses the Rust for it: the two
+// are one wire fact spelled in two languages, and a silent divergence would make
+// this command confidently wrong for exactly the interfaces that have no
+// scheduler map.
+const cosSyntheticDefaultForwardingClass = "best-effort"
+
+// cosUnitMaterializedClasses is the Go reading of the helper's `iface_classes`.
+func cosUnitMaterializedClasses(cfg *config.Config, cosUnit *config.CoSInterfaceUnit) map[string]bool {
+	out := map[string]bool{}
+	if sm := cfg.ClassOfService.SchedulerMaps[cosUnit.SchedulerMap]; sm != nil {
+		for className := range sm.Entries {
+			if cfg.ClassOfService.ForwardingClasses[className] != nil {
+				out[className] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		// scheduler_map_resolved_to_queues == false: the helper adds the
+		// synthetic default queue, so best-effort IS materialized here.
+		out[cosSyntheticDefaultForwardingClass] = true
+	}
+	return out
 }
 
 // FormatCoSRewriteRules renders `show class-of-service rewrite-rule [name <n>]
@@ -551,7 +633,7 @@ func FormatCoSRewriteRules(cfg *config.Config, nameFilter, typeFilter string) st
 		return "No class-of-service rewrite-rules configured\n"
 	}
 
-	boundDSCP, danglingDSCP := cosBoundDSCPRewriteRules(cfg)
+	boundDSCP, danglingDSCP, inertDSCP := cosBoundDSCPRewriteRules(cfg)
 
 	var b strings.Builder
 	for idx, blk := range blocks {
@@ -560,7 +642,8 @@ func FormatCoSRewriteRules(cfg *config.Config, nameFilter, typeFilter string) st
 		}
 		// Say what the operator loses, not just that a flag is off. This line
 		// is the whole point of the command: it answers "will this rule act?".
-		enforced := cosRewriteRuleEnforcement(blk.cpType, boundDSCP[blk.name], danglingDSCP[blk.name])
+		enforced := cosRewriteRuleEnforcement(blk.cpType, boundDSCP[blk.name],
+			danglingDSCP[blk.name], inertDSCP[blk.name])
 		fmt.Fprintf(&b, "Rewrite rule: %s, Code point type: %s, Enforced: %s\n",
 			blk.name, blk.cpType, enforced)
 		if !blk.modeled {


### PR DESCRIPTION
Closes #7063

`cosRewriteRuleEnforcement` answered `Enforced: yes` for a dscp rule as soon as a
configured logical interface unit bound it. The helper builds the rewrite matrix
only over the queues that interface materializes (`build_cos_iface_config`,
`forwarding_build/cos.rs`), so a rule whose forwarding-classes do not intersect
them rewrites nothing — the #6858 failure class **inside the command written to
expose that class**.

## The issue's premise is wrong, and that is the finding

#7063 says closing this "needs state the config alone does not carry", and
`FormatCoSRewriteRules(cfg, nameFilter, typeFilter)` indeed receives no
`ProcessStatus`. But the helper's predicate is pure config:

`iface_classes` (`cos.rs:1021`) is the scheduler-map's resolved classes when any
resolve, and `vec!["best-effort"]` when none do. Both are derivable here —
`buildCoSQueueViews` already derives the first from `schedulerMap.Entries` →
`ForwardingClasses[...]`.

## Only ONE predicate is mirrored, deliberately

`dscp_rewrite_targets_iface_class` is itself a disjunct of
`contributes_usable_cos_state`. A rule targeting a materialized class therefore
admits the interface **by that fact alone**, and the matrix loop then finds an
entry for that class's queue. A rule targeting none is inert either way — the
interface is dropped, or the matrix comes out empty. Mirroring the second
predicate would be redundant surface carrying its own drift risk.

## Where the drift risk actually is

The synthetic default class is one wire fact spelled in two languages.
`TestCoSSyntheticDefaultClassMatchesRust_7063` **parses `cos.rs`** for it rather
than restating it, the way `TestSnapshotProtocolVersionLockstepWithRust` parses
`control.rs`. A silent divergence would make this command confidently wrong for
exactly the interfaces with no scheduler-map — the case with no other signal.

## Mutation matrix

Full package, no `-run` filter. **118 collected, 0 build errors in every cell.**

| cell | mutation | FAIL cells | named |
|---|---|---|---|
| M0 | control | 0 | — |
| M1 | binding alone means enforced (revert) | 3 | the two "should be inert" rows |
| M2 | drop the synthetic `best-effort` fallback | 4 | `no_scheduler-map,_rule_targets_best-effort` **+ 2 pre-existing #6858 tests** |
| M3 | skew the synthetic class from Rust | 5 | `TestCoSSyntheticDefaultClassMatchesRust_7063` **+ the same 2** |

**M2 and M3 reddening `TestCoSInertAdvisoryAgreesWithRenderedEnforcement6858`
and `TestFormatCoSRewriteRulesDanglingInterfaceBindingIsNotEnforced6858` is the
most useful result** — those are fixtures I did not write, and they show the
synthetic fallback is load-bearing for *pre-existing* behaviour, not just for my
new rows. Implementing only the scheduler-map half would have broken them.

## The table row that kills the plausible wrong fix

**"no scheduler-map + rule targets best-effort → ENFORCED."** A fix treating "no
scheduler-map" as "materializes nothing" reports that inert — wrong in the
opposite direction, and invisible to both of the first two rows.

## A false negative the first draft introduced

A rule bound usefully on one interface and pointlessly on another was reported
not enforced — a false negative manufactured by the fix for a false positive.
Enforcement is a property of the rule across the box, not of its least useful
binding. `TestRewriteRuleBoundUsefullySomewhereIsEnforced_7063` pins it.

## Validation

- Matrix above; `go build ./...`, `gofmt` clean; `./pkg/dataplane/userspace/...`
  ok.
- Repo-wide `go test ./... -count=1` gating below.