### PR TITLE
daemon: bind both halves of the #6290 transport-access delta

### DIFF
--- a/docs/log/7066.md
+++ b/docs/log/7066.md
@@ -1,0 +1,38 @@
+# docs/log/7066.md — #7066 + #7067 (#6290 reader / writer binding gaps)
+
+- **Timestamp**: 2026-08-29
+- **Action**: Bind both halves of #6869's production delta — the guarded step-20
+  read and the existence of the transport publish.
+- **File(s)**: `pkg/daemon/cluster_transport_binding_7066_test.go`
+
+## Both premises measured, not inherited
+
+- **#7067** — deleting `setActiveTransportIfCurrent` at `daemon_ha_sync.go:820`
+  leaves `TestActiveClusterTransportIsMutexGuarded_6290` **green**, collected=1.
+- **#7066** — reverting `daemon_apply_tail.go`'s step-20 read to unguarded direct
+  field access leaves the whole `-race ./pkg/daemon/` suite **green**, 0 DATA
+  RACE.
+
+## A counting bug that nearly became a finding
+
+The first #7067 probe reported `collected=0`, which reads exactly like a `-run`
+filter matching nothing — the failure mode where Go exits 0 and prints `ok`. It
+was not: I grepped for `^=== RUN` without passing `-v`. Re-run with `-v` the cell
+was `collected=1` in both arms.
+
+The lesson is that the instrument and the subject fail the same way here. "The
+filter matched nothing" and "I did not ask for the lines I am counting" are
+indistinguishable from the count alone.
+
+## The fixture detail that decides #7067
+
+`clusterTransportFromConfig` reads `ControlInterface` / `PeerAddress` / the fabric
+fields. The existing #6290 fixture sets **none** of them, so its transport key is
+the **zero value** — a value assertion written against that fixture would be
+zero-equals-zero and would pass with the publish deleted, reproducing the very
+defect it was written to bind.
+
+`control-interface` alone gives a non-zero key for free: the heartbeat is gated on
+`ControlInterface && PeerAddress`, and `clusterSyncTransport` falls back to the
+empty fabric pair when either is missing, so no goroutine starts. The premise is
+asserted in the test rather than relied upon.

--- a/pkg/daemon/cluster_transport_binding_7066_test.go
+++ b/pkg/daemon/cluster_transport_binding_7066_test.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// clusteredStore7066 commits a cluster stanza that yields a NON-ZERO
+// clusterTransportKey while starting no comms goroutines.
+//
+// The non-zero part is load-bearing and is why this does not reuse the #6290
+// fixture. clusterTransportFromConfig reads ControlInterface / PeerAddress /
+// the fabric fields, and that fixture sets NONE of them — so its key is the
+// zero value, and a value assertion written against it would be
+// zero-equals-zero and pass with the publish deleted. That is the defect this
+// file exists to bind, reproduced in the test for it.
+//
+// control-interface ALONE is what gives a non-zero key for free: the heartbeat
+// is gated on ControlInterface AND PeerAddress, and clusterSyncTransport falls
+// back to the (empty) fabric pair when either is missing, so neither goroutine
+// starts.
+func clusteredStore7066(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, line := range []string{
+		"chassis cluster cluster-id 1",
+		"chassis cluster node 0",
+		"chassis cluster authentication-key test-cluster-psk-7066",
+		"chassis cluster control-interface em0",
+	} {
+		if err := store.SetFromInput(line); err != nil {
+			t.Fatalf("set %q: %v", line, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("commit clustered active: %v", err)
+	}
+	return store
+}
+
+// #7067: TestActiveClusterTransportIsMutexGuarded_6290 stays green when the
+// publish is DELETED OUTRIGHT — measured, collected=1 in both cells. With no
+// write there is no concurrent access, so the race detector has nothing to
+// report and the probe passes whether the access is correctly guarded or absent.
+//
+// That is inherent to any probe whose only assertion is the race detector: it
+// binds HOW an access is synchronized, never THAT the access happens. Binding
+// the write's existence needs a value assertion, which is this.
+//
+// TestSetActiveTransportDropsStaleEpoch does not cover it — that calls
+// setActiveTransportIfCurrent directly and never goes through startClusterComms,
+// so it binds the epoch gate rather than the call site.
+func TestStartClusterCommsPublishesTheTransport_7067(t *testing.T) {
+	store := clusteredStore7066(t)
+	active := store.ActiveConfig()
+	want := clusterTransportFromConfig(active)
+
+	// PREMISE. Without this the assertion below is zero == zero and passes
+	// against a build with the publish removed — which is exactly how the
+	// existing race probe fails to bind it.
+	if want == (clusterTransportKey{}) {
+		t.Fatalf("premise broken: this fixture's transport key is the ZERO value, so the "+
+			"assertion below cannot tell a publish from no publish at all. Give the cluster "+
+			"stanza a control-interface. key=%+v", want)
+	}
+
+	d := &Daemon{store: store, opts: Options{NoDataplane: true}}
+	if got := d.activeTransport(); got != (clusterTransportKey{}) {
+		t.Fatalf("premise broken: the daemon already holds a transport key before "+
+			"startClusterComms runs (%+v), so a passing assertion would not be evidence "+
+			"that the publish happened", got)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.startClusterComms(ctx)
+
+	if got := d.activeTransport(); got != want {
+		t.Errorf("startClusterComms did not publish the transport key.\n got %+v\nwant %+v\n"+
+			"Step 20 compares the next commit's transport against this field to decide "+
+			"whether to restart comms; unpublished it stays zero, the `active != zero` guard "+
+			"never passes, and a genuine endpoint change silently does not restart comms. "+
+			"The #6290 race probe cannot see this — with no write there is no concurrent "+
+			"access for the detector to report", got, want)
+	}
+}
+
+// #7066: the OTHER half of #6869's production delta — daemon_apply_tail.go's
+// step 20 replacing six direct d.activeClusterTransport reads with one guarded
+// d.activeTransport() snapshot — is unbound. Measured: revert that file to
+// master's shape and the whole `go test -race ./pkg/daemon/` suite stays green,
+// 0 DATA RACE.
+//
+// It cannot fail there because the #6290 probe's reader is the ACCESSOR, and no
+// test drives applyTailReconciles concurrently with startClusterComms. The other
+// step-20 drivers (cluster_transport_key_5078_test.go) are single-goroutine and
+// seed the field with a direct write. So the pair the reverted tree races —
+// step 20's read against startClusterComms' write — is never executed
+// concurrently by anything.
+//
+// This drives that actual pair. The transport does not change between the
+// committed active and the config passed to the tail, so step 20 READS and
+// decides not to restart: the read is what is under test, and a restart storm
+// would make the cell about something else.
+func TestStepTwentyReadsTheTransportUnderTheLock_7066(t *testing.T) {
+	installFakeNetworkctl(t)
+	store := clusteredStore7066(t)
+	cfg := store.ActiveConfig()
+
+	d := &Daemon{
+		store:     store,
+		networkd:  networkd.NewInDir(t.TempDir()),
+		vrrpMgr:   vrrp.NewManager(),
+		cluster:   cluster.NewManager(0, 1),
+		daemonCtx: context.Background(),
+		opts:      Options{NoDataplane: true},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// PREMISE: step 20 must actually reach the read. If the tail returned before
+	// it, this would be a race test over code that never runs.
+	d.startClusterComms(ctx)
+	if d.activeTransport() == (clusterTransportKey{}) {
+		t.Fatal("premise broken: no transport published, so step 20's `active != zero` " +
+			"branch is not exercised and this cell races nothing")
+	}
+
+	const iterations = 60
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			d.startClusterComms(ctx)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// The tail returns reconcile errors in this stripped-down harness;
+			// the access under test is step 20's read, which it performs
+			// regardless.
+			_ = d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/dataplane/userspace/egress_zone_identity_6722_test.go
+++ b/pkg/dataplane/userspace/egress_zone_identity_6722_test.go
@@ -1965,7 +1965,6 @@ func TestBarePortOfADifferentRethDoesNotDeferToThisOne_6722(t *testing.T) {
 			"measuring the aliasing, not the redundant-parent match")
 }
 
-
 // #7024: the OUTCOME half. A base/unit divergence must resolve FAIL-CLOSED.
 //
 // Cell P now TOLERATES a base-reference divergence, which is only defensible if


### PR DESCRIPTION
Closes #7066
Closes #7067

PR #6869 changed two things and **nothing bound either**. Both premises measured
at current `origin/master`, not inherited from the issues.

## #7067 — the WRITE

`TestActiveClusterTransportIsMutexGuarded_6290` stays **green** when the publish
at `daemon_ha_sync.go` is deleted outright (`collected=1` in both arms). With no
write there is no concurrent access, so the race detector has nothing to report
and the probe passes whether the access is correctly guarded **or absent**.

That is inherent to any probe whose only assertion is the race detector: **it
binds HOW an access is synchronized, never THAT the access happens.**
`TestSetActiveTransportDropsStaleEpoch` does not cover it either — it calls
`setActiveTransportIfCurrent` directly and never goes through
`startClusterComms`, so it binds the epoch gate rather than the call site.

## #7066 — the READ

Reverting `daemon_apply_tail.go`'s step 20 to unguarded direct field access
leaves the whole `go test -race ./pkg/daemon/` suite green, **0 DATA RACE** —
because the #6290 probe's reader is the *accessor*, and no test drives
`applyTailReconciles` concurrently with `startClusterComms`. The other step-20
drivers are single-goroutine and seed the field with a direct write, so the pair
the reverted tree races is never executed concurrently by anything.

The new cell drives that actual pair. The transport does not change between the
committed active and the config passed to the tail, so step 20 **reads and
decides not to restart** — the read is what is under test, and a restart storm
would make the cell about something else.

## The fixture detail that decides #7067

`clusterTransportFromConfig` reads `ControlInterface` / `PeerAddress` / the fabric
fields. **The existing #6290 fixture sets none of them**, so its transport key is
the zero value — a value assertion written against it would be zero-equals-zero
and would pass with the publish deleted, reproducing the defect it was written to
bind.

`control-interface` **alone** gives a non-zero key while starting no goroutines
(the heartbeat is gated on control-interface *and* peer-address;
`clusterSyncTransport` falls back to the empty fabric pair when either is
missing). The test **asserts** that premise rather than relying on it.

## Mutation matrix

`collected=2`, **0 build errors** in both cells.

| cell | mutation | result |
|---|---|---|
| M1 | delete the publish | `..._7067` reds on its value assertion; `..._7066` reds on its **premise guard** — correctly, since with no publish there is nothing to race |
| M2 | revert the step-20 reader | `..._7066` reds with **6 DATA RACE** reports where the suite was previously green; `..._7067` **PASSES**, the write being intact |

M2 is the load-bearing row: that revert was green across the entire `-race` suite
before this change.

## A counting bug that nearly became a finding

My first #7067 probe reported `collected=0`, which reads exactly like a `-run`
filter matching nothing — the failure mode where Go exits 0 and prints `ok`. It
was not: I grepped for `^=== RUN` without passing `-v`. Re-run with `-v` it was
`collected=1` in both arms.

Recorded in `docs/log/7066.md` because the instrument and the subject fail the
same way here: "the filter matched nothing" and "I did not ask for the lines I am
counting" are indistinguishable from the count alone.