### PR TITLE
nat64: correct the l3_ctx comment and bind the unguarded seam

### DIFF
--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -7,6 +7,7 @@
 //! that operate on a frame slice without mutating it.
 
 use super::*;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // #989: TCP-specific inspection helpers (frame_has_tcp_rst,
 // extract_tcp_flags_and_window, extract_tcp_window) and tcp_flags_str
@@ -1618,6 +1619,48 @@ pub(in crate::afxdp) fn parse_session_flow_from_meta(meta: UserspaceDpMeta) -> O
 /// and the deny/log records. Returns `None` when the meta carries no usable L3
 /// address (unspecified or non-IP family), in which case the caller leaves the
 /// packet's existing (resolve-only) flowless behavior unchanged.
+/// #7055: how many times a per-packet enforcement site was skipped because no
+/// L3 identity could be derived from the metadata, split by WHICH leg fired.
+///
+/// The name says the leg deliberately. A single "no L3 identity" counter would
+/// tell a future reader nothing about what to do, because the two legs have
+/// opposite meanings:
+///
+///   - `L3_CTX_NONE_UNKNOWN_FAMILY` should stay at ZERO in production. The shim
+///     writes `addr_family: parsed.addr_family` and `parsed` only ever comes
+///     from `parse_ipv4`/`parse_ipv6`, which hard-code AF_INET/AF_INET6; a
+///     packet whose parse fails never receives metadata at all. A non-zero value
+///     here means that invariant broke — a metadata-layout or shim change — and
+///     is a bug report, not a traffic observation.
+///   - `L3_CTX_NONE_UNSPECIFIED_ADDR` is REACHABLE with ordinary (if unusual)
+///     packets: the shim stamps `flow_{src,dst}_addr` faithfully, so an IP
+///     header carrying `0.0.0.0`/`::` produces `None` from a fully parsed
+///     packet. A dst-unspecified packet dies at NoRoute, but a SRC-unspecified
+///     one with a valid destination routes normally. A non-zero value here is a
+///     traffic observation, and on the fragment-association arms it means an
+///     operator-configured control (`from is-fragment then discard`, the PBR
+///     `then { routing-instance X; discard; }` term) was not evaluated.
+///
+/// Cumulative and process-global, like `INTERFACE_SNAT_PAT_COLLISIONS`, so tests
+/// read them as a delta.
+///
+/// These COUNT; they do not change disposition. The callers still forward, and
+/// deliberately so: the same `if let Some(l3_flow)` gate exists on the
+/// association-HIT arm, the session-MISS arm and the MissingNeighbor policy arm,
+/// and the hit/miss pair carries an explicit invariant that they must not
+/// diverge on what the filter sees. Making one arm discard would break that
+/// invariant while leaving the bypass reachable through the others. The
+/// disposition question is tracked separately in #7890 (which covers all three
+/// sites — the hit arm, the miss arm, and the MissingNeighbor policy arm — since
+/// changing one alone would break the stated hit/miss parity invariant while
+/// leaving the bypass reachable through the others). This counter exists so the
+/// seam cannot be silently widened by a future metadata change.
+pub(in crate::afxdp) static L3_CTX_NONE_UNKNOWN_FAMILY: AtomicU64 = AtomicU64::new(0);
+
+/// See `L3_CTX_NONE_UNKNOWN_FAMILY`. This is the leg that is reachable in
+/// production (#7055).
+pub(in crate::afxdp) static L3_CTX_NONE_UNSPECIFIED_ADDR: AtomicU64 = AtomicU64::new(0);
+
 pub(in crate::afxdp) fn l3_session_flow_from_meta(meta: UserspaceDpMeta) -> Option<SessionFlow> {
     let (src_ip, dst_ip) = match meta.addr_family as i32 {
         libc::AF_INET => {
@@ -1632,9 +1675,17 @@ pub(in crate::afxdp) fn l3_session_flow_from_meta(meta: UserspaceDpMeta) -> Opti
             IpAddr::V6(Ipv6Addr::from(meta.flow_src_addr)),
             IpAddr::V6(Ipv6Addr::from(meta.flow_dst_addr)),
         ),
-        _ => return None,
+        _ => {
+            // #7055: the UNREACHABLE leg — see the counter's doc block.
+            L3_CTX_NONE_UNKNOWN_FAMILY.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
     };
     if src_ip.is_unspecified() || dst_ip.is_unspecified() {
+        // #7055: the REACHABLE leg — an IP header carrying 0.0.0.0/:: from a
+        // fully parsed packet. On the fragment-association arms this is an
+        // operator-configured filter term not being evaluated.
+        L3_CTX_NONE_UNSPECIFIED_ADDR.fetch_add(1, Ordering::Relaxed);
         return None;
     }
     Some(SessionFlow {

--- a/userspace-dp/src/afxdp/frame/inspect_tests.rs
+++ b/userspace-dp/src/afxdp/frame/inspect_tests.rs
@@ -872,3 +872,130 @@ fn metadata_tuple_complete_refuses_unresolved_ipv6_ext_protocols_even_with_ports
          otherwise pass vacuously"
     );
 }
+
+// ---- #7055: which l3_session_flow_from_meta None legs are REACHABLE ----
+//
+// The fragment-association HIT arm and the session-miss arm both wrap their
+// entire per-packet enforcement block (interface input filter, PBR
+// `then { routing-instance X; discard; }`) in
+// `if let Some(l3_flow) = l3_ctx.as_ref()`. So every `None` is a packet
+// forwarded with NO filter evaluation, and which `None`s are reachable decides
+// whether that is a latent seam or a live fail-open.
+//
+// #7055 asserted `None` is "a test-fixture shape, not a production shape". These
+// cells pin the measurement that says that is only half true: the addr_family
+// leg is a fixture shape, the unspecified-source leg is not. Both the comment
+// #7055 corrects and #7055's own correction reason from "the shim stamps the
+// field" to "the value is usable", and that step does not hold.
+
+// Counter deltas, read the way INTERFACE_SNAT_PAT_COLLISIONS' tests do: these
+// are process-global and cumulative, so an absolute value would be order- and
+// parallelism-dependent. `make test-rust` runs --test-threads=1, so a delta
+// taken around a single call is exact.
+fn l3_none_counts_7055() -> (u64, u64) {
+    (
+        L3_CTX_NONE_UNKNOWN_FAMILY.load(std::sync::atomic::Ordering::Relaxed),
+        L3_CTX_NONE_UNSPECIFIED_ADDR.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
+#[test]
+fn l3_ctx_none_on_unknown_family_is_the_unreachable_leg_7055() {
+    // The shim writes `addr_family: parsed.addr_family`, and `parsed` only ever
+    // comes from parse_ipv4/parse_ipv6, which hard-code AF_INET/AF_INET6. A
+    // packet whose parse fails never receives metadata at all. So this leg is a
+    // FIXTURE shape: constructible here, not constructible by the shim.
+    let meta = UserspaceDpMeta {
+        addr_family: libc::AF_UNIX as u8,
+        flow_src_addr: [1u8; 16],
+        flow_dst_addr: [2u8; 16],
+        ..UserspaceDpMeta::default()
+    };
+    let (fam0, uns0) = l3_none_counts_7055();
+    assert!(
+        l3_session_flow_from_meta(meta).is_none(),
+        "a non-v4/v6 addr_family must yield None"
+    );
+    let (fam1, uns1) = l3_none_counts_7055();
+    assert_eq!(
+        fam1 - fam0,
+        1,
+        "the UNKNOWN-FAMILY counter must advance for this leg"
+    );
+    assert_eq!(
+        uns1 - uns0,
+        0,
+        "the UNSPECIFIED-ADDR counter must NOT advance for a family miss. The two \
+         legs mean opposite things — unknown-family should be ZERO in production \
+         and is a bug report, unspecified-addr is reachable traffic — so a \
+         counter that cannot tell them apart tells a future reader nothing \
+         actionable (#7055)"
+    );
+}
+
+#[test]
+fn l3_ctx_none_on_unspecified_source_is_the_reachable_leg_7055() {
+    // THE CELL THAT MATTERS. A fully-parsed IPv4 packet whose header carries
+    // 0.0.0.0 as the source: the shim stamps that faithfully, so this is a
+    // PRODUCTION shape, not a fixture artefact. Nothing upstream rejects it —
+    // routing keys on destination, `is_martian_dst` only sub-classifies an
+    // already-decided NoRoute, and the addr_class source predicates gate
+    // ICMP-error generation and neighbour learning rather than transit.
+    let mut src_zero = UserspaceDpMeta {
+        addr_family: libc::AF_INET as u8,
+        ..UserspaceDpMeta::default()
+    };
+    src_zero.flow_src_addr[..4].copy_from_slice(&[0, 0, 0, 0]);
+    src_zero.flow_dst_addr[..4].copy_from_slice(&[10, 0, 0, 1]);
+    let (fam0, uns0) = l3_none_counts_7055();
+    assert!(
+        l3_session_flow_from_meta(src_zero).is_none(),
+        "an unspecified IPv4 SOURCE with a valid destination must yield None — \
+         this is the leg #7055 called a fixture shape and it is reachable: the \
+         enforcement block is skipped for such a packet on both the hit and \
+         miss arms"
+    );
+    let (fam1, uns1) = l3_none_counts_7055();
+    assert_eq!(uns1 - uns0, 1, "the UNSPECIFIED-ADDR counter must advance");
+    assert_eq!(
+        fam1 - fam0,
+        0,
+        "the family counter must NOT advance — the family was valid AF_INET"
+    );
+
+    // Same for IPv6 (`::` source), the DAD shape.
+    let mut v6_src_zero = UserspaceDpMeta {
+        addr_family: libc::AF_INET6 as u8,
+        ..UserspaceDpMeta::default()
+    };
+    v6_src_zero.flow_dst_addr = [
+        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    ];
+    assert!(
+        l3_session_flow_from_meta(v6_src_zero).is_none(),
+        "an unspecified IPv6 source must yield None"
+    );
+
+    // POSITIVE CONTROL, on the same family and the same builder: a specified
+    // source DOES yield Some. Without this the two assertions above would pass
+    // on a function that returned None for everything, and the reachability
+    // claim would be vacuous.
+    let mut ok = UserspaceDpMeta {
+        addr_family: libc::AF_INET as u8,
+        ..UserspaceDpMeta::default()
+    };
+    ok.flow_src_addr[..4].copy_from_slice(&[192, 0, 2, 1]);
+    ok.flow_dst_addr[..4].copy_from_slice(&[10, 0, 0, 1]);
+    let (fam2, uns2) = l3_none_counts_7055();
+    let flow = l3_session_flow_from_meta(ok)
+        .expect("a fully specified v4 pair must yield Some — else these cells are vacuous");
+    assert_eq!(flow.forward_key.src_port, 0, "flowless: no L4 ports (#3291)");
+    let (fam3, uns3) = l3_none_counts_7055();
+    assert_eq!(
+        (fam3 - fam2, uns3 - uns2),
+        (0, 0),
+        "a SUCCESSFUL derivation must advance neither counter, or the counters \
+         measure call volume rather than the skipped-enforcement events they \
+         exist to report"
+    );
+}

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -3776,11 +3776,38 @@ pub(super) fn poll_binding_process_descriptor(
                     // fragment counter.
                     //
                     // The destination comes from the FRAME, not from `l3_ctx`.
-                    // `l3_ctx` is built from `meta.flow_{src,dst}_addr`, which
-                    // the shim stamps but a flowless packet need not carry — it
-                    // is `None` for exactly the meta-less fragments this gate
-                    // exists to stop, so gating on it would have left the leak
-                    // open on the majority of them. Placed after the transit
+                    // The reason is that the frame is the packet's own header
+                    // and does not depend on the flow-address stamp — NOT, as
+                    // this comment previously claimed, that `l3_ctx` is `None`
+                    // "for exactly the meta-less fragments this gate exists to
+                    // stop". That claim was wrong, and wrong in a way that would
+                    // have made the Element-2 guard ~500 lines above inert on
+                    // most real fragments if it had been true (#7055).
+                    //
+                    // Measured. `l3_session_flow_from_meta` returns `None` on
+                    // exactly two legs, and they differ:
+                    //
+                    //   - A non-v4/v6 `addr_family`: UNREACHABLE here. The shim
+                    //     writes `addr_family: parsed.addr_family` and `parsed`
+                    //     only ever comes from `parse_ipv4`/`parse_ipv6`, which
+                    //     hard-code AF_INET/AF_INET6; a packet whose parse fails
+                    //     never receives metadata at all.
+                    //   - An unspecified source or destination: REACHABLE, and
+                    //     nothing upstream drops it. The shim stamps
+                    //     `flow_{src,dst}_addr` faithfully from the IP header,
+                    //     so a header carrying `0.0.0.0`/`::` yields `None` from
+                    //     a fully-parsed packet. A dst-unspecified packet dies
+                    //     at NoRoute, but a SRC-unspecified one with a valid
+                    //     destination routes normally: `is_martian_dst` only
+                    //     sub-classifies an already-decided NoRoute, and the
+                    //     `addr_class` source predicates gate ICMP-error
+                    //     generation and neighbour learning, not transit.
+                    //
+                    // So a fragment IS normally `Some` — the shim stamps the
+                    // addresses for every packet that got this far — but "the
+                    // field is stamped" does not imply "the value is usable",
+                    // which is the step both the old comment and the issue that
+                    // corrected it skipped. Placed after the transit
                     // policy block (not inside it) for the same reason, and
                     // scoped to ForwardCandidate: NoRoute/MissingNeighbor/
                     // HAInactive/LocalDelivery have their own arms and none of


### PR DESCRIPTION
Closes #7055

Scope as decided: correct the comment, bind the seam with counters, leave the
forward in place. The disposition change is filed separately as **#7890**.

## Neither of the two contradicting statements is fully true

The Pref64 gate comment claimed `l3_ctx` "is `None` for exactly the meta-less
fragments this gate exists to stop". If that were so, the Element-2 guard ~500
lines above would be inert on most real fragments. #7055 corrected it by
asserting the opposite — that `None` is "a test-fixture shape, not a production
shape".

**That is also wrong, by the same step.** Both reason from *"the shim stamps the
field"* to *"the value is usable"*.

### Measured: two legs, different verdicts

**Leg 1 — non-v4/v6 `addr_family`: UNREACHABLE.** The shim writes
`addr_family: parsed.addr_family`, and `parsed` only ever comes from
`parse_ipv4`/`parse_ipv6`, which hard-code `AF_INET`/`AF_INET6`. A packet whose
parse fails never receives metadata at all.

**Leg 2 — unspecified source or destination: REACHABLE.** The shim stamps
`flow_{src,dst}_addr` faithfully, so an IP header carrying `0.0.0.0` / `::`
yields `None` from a **fully parsed** packet. Destination-unspecified dies at
NoRoute; **source**-unspecified with a valid destination routes normally.

Negative results, checked individually rather than inferred:

- `is_martian_dst` — its own doc says it "does not itself drop"; it only
  sub-classifies an already-decided NoRoute.
- `source_is_invalid_for_icmp_error` and the `addr_class.rs` predicates — gate
  locally-generated ICMP errors and neighbour learnability, **not** transit.
- The shim performs no martian/bogon source filtering.

The comment now names both legs and their separate verdicts rather than picking a
winner between two wrong sentences.

## Why counters and not a discard

The hit arm (`:3269`), the miss arm (`:3496`) **and** the MissingNeighbor policy
arm (`:4739`, which gates `evaluate_policy_result_l3_aware` with no `else`) all
skip enforcement on `None`. The comment directly above the hit arm states:

> Evaluated with the SAME inputs, in the same shape, as the miss branch's copy
> below … so hit and miss cannot diverge on what the filter sees.

Discarding on the hit arm alone would add a drop, keep the bypass reachable
through the other two, and break that invariant. All three move together or none
do — filed as **#7890**.

## The counters are split by leg, and named for it

`L3_CTX_NONE_UNKNOWN_FAMILY` and `L3_CTX_NONE_UNSPECIFIED_ADDR`. A single
"no L3 identity" counter would tell a future reader nothing actionable, because
the legs mean opposite things: the first should be **zero forever** and a
non-zero value is a bug report about a shim/metadata change; the second is
**reachable traffic**, and on the association arms means an operator-configured
control was not evaluated.

## The tests assert WHICH counter moves

Not merely that `None` is returned — plus a positive control that a **successful**
derivation advances neither, or the counters would be measuring call volume
rather than the skipped-enforcement events they exist to report.

**That assertion earned its keep immediately.** My first instrumentation landed in
`parse_session_flow_from_meta`, a near-identical sibling of
`l3_session_flow_from_meta` whose `None` legs are textually identical — my
`replace` had no uniqueness assertion. The build was clean and the `is_none()`
assertions passed. **Only the counter delta caught it.** Had the tests asserted
only "returns `None`", this would have shipped instrumentation on a function
these sites never call, and reported the seam as bound. Noted in #7890 so the
next editor anchors on the enclosing function.

## Scope

Touches `poll_descriptor/mod.rs` (comment only) and `frame/inspect.rs` +
`frame/inspect_tests.rs`. **Does not reach `FragAuthority` or the frag key** — no
overlap with #7051 or #7054.

## Validation

- `cargo build` — clean
- `cargo test --bins -- --test-threads=1 _7055` — **2 passed**, 4762 filtered,
  under a per-cell `CARGO_TARGET_DIR` in `/var/tmp`; `df -h /` checked first
  (200G free)
- Full `cargo test --bins -- --test-threads=1` running; result posted as a
  comment when it lands.