### PR TITLE
daemon: bind the RETH rollback's joined-dataplane pin

### DIFF
--- a/docs/log/7074.md
+++ b/docs/log/7074.md
@@ -1,0 +1,59 @@
+# #7074 — bind the RETH rollback's dataplane pin
+
+- **Timestamp**: 2026-08-28
+- **Action**: Bound `programRethMACWithWorkerJoin`'s `joined` pin with two tests.
+  Test-only; no production behaviour change.
+- **File(s)**: `pkg/daemon/reth_rollback_dataplane_pin_7074_test.go` (new),
+  `pkg/daemon/reth_prepare_abort_recovery_5103_test.go` (additive `onPrepare` hook)
+
+## Premise re-measured at head, and one correction
+
+The issue's diff quotes the rollback as
+`joined.Link().NotifyLinkCycle()`. At `2f76a925e` the call is
+`joined.Link().NotifyLinkCycleKeepingLease()` — changed by #7007, the
+repair-without-release variant. The substance is unchanged, but an edit anchored
+on the issue's text matches NOTHING.
+
+That mattered: my first revert script asserted uniqueness on both anchors, the
+second assertion fired, and the file was left untouched. The build and suite I
+then ran were measuring UNMODIFIED code and came back green — which would have
+read as "the revert is green", the very claim under test, from a run that never
+applied the revert. Re-measured with the correct anchor:
+
+```
+go build ./pkg/daemon/            rc=0
+go test -count=1 ./pkg/daemon/... rc=0, zero named failures
+```
+
+Premise confirmed: the pin is genuinely unbound.
+
+## The window, and why no existing test reaches it
+
+Since #6743 the dataplane is read through an atomic cell, so it can be swapped or
+cleared between the join and the rollback. Reaching that needs a republish DURING
+the `beforeCycle` hook — the only window in which the cell is live and the
+rollback has not yet run. The existing fixtures had no way to run code inside the
+hook, so an additive `onPrepare func()` on `abortRecoveryLinkController` (nil for
+every pre-existing test) supplies it.
+
+## Two cells, because a cell can do two things a plain field could not
+
+| cell | models | what the re-read does |
+|---|---|---|
+| `...RebindsTheJOINEDDataplane_7074` | a DIFFERENT dataplane published mid-hook | rebinds the wrong helper — unwinds a `stop_workers` sent to another instance, leaving the joined one mid-teardown with no owner |
+| `...SurvivesAClearedDataplaneCell_7074` | the cell CLEARED mid-hook | nil-derefs and panics the apply |
+
+Both assert the rebind LANDED (`notifyCalls == 1`), not merely that nothing
+panicked: a rollback that silently did nothing would also not panic.
+
+## Red-on-revert, measured
+
+Both cells fail under the revert, and the cleared-cell test fails with
+`panic: runtime error: invalid memory address or nil pointer dereference` —
+confirming the nil-deref claim empirically rather than by reasoning.
+
+## No documentation change
+
+Production behaviour is unchanged; this binds an existing invariant. The
+invariant's rationale is already stated in `programRethMACWithWorkerJoin`'s own
+comment (#6743), and the new tests reference it.

--- a/pkg/daemon/reth_prepare_abort_recovery_5103_test.go
+++ b/pkg/daemon/reth_prepare_abort_recovery_5103_test.go
@@ -55,6 +55,11 @@ import (
 // renewal that fires on some members and not others is the same intermittent
 // defect with extra steps.
 type abortRecoveryLinkController struct {
+	// #7074: onPrepare runs INSIDE PrepareLinkCycle, i.e. inside the
+	// beforeCycle hook, which is the only window in which the dataplane cell
+	// can be republished between the join and the rollback. Nil for every
+	// pre-existing test, so this is additive.
+	onPrepare    func()
 	prepareErr   error
 	notifyErr    error
 	prepareCalls int
@@ -68,6 +73,9 @@ func (c *abortRecoveryLinkController) SetDeferWorkers(bool) {}
 
 func (c *abortRecoveryLinkController) PrepareLinkCycle() error {
 	c.prepareCalls++
+	if c.onPrepare != nil {
+		c.onPrepare()
+	}
 	return c.prepareErr
 }
 

--- a/pkg/daemon/reth_rollback_dataplane_pin_7074_test.go
+++ b/pkg/daemon/reth_rollback_dataplane_pin_7074_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+// #7074: the RETH abort rollback must rebind the dataplane instance whose
+// workers it actually stopped, not whichever one happens to be published when
+// the rollback runs.
+//
+// Since #6743 the dataplane is read through an atomic cell (`d.dataplane()`),
+// not a plain field, so a bootstrap-exit publish can swap or clear it between
+// the join and the rollback. `programRethMACWithWorkerJoin` therefore pins the
+// joined instance in a local. Before this test nothing bound that pin: reverting
+// it to a re-read (`d.dataplane().Link().NotifyLinkCycleKeepingLease()`) left
+// `go test ./pkg/daemon/...` fully green — measured at 2f76a925e, rc=0, zero
+// named failures.
+//
+// The window is real but narrow, which is why no existing test reaches it: it
+// needs a republish DURING the beforeCycle hook. That is what `onPrepare` is
+// for.
+//
+// What the re-read would do, and why it is worse than a nil-deref: the rollback
+// exists to send "rebind" to undo the "stop_workers" the hook sent. Re-reading
+// the cell can address that rebind to a DIFFERENT helper — one whose workers
+// were never stopped — leaving the first instance mid-teardown with no owner
+// (forwarding down on the node, the #5103 F4 outage) while the second is told to
+// rebind sockets it never released.
+func TestRethAbortRollbackRebindsTheJOINEDDataplane_7074(t *testing.T) {
+	var events []string
+	withRethOps(t, newRecordingRethOps(t, &events, curMAC5103, true /* force the cycle */))
+
+	// The instance the hook will actually join, and the one published over it.
+	first := &abortRecoveryLinkController{prepareErr: errors.New("stop_workers: helper did not respond")}
+	second := &abortRecoveryLinkController{}
+
+	d := &Daemon{}
+	d.setDataplane(&abortRecoveryTestDP{link: first})
+
+	// Republish INSIDE the hook — after the join has read the cell and stopped
+	// `first`'s workers, before the rollback runs. This models the #6743
+	// bootstrap-exit publish landing mid-apply.
+	first.onPrepare = func() {
+		d.setDataplane(&abortRecoveryTestDP{link: second})
+	}
+
+	linkCycled, commitErr := d.programRethMACWithWorkerJoin("ge-0-0-1", virtMAC5103, nil)
+
+	// Preconditions. Without these the assertions below could pass on a fixture
+	// that never reached the hook or never aborted, which is the vacuous shape.
+	if first.prepareCalls != 1 {
+		t.Fatalf("precondition: the hook must run on the FIRST instance "+
+			"(PrepareLinkCycle calls = %d, want 1)", first.prepareCalls)
+	}
+	if second.prepareCalls != 0 {
+		t.Fatalf("precondition: the SECOND instance's workers were never stopped, so it "+
+			"must not have been prepared (calls = %d, want 0)", second.prepareCalls)
+	}
+	if linkCycled {
+		t.Fatal("precondition: the cycle must have aborted")
+	}
+	if commitErr == nil {
+		t.Fatal("precondition: an aborted join must reach the commit")
+	}
+
+	// THE ASSERTION.
+	if first.notifyCalls != 1 {
+		t.Errorf("the rollback rebound %d time(s) on the JOINED dataplane, want 1. "+
+			"The hook stopped THIS instance's workers, so this is the instance that "+
+			"must be told to rebind; leaving it mid-teardown with no owner is the "+
+			"#5103 F4 forwarding outage the rollback exists to prevent (#7074)",
+			first.notifyCalls)
+	}
+	if second.notifyCalls != 0 {
+		t.Errorf("the rollback rebound the dataplane published AFTER the join "+
+			"(%d call(s), want 0). That helper's workers were never stopped, so the "+
+			"rebind unwinds a stop_workers that was sent to a DIFFERENT helper — "+
+			"the re-read reads the cell at rollback time instead of the pinned "+
+			"instance (#7074)", second.notifyCalls)
+	}
+}
+
+// TestRethAbortRollbackSurvivesAClearedDataplaneCell_7074 is the paired cell for
+// the other thing a cell can do that a plain field could not: go to nil.
+//
+// A re-read would nil-deref here and panic the apply goroutine. The pin keeps
+// the rollback addressed to the instance it joined, so the rebind still lands.
+// Asserting "does not panic" alone would be weak — a rollback that silently did
+// nothing would also not panic — so the rebind is asserted to have happened.
+func TestRethAbortRollbackSurvivesAClearedDataplaneCell_7074(t *testing.T) {
+	var events []string
+	withRethOps(t, newRecordingRethOps(t, &events, curMAC5103, true))
+
+	joined := &abortRecoveryLinkController{prepareErr: errors.New("stop_workers: timeout")}
+	d := &Daemon{}
+	d.setDataplane(&abortRecoveryTestDP{link: joined})
+	joined.onPrepare = func() { d.setDataplane(nil) }
+
+	_, commitErr := d.programRethMACWithWorkerJoin("ge-0-0-1", virtMAC5103, nil)
+
+	if joined.prepareCalls != 1 {
+		t.Fatalf("precondition: the hook must have joined the instance; calls = %d", joined.prepareCalls)
+	}
+	if commitErr == nil {
+		t.Fatal("precondition: an aborted join must reach the commit")
+	}
+	if joined.notifyCalls != 1 {
+		t.Errorf("with the dataplane cell CLEARED during the hook the rollback must still "+
+			"rebind the joined instance (calls = %d, want 1). A re-read would dereference "+
+			"a nil dataplane and panic the apply; joinRan implying non-nil was sound "+
+			"against the pre-#6743 plain field and is not sound against a cell (#7074)",
+			joined.notifyCalls)
+	}
+}


### PR DESCRIPTION
Closes #7074

Test-only. `programRethMACWithWorkerJoin` pins the dataplane instance its
`beforeCycle` hook joined so the abort rollback rebinds the instance whose
workers it actually stopped. Nothing bound that pin — reverting it to a re-read
left `./pkg/daemon/...` fully green.

## Premise re-measured, and the issue's snippet is stale

The issue quotes the rollback as `joined.Link().NotifyLinkCycle()`. At head it is
`joined.Link().NotifyLinkCycleKeepingLease()` — changed by #7007, the
repair-without-release variant. Substance unchanged, but **an edit anchored on
the issue's text matches nothing**.

That mattered, and it is worth stating because the failure mode was a false
confirmation rather than an error: my revert script asserted uniqueness on both
anchors, the second assertion fired, and the file was left **untouched**. The
`go build` and `go test` I ran next were measuring **unmodified code** and came
back green — which reads exactly like "the revert is green", the very claim under
test, from a run that never applied the revert. Only `git diff --stat` showing no
change distinguished them.

Re-measured with the correct anchor: the revert builds, and
`go test -count=1 ./pkg/daemon/...` is **rc=0 with zero named failures**. The
premise holds.

## Why no existing test reaches the window

Since #6743 the dataplane is read through an atomic cell, so it can be swapped or
cleared between the join and the rollback. Reaching that needs a republish
**during** the `beforeCycle` hook — the only moment the cell is live and the
rollback has not yet run. The existing fixtures could not run code inside the
hook, so an additive `onPrepare func()` on `abortRecoveryLinkController` (nil for
every pre-existing test) supplies it. That is the "second recorder plus a publish
inside the hook" the issue describes.

## Two cells, because a cell can do two things a plain field could not

| cell | models | what the re-read does |
|---|---|---|
| `TestRethAbortRollbackRebindsTheJOINEDDataplane_7074` | a **different** dataplane published mid-hook | rebinds the wrong helper — unwinds a `stop_workers` sent to another instance, leaving the joined one mid-teardown with no owner (the #5103 F4 forwarding outage) |
| `TestRethAbortRollbackSurvivesAClearedDataplaneCell_7074` | the cell **cleared** mid-hook | nil-derefs and panics the apply; `joinRan` implying non-nil was sound against a plain field and is not against a cell |

Both assert the rebind **landed** (`notifyCalls == 1`), not merely that nothing
panicked — a rollback that silently did nothing would also not panic. Both carry
preconditions (the hook ran on the first instance; the second was never prepared;
the cycle aborted; the commit failed) so they cannot pass on a fixture that never
reached the hook.

## Red-on-revert

Both cells fail under the revert with named failures, and the cleared-cell test
fails with:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

— confirming the nil-deref empirically rather than by argument.

## Scope

`pkg/daemon/reth_rollback_dataplane_pin_7074_test.go` (new) and an additive hook
in `reth_prepare_abort_recovery_5103_test.go`. **Does not touch
`daemon_apply_tail.go`, `daemon_ha_sync.go`, or `cluster_transport_race_6290_test.go`**
— no overlap with #7889 or close-6948's #7071/#7072.

## No documentation change

Production behaviour is unchanged; this binds an existing invariant whose
rationale already lives in the function's own #6743 comment, which the tests
cite.

## Validation

`go test -count=1 ./pkg/daemon/...` — **ok, ok**