### PR TITLE
userspace-dp/nat64: count fragment-association evictions of LIVE entries

### DIFF
--- a/pkg/dataplane/userspace/protocol_binding.go
+++ b/pkg/dataplane/userspace/protocol_binding.go
@@ -214,6 +214,10 @@ type BindingStatus struct {
 	// omitempty + the Rust serde `default` keep cross-version wire safety (an
 	// older helper omits it → 0).
 	Nat64FragDropped uint64 `json:"nat64_frag_dropped,omitempty"`
+	// #7054: first-fragment installs that evicted a still-LIVE fragment
+	// association (shard at cap, nothing expired to reclaim). Separates capacity
+	// pressure from ordinary reorder/orphan drops.
+	Nat64FragAssocEvicted uint64 `json:"nat64_frag_assoc_evicted,omitempty"`
 	// #5623: fail-closed NAT64 SOURCE-ineligibility drops — an incoming IPv6
 	// packet whose SOURCE lies within a configured Pref64 (a looping/synthesized
 	// "already-translated" source, the RFC 6146 §5 hairpin construction — plus

--- a/userspace-dp/src/afxdp/binding_state/mod.rs
+++ b/userspace-dp/src/afxdp/binding_state/mod.rs
@@ -301,6 +301,8 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// fragments traverse end-to-end is deferred, so this is the observable-drop
     /// half of #2562.
     pub(super) nat64_frag_dropped: AtomicU64,
+    /// #7054: first-fragment installs that evicted a still-LIVE association.
+    pub(super) nat64_frag_assoc_evicted: AtomicU64,
     /// #5623: cumulative fail-closed NAT64 SOURCE-ineligibility drops — an
     /// incoming IPv6 packet whose SOURCE lies within a configured Pref64 (a
     /// looping/synthesized "already-translated" source, the RFC 6146 §5 hairpin
@@ -814,10 +816,25 @@ pub(in crate::afxdp) struct BindingLiveState {
 // guard reporting a real layout change and being answered, not defeated.
 // `size_of` is unchanged at 2304: the 8 bytes came out of existing tail
 // padding, so the next field added here will move it and should expect to.
+//
+// #7054 re-measured the two offsets again (2160 -> 2168, 2288 -> 2296) when
+// `nat64_frag_assoc_evicted` joined the cold-counter run. Same legitimate case
+// as #6664: the field is UNCONDITIONAL, so the production and test builds shift
+// by the same 8 bytes and re-measuring makes both green together — the guard
+// reporting a real layout change and being answered, not defeated. (Contrast
+// the `#[cfg(test)]` hazard above, where at most one of the two builds can be
+// green at any one pair of literals, which is what makes that case
+// un-satisfiable by re-measuring.)
+//
+// The #6664 note's prediction that "the next field added here will move
+// `size_of`" did NOT hold: it is still 2304, because the tail padding had room
+// for a second u64. Recorded so the next reader does not treat an unchanged
+// 2304 as evidence their field failed to land — check the OFFSETS, which did
+// move.
 const _: [(); 2304] = [(); std::mem::size_of::<BindingLiveState>()];
 const _: [(); 64] = [(); std::mem::align_of::<BindingLiveState>()];
-const _: [(); 2160] = [(); std::mem::offset_of!(BindingLiveState, pending_tx_admitted)];
-const _: [(); 2288] = [(); std::mem::offset_of!(BindingLiveState, delta_loss_pending)];
+const _: [(); 2168] = [(); std::mem::offset_of!(BindingLiveState, pending_tx_admitted)];
+const _: [(); 2296] = [(); std::mem::offset_of!(BindingLiveState, delta_loss_pending)];
 
 impl BindingLiveState {
     pub(super) fn new() -> Self {
@@ -899,6 +916,7 @@ impl BindingLiveState {
             nat64_no_source_pool: AtomicU64::new(0),
             nat64_pool_exhausted: AtomicU64::new(0),
             nat64_frag_dropped: AtomicU64::new(0),
+            nat64_frag_assoc_evicted: AtomicU64::new(0),
             nat64_ineligible_source: AtomicU64::new(0),
             nat64_ineligible_dest: AtomicU64::new(0),
             nat64_exthdr_ineligible: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/binding_state/snapshot.rs
+++ b/userspace-dp/src/afxdp/binding_state/snapshot.rs
@@ -149,6 +149,7 @@ impl BindingLiveState {
             nat64_no_source_pool: self.nat64_no_source_pool.load(Ordering::Relaxed),
             nat64_pool_exhausted: self.nat64_pool_exhausted.load(Ordering::Relaxed),
             nat64_frag_dropped: self.nat64_frag_dropped.load(Ordering::Relaxed),
+            nat64_frag_assoc_evicted: self.nat64_frag_assoc_evicted.load(Ordering::Relaxed),
             nat64_ineligible_source: self.nat64_ineligible_source.load(Ordering::Relaxed),
             nat64_ineligible_dest: self.nat64_ineligible_dest.load(Ordering::Relaxed),
             nat64_exthdr_ineligible: self.nat64_exthdr_ineligible.load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs
+++ b/userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs
@@ -139,6 +139,15 @@ fn enqueue_tx_owned_below_cap_does_not_touch_overflow_counter() {
 /// full scope, including why `repr(Rust)` plus an unpinned toolchain makes these
 /// literals a build tripwire rather than a portable invariant.
 #[test]
+// #7054 re-measured the two OFFSET literals here (2160 -> 2168, 2288 -> 2296)
+// in lockstep with the compile-time asserts in `binding_state/mod.rs`, when the
+// unconditional `nat64_frag_assoc_evicted` counter joined the cold-counter run.
+// Both must move together: this runtime cell and those `const _` asserts are
+// the pair that makes a `#[cfg(test)]` field detectable, because for such a
+// field production and test builds disagree and at most one can be green at any
+// one set of literals. An unconditional field shifts both by the same 8 bytes,
+// so re-measuring both is the guard being ANSWERED. `size_of` stays 2304 — the
+// bytes came out of tail padding, again.
 fn admission_attempt_instrument_leaves_four_pinned_layout_values_unchanged_6304() {
     assert_eq!(
         std::mem::size_of::<BindingLiveState>(),
@@ -155,14 +164,14 @@ fn admission_attempt_instrument_leaves_four_pinned_layout_values_unchanged_6304(
     );
     assert_eq!(
         std::mem::offset_of!(BindingLiveState, pending_tx_admitted),
-        2160,
+        2168,
         "#6304/#6114: ...nor the OFFSET of the admission counter whose \
          cacheline this is all about. A `cfg(test)` field ahead of it moves \
          this to 2160 while leaving the size assert above satisfied"
     );
     assert_eq!(
         std::mem::offset_of!(BindingLiveState, delta_loss_pending),
-        2288,
+        2296,
         "#6304: ...nor the offset of the last-declared field, which is the \
          sentinel for a `cfg(test)` member appended at the END of the struct — \
          that shape moves this to 2288 and trips nothing else"

--- a/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
@@ -53,6 +53,7 @@ pub(super) fn reset_binding_counters(bindings: &mut [BindingStatus]) {
         binding.nat64_no_source_pool = 0;
         binding.nat64_pool_exhausted = 0;
         binding.nat64_frag_dropped = 0;
+        binding.nat64_frag_assoc_evicted = 0;
         binding.nat64_ineligible_source = 0;
         binding.nat64_ineligible_dest = 0;
         binding.nat64_exthdr_ineligible = 0;

--- a/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
+++ b/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
@@ -137,6 +137,7 @@ fn copy_live_snapshot(binding: &mut BindingStatus, snap: BindingLiveSnapshot) {
     binding.nat64_no_source_pool = snap.nat64_no_source_pool;
     binding.nat64_pool_exhausted = snap.nat64_pool_exhausted;
     binding.nat64_frag_dropped = snap.nat64_frag_dropped;
+    binding.nat64_frag_assoc_evicted = snap.nat64_frag_assoc_evicted;
     binding.nat64_ineligible_source = snap.nat64_ineligible_source;
     binding.nat64_ineligible_dest = snap.nat64_ineligible_dest;
     binding.nat64_exthdr_ineligible = snap.nat64_exthdr_ineligible;
@@ -360,6 +361,7 @@ fn zero_unbound_slot(binding: &mut BindingStatus) {
     binding.nat64_no_source_pool = 0;
     binding.nat64_pool_exhausted = 0;
     binding.nat64_frag_dropped = 0;
+    binding.nat64_frag_assoc_evicted = 0;
     binding.nat64_ineligible_source = 0;
     binding.nat64_ineligible_dest = 0;
     binding.nat64_exthdr_ineligible = 0;

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -675,6 +675,15 @@ pub(in crate::afxdp) struct BatchCounters {
     // let real fragments traverse end-to-end (#3291 stage 4) is deferred, so
     // this is the observable-drop half of #2562.
     nat64_frag_dropped: u64,
+    // #7054: first-fragment installs that evicted a still-LIVE association
+    // because their shard was at `NAT64_FRAG_CAP_PER_SHARD` with nothing
+    // expired to reclaim. The eviction itself is correct — a fixed ceiling has
+    // to sacrifice something — but it was SILENT: the victim's non-first
+    // fragments then miss and are dropped fail-closed, and the only trace was a
+    // `nat64_frag_dropped` bump indistinguishable from an ordinary orphan.
+    // Counting it separates "capacity pressure" from "reorder/orphan", which is
+    // what tells an operator whether the shard cap is the problem.
+    nat64_frag_assoc_evicted: u64,
     // #5623: fail-closed NAT64 SOURCE-ineligibility drops — an incoming IPv6
     // packet whose SOURCE lies within a configured Pref64 (a looping/synthesized
     // "already-translated" source, the RFC 6146 §5 hairpin construction — plus
@@ -887,6 +896,13 @@ impl BatchCounters {
         self.nat64_frag_dropped += 1;
     }
 
+    /// #7054: record one first-fragment install that evicted a still-LIVE
+    /// association. Flushed to `BindingLiveState.nat64_frag_assoc_evicted`.
+    pub(in crate::afxdp) fn record_nat64_frag_assoc_evicted(&mut self) {
+        self.touched = true;
+        self.nat64_frag_assoc_evicted += 1;
+    }
+
     /// #6122: record a fail-closed drop of an ordinary same-family NAT'd
     /// non-first fragment that missed the fragment-association cache. Bumped on
     /// the flowless miss path when `flowless_fragment_requires_nat_translation`
@@ -1026,6 +1042,11 @@ impl BatchCounters {
         }
         // #2562: fail-closed NAT64 fragment-drop tally, batched like the sibling
         // nat64 drop counters above.
+        if self.nat64_frag_assoc_evicted != 0 {
+            live.nat64_frag_assoc_evicted
+                .fetch_add(self.nat64_frag_assoc_evicted, Ordering::Relaxed);
+            self.nat64_frag_assoc_evicted = 0;
+        }
         if self.nat64_frag_dropped != 0 {
             live.nat64_frag_dropped
                 .fetch_add(self.nat64_frag_dropped, Ordering::Relaxed);

--- a/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
@@ -99,25 +99,25 @@ pub(super) fn nat64_install_forward_fragment_assoc(
     authority: crate::nat64::FragAuthority,
     decision: &SessionDecision,
     now_ns: u64,
-) {
+) -> bool {
     // #5146: only a genuine NAT64 (cross-family) decision installs here. The
     // ordinary same-family NAT / NPTv6 association is installed by
     // `nat_install_forward_fragment_assoc` (which self-gates the other way), so
     // both can be called at one commit site and exactly one populates the table.
     if !decision.nat.nat64 {
-        return;
+        return false;
     }
     if decision.resolution.disposition != ForwardingDisposition::ForwardCandidate
         || decision.resolution.neighbor_mac.is_none()
     {
-        return;
+        return false;
     }
     if let Some(key) = crate::nat64::nat64_first_fragment_key(l3_packet, addr_family, authority) {
         // #5624: stamp the association with the generation of the forwarding
         // state that admitted this first fragment. `build_generation` advances
         // on every config reload, so an association installed here is rejected
         // once a later commit changes deny/NAT64 rules.
-        forwarding.nat64.frag_assoc.install(
+        return forwarding.nat64.frag_assoc.install(
             key,
             *decision,
             None,
@@ -130,6 +130,7 @@ pub(super) fn nat64_install_forward_fragment_assoc(
             crate::afxdp::forwarding::owner_rg_for_resolution(forwarding, decision.resolution),
         );
     }
+    false
 }
 
 /// #2562: consult the fragment association for a NON-first NAT64 forward
@@ -205,21 +206,21 @@ pub(super) fn nat_install_forward_fragment_assoc(
     authority: crate::nat64::FragAuthority,
     decision: &SessionDecision,
     now_ns: u64,
-) {
+) -> bool {
     // Cross-family NAT64 has its own install (which also stamps the reverse
     // info); here we cache only an ordinary same-family address rewrite.
     if decision.nat.nat64
         || (decision.nat.rewrite_src.is_none() && decision.nat.rewrite_dst.is_none())
     {
-        return;
+        return false;
     }
     if decision.resolution.disposition != ForwardingDisposition::ForwardCandidate
         || decision.resolution.neighbor_mac.is_none()
     {
-        return;
+        return false;
     }
     if let Some(key) = crate::nat64::nat64_first_fragment_key(l3_packet, addr_family, authority) {
-        forwarding.nat64.frag_assoc.install(
+        return forwarding.nat64.frag_assoc.install(
             key,
             *decision,
             None,
@@ -232,6 +233,7 @@ pub(super) fn nat_install_forward_fragment_assoc(
             crate::afxdp::forwarding::owner_rg_for_resolution(forwarding, decision.resolution),
         );
     }
+    false
 }
 
 /// #5689: consult the fragment association for a NON-first ORDINARY same-family

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2625,22 +2625,38 @@ pub(super) fn poll_binding_process_descriptor(
                                                 meta,
                                                 frag_authority_zone_override,
                                             );
-                                            nat64_install_forward_fragment_assoc(
+                                            // #7054: both installs report
+                                            // whether they had to sacrifice a
+                                            // still-LIVE association to a full
+                                            // shard. Counting it separates
+                                            // capacity pressure from the
+                                            // ordinary reorder/orphan miss the
+                                            // victim's later fragments will be
+                                            // dropped as.
+                                            if nat64_install_forward_fragment_assoc(
                                                 worker_ctx.forwarding,
                                                 l3_packet,
                                                 meta.addr_family as i32,
                                                 frag_authority,
                                                 &decision,
                                                 now_ns,
-                                            );
-                                            nat_install_forward_fragment_assoc(
+                                            ) {
+                                                telemetry
+                                                    .counters
+                                                    .record_nat64_frag_assoc_evicted();
+                                            }
+                                            if nat_install_forward_fragment_assoc(
                                                 worker_ctx.forwarding,
                                                 l3_packet,
                                                 meta.addr_family as i32,
                                                 frag_authority,
                                                 &decision,
                                                 now_ns,
-                                            );
+                                            ) {
+                                                telemetry
+                                                    .counters
+                                                    .record_nat64_frag_assoc_evicted();
+                                            }
                                         }
                                         let forward_entry = SyncedSessionEntry {
                                             key: flow.forward_key.clone(),

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1517,6 +1517,8 @@ pub(crate) struct BindingLiveSnapshot {
     /// #2562: cumulative fail-closed NAT64 fragment drops snapshotted from
     /// BindingLiveState (a non-first fragment or a real ICMP/ICMPv6 fragment).
     pub(crate) nat64_frag_dropped: u64,
+    /// #7054: first-fragment installs that evicted a still-LIVE association.
+    pub(crate) nat64_frag_assoc_evicted: u64,
     /// #5623: cumulative fail-closed NAT64 source-ineligibility drops snapshotted
     /// from BindingLiveState (an incoming IPv6 packet whose source lies within a
     /// configured Pref64 — the RFC 6146 §3.5 mandatory hairpin/source drop).

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -667,8 +667,11 @@ impl Nat64FragAssoc {
         // #6857: owner RG of the resolution this fragment was admitted under;
         // 0 when no RG-bound interface owns it.
         owner_rg: i32,
-    ) {
+    ) -> bool {
         let deadline_ns = now_ns.saturating_add(NAT64_FRAG_TTL_NS);
+        // #7054: did this install sacrifice a LIVE association? Reported to the
+        // caller so the condition is observable; see the note above the eviction.
+        let mut evicted_live = false;
         let idx = nat64_frag_shard_index(&key);
         let mut shard = self.shards[idx]
             .lock()
@@ -690,7 +693,7 @@ impl Nat64FragAssoc {
             // would leave the entry stamped with the old value.
             e.owner_rg = owner_rg;
             shard.push(e);
-            return;
+            return false;
         }
         if shard.len() >= NAT64_FRAG_CAP_PER_SHARD {
             // Reclaim EXPIRED slots before touching a live one. Under a flood of
@@ -706,6 +709,7 @@ impl Nat64FragAssoc {
             shard.retain(|e| e.deadline_ns > now_ns);
             if shard.len() >= NAT64_FRAG_CAP_PER_SHARD {
                 shard.remove(0);
+                evicted_live = true;
             }
         }
         shard.push(Nat64FragEntry {
@@ -716,6 +720,7 @@ impl Nat64FragAssoc {
             generation,
             owner_rg,
         });
+        evicted_live
     }
 
     /// Consult the association for a NON-first fragment. Prunes expired entries

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -5138,6 +5138,104 @@ fn nat64_frag_assoc_install_prunes_expired_before_evicting_live() {
 }
 
 #[test]
+fn nat64_frag_assoc_install_reports_only_live_evictions_7054() {
+    // #7054: the shard-cap eviction of a still-LIVE association was SILENT. The
+    // eviction itself is correct — a fixed ceiling has to sacrifice something —
+    // but the victim's non-first fragments then miss and are dropped
+    // fail-closed, and the only trace was a `nat64_frag_dropped` bump
+    // indistinguishable from an ordinary reorder/orphan. `install` now reports
+    // it so the caller can count it.
+    //
+    // REACHABILITY IS ALREADY PROVEN and is not re-proven here:
+    // `nat64_frag_assoc_install_all_live_still_evicts_oldest` below drives an
+    // all-live shard at cap and shows the front entry evicted. What this cell
+    // adds is the SIGNAL.
+    //
+    // THE FALSE CASES ARE THE POINT. `assert!(evicted)` alone passes against a
+    // function that returns `true` unconditionally — and a counter that fires on
+    // every install is worse than no counter, because it reads as constant
+    // capacity pressure. So the three ordinary paths are asserted false: a plain
+    // install into a shard with room, a REFRESH of an existing key, and an
+    // install that reclaimed an EXPIRED slot (the #5447 prune, which must not be
+    // reported as a live eviction).
+    let src = IpAddr::V6("2001:db8::7054".parse().unwrap());
+    let dst = IpAddr::V6("64:ff9b::0707:0707".parse().unwrap());
+    let family = libc::AF_INET6 as u8;
+    let decision = frag_test_decision(Nat64State::forward_decision(
+        Ipv4Addr::new(198, 51, 100, 7),
+        Ipv4Addr::new(7, 7, 7, 7),
+        5007,
+    ));
+    let idents = frag_idents_in_one_shard(src, dst, family, NAT64_FRAG_CAP_PER_SHARD + 2);
+    let mk = |ident: u32| Nat64FragKey {
+        addr_family: family,
+        src,
+        dst,
+        ident,
+        protocol: PROTO_UDP,
+        authority: frag_test_authority(),
+    };
+
+    let cache = Nat64FragAssoc::new();
+
+    // FALSE 1 — a plain install with room in the shard.
+    assert!(
+        !cache.install(mk(idents[0]), decision, None, 1_000, 1, 0),
+        "an install into a shard with room evicted nothing and must report false"
+    );
+    // FALSE 2 — a REFRESH of the same key. It takes the early return and cannot
+    // evict; reporting true here would count every retransmitted first fragment.
+    assert!(
+        !cache.install(mk(idents[0]), decision, None, 2_000, 1, 0),
+        "a same-key refresh evicts nothing and must report false"
+    );
+
+    for &ident in &idents[1..NAT64_FRAG_CAP_PER_SHARD] {
+        assert!(
+            !cache.install(mk(ident), decision, None, 1_000, 1, 0),
+            "filling the shard must not report an eviction until it is full"
+        );
+    }
+    assert_eq!(
+        cache.len(),
+        NAT64_FRAG_CAP_PER_SHARD,
+        "fixture: the shard must be exactly at cap, or the cell below is not \
+         exercising the eviction branch at all"
+    );
+
+    // TRUE — every entry live, shard at cap: the oldest live entry is sacrificed.
+    assert!(
+        cache.install(mk(idents[NAT64_FRAG_CAP_PER_SHARD]), decision, None, 1_000, 1, 0),
+        "an install that evicted a still-LIVE association must report it — this \
+         is the condition #7054 exists to make observable"
+    );
+    assert!(
+        cache
+            .lookup(&mk(idents[0]), 1_000, 1, |_| true)
+            .is_none(),
+        "control: the reported eviction really did remove the front entry"
+    );
+
+    // FALSE 3 — the #5447 prune path. Advance past the TTL so every entry is
+    // expired; the install then reclaims a dead slot and must NOT be reported as
+    // a live eviction.
+    let past_ttl = 1_000 + NAT64_FRAG_TTL_NS + 1;
+    assert!(
+        !cache.install(
+            mk(idents[NAT64_FRAG_CAP_PER_SHARD + 1]),
+            decision,
+            None,
+            past_ttl,
+            1,
+            0
+        ),
+        "an install that reclaimed EXPIRED slots sacrificed no live association \
+         and must report false — otherwise the counter fires on ordinary TTL \
+         turnover and tells an operator nothing (#5447/#7054)"
+    );
+}
+
+#[test]
 fn nat64_frag_assoc_install_all_live_still_evicts_oldest() {
     // Control / capacity-bound preservation: when EVERY entry in a full shard is
     // LIVE, pruning reclaims nothing, so `install` still evicts the OLDEST

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -558,6 +558,12 @@ pub(crate) struct BindingStatus {
     /// it and Go/Rust read 0).
     #[serde(rename = "nat64_frag_dropped", default)]
     pub nat64_frag_dropped: u64,
+    /// #7054: first-fragment installs that evicted a still-LIVE fragment
+    /// association because the shard was at cap with nothing expired to
+    /// reclaim. Additive + `default`, so an older reader simply does not see
+    /// it and no interpretation of existing bytes changes.
+    #[serde(rename = "nat64_frag_assoc_evicted", default)]
+    pub nat64_frag_assoc_evicted: u64,
     /// #5623: fail-closed NAT64 SOURCE-ineligibility drops — an incoming IPv6
     /// packet whose SOURCE lies within a configured Pref64 (a looping/synthesized
     /// "already-translated" source, the RFC 6146 §5 hairpin construction — plus

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -116,6 +116,7 @@
     "mirrored_bytes": 0,
     "mirrored_packets": 0,
     "nat64_exthdr_ineligible": 0,
+    "nat64_frag_assoc_evicted": 0,
     "nat64_frag_dropped": 0,
     "nat64_ineligible_dest": 0,
     "nat64_ineligible_source": 0,


### PR DESCRIPTION
Closes #7054

## Reachability first — and it is already proven in-tree

`nat64_frag_assoc_install_all_live_still_evicts_oldest` (nat64_tests.rs) already
drives an all-live shard to `NAT64_FRAG_CAP_PER_SHARD` and shows `install`
evicting the front entry, using a `frag_idents_in_one_shard` helper that computes
colliding idents. **The eviction path is not in doubt and is not re-proven here.**
What was missing is the signal: no counter, no log — the condition was silent.

## The digest is deliberately left alone

Excluding `protocol` and `authority` from `nat64_frag_shard_index` is documented
and correct: membership is full-key equality inside the bucket, so a cross-domain
fragment lands in the same shard, finds no equal key, and **misses fail-closed**.
Widening the digest would change that miss behaviour — the property the
fail-closed posture rests on — to buy capacity headroom. Not a trade worth making
for an observability gap, which is why this takes the issue's third option.

## What lands

`install` reports whether it sacrificed a still-live association; the two
production call sites count it as `nat64_frag_assoc_evicted`, beside the existing
`nat64_frag_dropped`.

**The distinction is the whole point.** Today the victim's later fragments are
dropped fail-closed and bump `nat64_frag_dropped` — indistinguishable from an
ordinary reorder or orphan. Separating them is what tells an operator whether the
shard cap is the problem.

## The false cases are what make the counter mean anything

A signal that fires on every install reads as constant capacity pressure and is
worse than none. So three ordinary paths are asserted **false** — a plain install
with room, a same-key **refresh** (which would otherwise count every
retransmitted first fragment), and an install that reclaimed **expired** slots via
the #5447 prune — and only the all-live-at-cap install reports true.

| cell | rc | tests passed | named failing | which |
|---|---|---|---|---|
| control | 0 | **4889** | 0 | — |
| L1 the live eviction stops being reported | 101 | 4819 | **1** | `nat64_frag_assoc_install_reports_only_live_evictions_7054` |
| L2 report an eviction on **every** call | 101 | 4819 | **1** | same |
| L3 a **prune-reclaimed** slot reported as a live eviction | 101 | 4819 | **1** | same |

Three different failure axes — under-report, over-report, mis-attribute — each
caught. L2 is the one that justifies the false cases: `assert!(evicted)` alone
passes against a function that returns `true` unconditionally.

## Two layout guards fired, and were answered rather than defeated

The compile-time `const _` asserts in `binding_state/mod.rs` and the runtime cell
in `tests/tx_inbox.rs` both pin `pending_tx_admitted` / `delta_loss_pending`
offsets; the new counter shifted both by 8 (**2160 → 2168**, **2288 → 2296**).

That is the legitimate case the guard's own comment names: the field is
**unconditional**, so production and test builds shift together and re-measuring
makes both green — unlike a `#[cfg(test)]` field, for which at most one
configuration can be green at any one pair of literals, which is what makes that
case un-satisfiable by re-measuring. Both sets were re-measured in lockstep, and
both build configurations were checked.

One prediction in the #6664 note did **not** hold and is recorded rather than
quietly stepped over: "the next field added here will move `size_of`". It is
still **2304** — the bytes came out of tail padding again. Noted so a future
reader does not read an unchanged 2304 as their field failing to land; the
offsets are what moved.

## The golden was classified, not just regenerated

`wire_invariant_default_specimens` needed a regen. Diff classified before
accepting it:

```
added  : 1  ['binding_status.nat64_frag_assoc_evicted']   (value 0)
removed: 0
changed: 0
```

Additive with `default` on both the Rust and Go sides, so no older reader's
interpretation of existing bytes changes and **no protocol bump is owed**.

## Gates, and a flakiness warning for the board

`cargo test` whole crate `rc=0`, **4759 passed**, `--test-threads=1`. `go test
./...` **67 packages ok**. Every log checked for `no space left` — **0**
everywhere; the matrix harness classifies a disk-void cell as `VOID-DISK` rather
than letting it read as a red.

**Four different Go timing tests failed once each and passed on retry during this
work** — `pkg/cluster` (`TestStartHeartbeatDoesNotRaceStopHeartbeat7257`, then
`TestReceiveLoopKeepsConnectionAliveWithHeartbeatAck`), `pkg/vrrp`
(`TestSyncHold_RearmStopsPreviousTimer`), `pkg/ipmon` (`TestDebounceCoalescing`).
Load average peaked around **35** with several lanes gating in parallel. None of
those packages imports anything this branch touches, and each passed twice in
isolation. Flagging the pattern because another lane could easily read one of
these as a real red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
