### PR TITLE
config: reject a POOL-LESS packed NAT contradiction (completes #7033)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5219,6 +5219,13 @@ Three properties bound the scan, each with its own cell in
   `frobnicate { off; }` keeps its ZERO-action rejection instead of yielding an
   exemption nobody wrote.
 
+A packed contradiction need not involve a pool. `then { source-nat interface
+off; }` authors an exemption and publishes an interface translation, and it is
+rejected on the same footing as the pool rows — the per-container record is
+ranked by distinct MODES first and pool names second, so a container naming no
+pool is still captured. Ranking on pool names alone made that whole class
+invisible while every pool-bearing row was correctly rejected.
+
 The check applies to the `n == 1` class only, so a block that lowers two actions
 (or none) keeps the diagnostic it already had. Two sites enforce that and either
 alone suffices — the call sits after the count's switch, and the predicate

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5248,9 +5248,15 @@ this does not disturb #3850 or #7035:
 - **The same pool named twice in one block** — nothing is discarded, so it is a
   redundancy rather than an error.
 
-`off` and `interface` are not recorded at all: they carry no value, so repeating
-either discards nothing. `compiler_nat_then_occurrences_7013_test.go` pins every
-row above, including the three legal ones.
+Repeating `off` or `interface` is likewise a redundancy: they carry no value, so
+`off off` means the same exemption twice and commits. **That is a statement about
+a REPEAT, not about the mode.** `off pool P` packs two DIFFERENT modes onto one
+run, one of them is discarded, and #7033 rejects it — the asymmetry is why the
+authored record carries modes as well as pool names.
+`compiler_nat_then_occurrences_7013_test.go` pins every row above, including the
+three legal ones, and
+`TestRepeatedValuelessModeIsARedundancyNotAContradiction_7033` pins both halves
+of the asymmetry side by side.
 
 *What the tolerant path actually does (#5717).* Only a malformed rule reaches
 the lenient arm — the strict commit path rejects it — but the two arities land

--- a/docs/log/7033.md
+++ b/docs/log/7033.md
@@ -59,6 +59,28 @@ removed the stop rule. `TestOpenWorldTailContainingOffStillCommits_7033` puts th
 token `off` IN the tail, which is the smallest shape where the stop rule changes
 an outcome.
 
+## The hole the matrix found in my own fix
+
+A cell that counted RAW modes instead of distinct ones redded the #7013
+same-pool cell but NOT the new `off off` cell. That is only possible if `off off`
+never records two modes — and it recorded nothing at all. The per-container
+record was ranked by distinct POOLS, so a container naming no pool never beat the
+empty starting record and was never stored.
+
+The consequence was a missed class, not a cosmetic one:
+
+    then { source-nat interface off; }   ACCEPTED, resolving {Interface:true}
+
+That is the inversion this issue is about — an authored exemption, an applied
+translation — and it was invisible because every fixture in the first draft named
+a pool. The table sampled that axis instead of varying it.
+
+Ranking is now distinct MODES first, distinct POOLS second (ties). Pool-less rows
+were added in all three shapes and both orders, plus a shape-table row. `N9` (rank
+by pools only) now reds them, and `N8` (raw modes) reds the asymmetry cell, which
+was VACUOUS before the ranking fix — it had been passing because the record was
+never stored, not because distinctness deduped it.
+
 ## What the matrix found that review did not
 
 `N5` — moving the check ahead of the resolved-field count — came back GREEN. Not

--- a/pkg/config/compiler_nat_destination.go
+++ b/pkg/config/compiler_nat_destination.go
@@ -248,7 +248,7 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 			// false-rejects a config the suite already pins as legal. The worst
 			// single container is the one worth reporting.
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
-				if c := natThenAuthoredOccurrences(thenNode, "destination-nat"); len(c.distinctPools()) > len(rule.thenAuthored.distinctPools()) {
+				if c := natThenAuthoredOccurrences(thenNode, "destination-nat"); c.worseThan(rule.thenAuthored) {
 					rule.thenAuthored = c
 				}
 			}

--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -1057,7 +1057,7 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 			// false-rejects a config the suite already pins as legal. The worst
 			// single container is the one worth reporting.
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
-				if c := natThenAuthoredOccurrences(thenNode, "source-nat"); len(c.distinctPools()) > len(rule.thenAuthored.distinctPools()) {
+				if c := natThenAuthoredOccurrences(thenNode, "source-nat"); c.worseThan(rule.thenAuthored) {
 					rule.thenAuthored = c
 				}
 			}

--- a/pkg/config/compiler_nat_then_occurrences_7013.go
+++ b/pkg/config/compiler_nat_then_occurrences_7013.go
@@ -44,11 +44,28 @@ package config
 // the survivor reds against a correct compiler and a buggy one alike, for
 // opposite reasons, which invites "fixing" the assertion.
 //
-// ONLY POOLS ARE RECORDED. `off` and `interface` carry no value, so writing
-// either twice discards nothing — the config means what it says and there is
-// nothing to report. Counting them would reject an idempotent typo. A rule
-// mixing DIFFERENT modes is still caught, by the mode count that follows this
-// check.
+// POOL NAMES AND MODES ARE BOTH RECORDED, and they answer two different
+// questions — this paragraph used to say only pools were recorded, which #7033
+// made false.
+//
+// The asymmetry is the part worth stating, because "`off` carries no value, so
+// repeating it discards nothing" is true and is NOT a reason to ignore `off`:
+//
+//   - `off off` in one block discards nothing. Both spellings mean the same
+//     exemption, so it is a redundancy and commits. distinctModes is what makes
+//     that so, exactly as distinctPools does for `pool P pool P`.
+//   - `off pool P` in one block DOES discard something. Two different modes
+//     packed onto one run lower to a single field, and the one that loses is
+//     gone with no diagnostic — and when the loser is `off`, what the dataplane
+//     enforces is the inverse of what was authored. That is #7033, checked on
+//     the recorded MODES.
+//
+// So "carries no value" justifies ignoring a REPEAT of one valueless mode. It
+// never justified ignoring the mode itself.
+//
+// A rule that LOWERS two distinct modes is caught earlier still, by the
+// resolved-field count; the modes recorded here are for the packed case that
+// count cannot see.
 
 // natThenAuthored is what ONE `then` container authored, before NATThen's
 // scalar collapsed it.

--- a/pkg/config/compiler_nat_then_occurrences_7013.go
+++ b/pkg/config/compiler_nat_then_occurrences_7013.go
@@ -123,6 +123,24 @@ func (a natThenAuthored) distinctModes() []string {
 	return out
 }
 
+// worseThan reports whether c records a more serious authored contradiction than
+// a, and is how a rule with several `then` containers picks the one to report.
+//
+// MODES RANK FIRST, POOLS SECOND, and getting that wrong is not a matter of
+// which message you get. The original ranking compared distinct POOLS only, so a
+// container with no pool at all — `then { source-nat interface off; }` — never
+// beat the zero-valued starting record, was never stored, and its packed
+// cross-mode contradiction was never seen. That rule authors an exemption and
+// publishes an interface translation: the same inversion #7033 exists to reject,
+// silently missed because every fixture in the first draft happened to name a
+// pool. Ranking on modes is what makes a pool-less contradiction visible.
+func (c natThenAuthored) worseThan(a natThenAuthored) bool {
+	if cm, am := len(c.distinctModes()), len(a.distinctModes()); cm != am {
+		return cm > am
+	}
+	return len(c.distinctPools()) > len(a.distinctPools())
+}
+
 // natThenAuthoredOccurrences records every pool and every terminal action mode
 // of `kind` that thenNode authored.
 //

--- a/pkg/config/compiler_nat_then_packed_contradiction_7033_test.go
+++ b/pkg/config/compiler_nat_then_packed_contradiction_7033_test.go
@@ -87,6 +87,24 @@ func TestPackedCrossModeContradictionRejected_7033(t *testing.T) {
 			modes: []string{"pool", "interface"},
 		},
 		{
+			// POOL-LESS cross-mode packs. These are the rows the first draft of
+			// the fix MISSED: the per-container record was ranked by distinct
+			// POOLS, so a container naming no pool never beat the empty starting
+			// record and its contradiction was never recorded. Every other row in
+			// this table names a pool, so the table sampled the axis instead of
+			// varying it and the whole class was invisible.
+			name: "root_packed_interface_then_off", text: snat7033("then { source-nat interface off; }"),
+			modes: []string{"interface", "off"}, offDroppd: true,
+		},
+		{
+			name: "root_packed_off_then_interface", text: snat7033("then { source-nat off interface; }"),
+			modes: []string{"off", "interface"},
+		},
+		{
+			name: "child_packed_interface_then_off", text: snat7033("then { source-nat { interface off; } }"),
+			modes: []string{"interface", "off"}, offDroppd: true,
+		},
+		{
 			name: "dnat_child_packed_pool_then_off", text: dnat7033("then { destination-nat { pool PD off; } }"),
 			modes: []string{"pool", "off"}, offDroppd: true,
 		},
@@ -136,6 +154,9 @@ func TestFlatSetPackedContradictionRejected_7033(t *testing.T) {
 		{"flat_pool_then_off", "set security nat source rule-set RS rule R1 then source-nat pool P off"},
 		{"flat_off_then_pool", "set security nat source rule-set RS rule R1 then source-nat off pool P"},
 		{"flat_interface_then_pool", "set security nat source rule-set RS rule R1 then source-nat interface pool P"},
+		// Pool-less, in the shape an operator types.
+		{"flat_interface_then_off", "set security nat source rule-set RS rule R1 then source-nat interface off"},
+		{"flat_off_then_interface", "set security nat source rule-set RS rule R1 then source-nat off interface"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tree := buildTree(t, []string{
@@ -416,6 +437,13 @@ func TestPackedActionScanShapes_7033(t *testing.T) {
 			name:      "open_world_tail_stops_the_scan",
 			node:      &Node{Keys: []string{"then", "source-nat", "pool", "P", "persistent-nat", "permit", "off"}},
 			wantModes: []string{"pool"},
+		},
+		{
+			// No pool at all. The record must still be captured, or a pool-less
+			// contradiction is invisible to the gate.
+			name:      "pool_less_cross_mode_pack",
+			node:      &Node{Keys: []string{"then", "source-nat", "interface", "off"}},
+			wantModes: []string{"interface", "off"},
 		},
 		{
 			name: "unrecognised_container_records_nothing",

--- a/pkg/config/compiler_nat_then_packed_contradiction_7033_test.go
+++ b/pkg/config/compiler_nat_then_packed_contradiction_7033_test.go
@@ -228,6 +228,37 @@ func TestPoolNamedOffIsAPoolNotAnExemption_7033(t *testing.T) {
 	}
 }
 
+// TestRepeatedValuelessModeIsARedundancyNotAContradiction_7033 pins the
+// asymmetry that decides what this check may report.
+//
+// `off` carries no value, so `off off` means the same exemption twice: nothing
+// is discarded and it commits, the same way `pool P pool P` does under #7013.
+// `off pool P` is a different matter — two modes packed onto one run lower to
+// one field and the loser vanishes. "Carries no value" therefore justifies
+// ignoring a REPEAT of a valueless mode; it never justified ignoring the mode.
+//
+// Without this cell, counting raw modes instead of distinct ones passes every
+// other case in this file and rejects a config whose meaning is unambiguous.
+func TestRepeatedValuelessModeIsARedundancyNotAContradiction_7033(t *testing.T) {
+	for _, tc := range []struct{ name, then string }{
+		{"off_twice", "then { source-nat off off; }"},
+		{"interface_twice", "then { source-nat interface interface; }"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := compileText7033(t, snat7033(tc.then)); err != nil {
+				t.Fatalf("%q repeats ONE valueless mode: both spellings mean the same "+
+					"thing, nothing is discarded, and it must commit. Got: %v", tc.then, err)
+			}
+		})
+	}
+	// And the other half of the asymmetry, so the two live side by side: the
+	// same `off`, packed against a pool, IS a contradiction.
+	if err := compileText7033(t, snat7033("then { source-nat off pool P; }")); err == nil {
+		t.Fatal("`off pool P` packs two DIFFERENT modes onto one run: one is discarded " +
+			"with no diagnostic, and it must be rejected")
+	}
+}
+
 // TestUnrecognisedContainerDoesNotFabricateAnExemption_7033 is #6820 round 6's
 // reverted regression, kept as a standing cell.
 //


### PR DESCRIPTION
Follow-up to #7886 (merged). Completes #7033.

## What is wrong on master right now

#7886 merged at `b5cdee901`, three commits before the branch tip. The commits it
missed close a class of the very defect it fixed, so **master today rejects a
packed contradiction that names a pool and accepts one that does not**:

```
then { source-nat interface off; }    ACCEPTED, resolves {Interface:true}
then { source-nat off interface; }    ACCEPTED, resolves {Off:true}
```

The first is the inversion #7033 exists to reject: the operator authored a no-NAT
**exemption** and the firewall applies an interface translation, committed clean
under strict with no diagnostic. This PR is the remainder of that branch, rebased
onto current master — no new work beyond what the merge cut off.

## Why the class was missed

The per-container authored record was ranked by distinct **pool names**. A
container naming no pool never beat the empty starting record, so it was never
stored and its contradiction was never seen. Every fixture in the first draft
named a pool, so the table **sampled that axis rather than varying it**.

Ranking is now distinct **modes** first, pool names second (ties only), which is
what makes a pool-less contradiction visible. Pool-less rows are added in all
three AST shapes and both token orders, plus a shape-table row that drives the
walk directly so the class fails by name.

## How it surfaced — a mutation that redded the wrong cell

A cell counting RAW modes instead of distinct ones redded the #7013 same-pool
cell but **not** the `off off` cell. That is only possible if `off off` never
records two modes; it recorded nothing at all. Two consequences:

- `N9` (rank by pool names only) reds the pool-less rows — the class is guarded.
- `N8` (raw modes) now reds the asymmetry cell, which was **vacuous** before this
  fix: it passed because the record was never stored, not because distinctness
  deduped it.

## The asymmetry, also in this range

"`off` carries no value, so repeating it discards nothing" is true and is NOT a
reason to ignore `off`. `off off` means the same exemption twice and commits;
`off pool P` discards one of two modes, and when the loser is `off` the dataplane
enforces the inverse of what was authored. So the reasoning justifies ignoring a
**repeat of one valueless mode** — never the mode itself.

The #7013 file header and its `docs/config-schema.md` paragraph both said `off`
and `interface` are not recorded at all: true when written, made false by #7886,
corrected here. A standing claim that has become half-true survives a reader
checking it, which is worse than one that is simply wrong.

## Validation

- `go test -count=1 ./pkg/config/` — ok
- `go test -count=1 ./...` — clean at the merged head: 68 packages ok, 0 failures,
  0 `no space left`
- Full 10-cell mutation matrix re-run at the current head on fresh log paths,
  green control, every cell naming a failing test with tests-collected > 0. The
  two cells specific to this range are `N8` and `N9` above.

No cluster smoke: config compiler only.
