### PR TITLE
nat64: count refused fragment-association aliases distinctly

### DIFF
--- a/docs/log/7056.md
+++ b/docs/log/7056.md
@@ -1,0 +1,60 @@
+# #7056 — #5798 residuals
+
+- **Timestamp**: 2026-08-28
+- **Action**: Delivered required-fix #5 (distinct cross-domain counter). Measured
+  required-fix #1 (modular `fragment_assoc/`) and did NOT do it — recommendation
+  below.
+
+## What actually remained at current master
+
+Measured, because a "residuals" issue goes stale fast and several NAT64 changes
+landed the same day:
+
+- No `fragment_assoc/` component exists. The cache is still `nat64.rs` (4391
+  lines) + `afxdp/poll_descriptor/frag_assoc.rs` (444).
+- No cross-domain counter exists (`grep` for `cross_domain` returns nothing
+  outside tests).
+
+Both parts genuinely remained.
+
+## Required-fix #5 — delivered
+
+The premise checks out exactly. `nat64_frag_shard_index` digests only
+`(family, src, dst, ident)` and its own doc block states why: *"It keeps
+same-datagram candidates CO-LOCATED, so a cross-domain aliasing attempt is
+observable with a single-shard scan."* So the classification costs one pass over
+a bucket `lookup` had already locked and walked.
+
+Two counters, not one, because the legs are different operator stories:
+CROSS_DOMAIN (different ingress `FragAuthority` — the #5798 defect) and
+PROTOCOL_ALIAS (TCP/UDP colliding on `(src, dst, ident)` — required-fix #2).
+
+Full surfacing path wired: Rust atomic → `coordinator/status.rs` accessor →
+`server/helpers/status.rs` → `protocol/control.rs` (additive + `default`, #1961)
+→ Go `protocol_status.go` → two Prometheus series.
+
+## Required-fix #1 — measured, NOT done, and a recommendation rather than a decline
+
+The seam argument **survives the move**, which I checked rather than assumed:
+`Nat64FragKey` is already family-agnostic (`addr_family`, `src`, `dst`, `ident`,
+`protocol`, `authority` — nothing NAT64-specific), and `Nat64FragEntry`'s only
+NAT64-flavoured field is `reverse: Option<Nat64ReverseInfo>`, already `Option`
+because the same-family NAT arm leaves it `None`. The data model is ALREADY the
+shared thing; only the module name says otherwise.
+
+So this is not a split that scatters the property it names — it would concentrate
+one that is already true and mislabelled. That argues for doing it.
+
+What argues against doing it NOW is churn, not design: it is a rename+move across
+a 4391-line file with call sites in `afxdp/poll_descriptor/`, in an area where
+two other lanes have been landing changes the same day. A pure-motion PR there
+maximises conflict surface for zero behaviour change.
+
+**Recommendation: schedule it when `nat64.rs` is quiet, as a motion-only PR with
+no behaviour change in the same commit.** Not declined — the seam is real.
+
+## Note
+
+`git checkout --` ate the uncommitted classification during a red-on-revert
+check. The fix was re-applied and COMMITTED BEFORE the revert was re-run. Commit
+the fix before mutating; the rule exists for exactly this.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -466,6 +466,8 @@ type xpfCollector struct {
 	// outcomes — PAT'd collisions, identity exhaustion, registry-cap
 	// exhaustion.
 	userspaceInterfaceSNATPATCollisions      *prometheus.Desc
+	userspaceNAT64FragCrossDomainMisses      *prometheus.Desc
+	userspaceNAT64FragProtocolAliasMisses    *prometheus.Desc
 	userspaceInterfaceSNATIdentityExhaustion *prometheus.Desc
 	userspaceInterfaceSNATSyncConflictDrops  *prometheus.Desc
 	userspaceInterfaceSNATRegistryCap        *prometheus.Desc
@@ -926,6 +928,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceSyncedImportCapDrops
 	ch <- c.userspaceNatReverseKeySharedDisplacements
 	ch <- c.userspaceInterfaceSNATPATCollisions
+	ch <- c.userspaceNAT64FragCrossDomainMisses
+	ch <- c.userspaceNAT64FragProtocolAliasMisses
 	ch <- c.userspaceInterfaceSNATIdentityExhaustion
 	ch <- c.userspaceInterfaceSNATSyncConflictDrops
 	ch <- c.userspaceInterfaceSNATRegistryCap

--- a/pkg/api/metrics_descriptors_userspace_session.go
+++ b/pkg/api/metrics_descriptors_userspace_session.go
@@ -48,6 +48,33 @@ func (c *xpfCollector) initUserspaceSessionDescriptors() {
 			"against an already-unindexed session are not counted.",
 		nil, nil,
 	)
+	c.userspaceNAT64FragCrossDomainMisses = prometheus.NewDesc(
+		"xpf_userspace_nat64_frag_cross_domain_misses_total",
+		"#7056 (#5798 required-fix #5): fragment-association lookups that "+
+			"MISSED because a same-datagram association exists under a "+
+			"DIFFERENT ingress security domain, so the #5798 authority-scoped "+
+			"key refused it. The refusal itself is the fail-closed behaviour "+
+			"and is not a defect; this series exists because such a miss was "+
+			"previously indistinguishable from a reorder, a TTL straddle, a "+
+			"shard eviction or a config-generation bump, all of which land on "+
+			"the same drop counter. It is the only one of that group that "+
+			"describes the TRAFFIC rather than cache pressure: a nonzero and "+
+			"rising value means fragments are arriving in one security domain "+
+			"bearing the identity of a datagram admitted in another.",
+		nil, nil,
+	)
+	c.userspaceNAT64FragProtocolAliasMisses = prometheus.NewDesc(
+		"xpf_userspace_nat64_frag_protocol_alias_misses_total",
+		"#7056: the sibling of the cross-domain series — a same-datagram "+
+			"association exists under the SAME ingress domain but a different "+
+			"upper-layer protocol, i.e. a TCP and a UDP datagram collided on "+
+			"(src, dst, ident) and were separated by the #5798 `protocol` key "+
+			"field. Kept as a DISTINCT series rather than folded into the "+
+			"cross-domain total because the two are different operator "+
+			"stories: this one is ordinary identifier reuse between protocols, "+
+			"not a domain-crossing attempt.",
+		nil, nil,
+	)
 	c.userspaceInterfaceSNATPATCollisions = prometheus.NewDesc(
 		"xpf_userspace_interface_snat_pat_collisions_total",
 		"#6751: interface-mode source-NAT admissions whose PRESERVED "+

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -909,6 +909,22 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		// #7056: this literal enumerates every Desc
+		// emitUserspaceDynamicBufferMetrics touches, so a new emit without a
+		// matching entry here nil-derefs inside MustNewConstMetric rather than
+		// failing an assertion.
+		userspaceNAT64FragCrossDomainMisses: prometheus.NewDesc(
+			"xpf_userspace_nat64_frag_cross_domain_misses_total",
+			"nat64 frag cross-domain refused-alias misses",
+			nil,
+			nil,
+		),
+		userspaceNAT64FragProtocolAliasMisses: prometheus.NewDesc(
+			"xpf_userspace_nat64_frag_protocol_alias_misses_total",
+			"nat64 frag protocol refused-alias misses",
+			nil,
+			nil,
+		),
 		userspaceInterfaceSNATIdentityExhaustion: prometheus.NewDesc(
 			"xpf_userspace_interface_snat_identity_exhaustion_total",
 			"interface snat identity exhaustion",
@@ -1193,7 +1209,11 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 		// #6751 PR 2/3: three DISTINCT non-zero values, so an emit wired to
 		// the wrong one of the trio cannot satisfy the assertions below --
 		// the two exhaustion counters exist precisely to be read apart.
-		InterfaceSNATPATCollisionsTotal:             17,
+		InterfaceSNATPATCollisionsTotal: 17,
+		// #7056: DISTINCT fixture values, so an emit wired to the wrong field
+		// swaps two numbers that differ rather than two that happen to match.
+		NAT64FragCrossDomainMissesTotal:             23,
+		NAT64FragProtocolAliasMissesTotal:           29,
 		InterfaceSNATIdentityExhaustionTotal:        19,
 		InterfaceSNATSyncIdentityConflictDropsTotal: 29,
 		InterfaceSNATRegistryCapExhaustionTotal:     23,
@@ -1275,9 +1295,12 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// (PAT collisions + identity exhaustion + sync-import identity-conflict
 	// drops + registry-cap exhaustion) = 44, plus the #6842
 	// gre_decap_unsupported_version_refusals_total counter = 45, plus the
-	// #6929 worker_command_queue_drops_total counter = 46.
-	if len(got) != 46 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 46 metrics, got %d", len(got))
+	// #6929 worker_command_queue_drops_total counter = 46, plus the #7056
+	// refused-alias PAIR (cross-domain + protocol) = 48. The pair is counted as
+	// TWO because they are deliberately distinct series; if a later change folds
+	// them into one total this census is the guard that notices.
+	if len(got) != 48 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 48 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -1291,6 +1314,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// #6751 PR 2/3: the interface-mode SNAT identity registry trio, each
 	// carrying its own value.
 	assertCounterClose(t, got, c.userspaceInterfaceSNATPATCollisions, nil, 17)
+	// #7056: assert the VALUES, not merely that two more series appeared — a
+	// census bump alone would pass against emits wired to the wrong field.
+	assertCounterClose(t, got, c.userspaceNAT64FragCrossDomainMisses, nil, 23)
+	assertCounterClose(t, got, c.userspaceNAT64FragProtocolAliasMisses, nil, 29)
 	assertCounterClose(t, got, c.userspaceInterfaceSNATIdentityExhaustion, nil, 19)
 	assertCounterClose(t, got, c.userspaceInterfaceSNATSyncConflictDrops, nil, 29)
 	assertCounterClose(t, got, c.userspaceInterfaceSNATRegistryCap, nil, 23)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -768,6 +768,18 @@ func (c *xpfCollector) emitUserspaceDynamicBufferMetrics(ch chan<- prometheus.Me
 		prometheus.CounterValue,
 		float64(status.InterfaceSNATPATCollisionsTotal),
 	)
+	// #7056: emitted unconditionally like the sibling above — a published 0 is
+	// the informative reading (no alias was ever refused), not an absent series.
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceNAT64FragCrossDomainMisses,
+		prometheus.CounterValue,
+		float64(status.NAT64FragCrossDomainMissesTotal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceNAT64FragProtocolAliasMisses,
+		prometheus.CounterValue,
+		float64(status.NAT64FragProtocolAliasMissesTotal),
+	)
 	ch <- prometheus.MustNewConstMetric(
 		c.userspaceInterfaceSNATIdentityExhaustion,
 		prometheus.CounterValue,

--- a/pkg/dataplane/userspace/protocol_status.go
+++ b/pkg/dataplane/userspace/protocol_status.go
@@ -359,6 +359,23 @@ type ProcessStatus struct {
 	// xpf_userspace_interface_snat_pat_collisions_total. Omitempty for wire
 	// compat with older helpers.
 	InterfaceSNATPATCollisionsTotal uint64 `json:"interface_snat_pat_collisions_total,omitempty"`
+
+	// NAT64FragCrossDomainMissesTotal is #7056 (#5798 required-fix #5):
+	// fragment-association misses where a same-datagram entry existed under a
+	// DIFFERENT ingress security domain. The fail-closed refusal is #6835's;
+	// this is the observability half required-fix #5 asked for. Before it,
+	// such a miss was indistinguishable from a reorder, a TTL straddle, a
+	// shard eviction or a config-generation bump — all of which land on
+	// nat64_frag_dropped. This is the only one of that group that describes
+	// the TRAFFIC rather than cache pressure.
+	NAT64FragCrossDomainMissesTotal uint64 `json:"nat64_frag_cross_domain_misses_total,omitempty"`
+
+	// NAT64FragProtocolAliasMissesTotal is #7056's sibling leg: same ingress
+	// domain, different upper-layer protocol — a TCP and a UDP datagram that
+	// collided on (src, dst, ident) and were separated by the #5798 `protocol`
+	// key field. Kept DISTINCT from the cross-domain counter because the two
+	// are different operator stories; one total would answer neither.
+	NAT64FragProtocolAliasMissesTotal uint64 `json:"nat64_frag_protocol_alias_misses_total,omitempty"`
 	// InterfaceSNATIdentityExhaustionTotal is #6751 PR 2/3: interface-mode
 	// SNAT admissions that failed CLOSED because no free translated
 	// identity existed for their (egress address, remote endpoint) — every

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -320,6 +320,26 @@ impl super::Coordinator {
         crate::nat::INTERFACE_SNAT_PAT_COLLISIONS.load(Ordering::Relaxed)
     }
 
+    /// #7056 (#5798 required-fix #5): fragment-association misses where a
+    /// same-datagram entry existed under a DIFFERENT ingress security domain.
+    /// The fail-closed refusal itself is #6835's; this is the observability
+    /// half, and it is the one miss cause that describes the TRAFFIC rather
+    /// than cache pressure. Surfaced as
+    /// `xpf_userspace_nat64_frag_cross_domain_misses_total`.
+    pub fn nat64_frag_cross_domain_misses_total(&self) -> u64 {
+        crate::nat64::NAT64_FRAG_CROSS_DOMAIN_MISSES.load(Ordering::Relaxed)
+    }
+
+    /// #7056: the sibling leg — same ingress domain, different upper-layer
+    /// protocol, i.e. a TCP and a UDP datagram that collided on
+    /// `(src, dst, ident)` and were separated by the #5798 `protocol` key
+    /// field. Kept DISTINCT from the cross-domain counter because the two are
+    /// different operator stories. Surfaced as
+    /// `xpf_userspace_nat64_frag_protocol_alias_misses_total`.
+    pub fn nat64_frag_protocol_alias_misses_total(&self) -> u64 {
+        crate::nat64::NAT64_FRAG_PROTOCOL_ALIAS_MISSES.load(Ordering::Relaxed)
+    }
+
     /// #6751 PR 2/3: interface-mode SNAT admissions that failed CLOSED with no
     /// free translated identity for their `(egress, remote)` pair, plus
     /// peer-synced imports refused for the same reason. Surfaced as

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -183,7 +183,7 @@ use crate::nat::{
 };
 use crate::session::SessionDecision;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 /// #4381: NAT64 translated-port allocation range. RFC 6146 does not mandate a
@@ -390,6 +390,39 @@ pub(crate) struct Nat64ReverseInfo {
 // ===========================================================================
 
 /// Number of independent shards. Power of two so the shard index is a mask.
+/// #7056 (#5798 required-fix #5): fragment-association misses caused by the
+/// #5798 key REFUSING an alias, split by which field refused it.
+///
+/// The fail-closed behaviour these count was delivered by #6835 — a cross-domain
+/// or protocol-aliased fragment builds a different key, misses, and dies on the
+/// Pref64 gate or the #6122 discriminator. What was missing is the ability to
+/// SEE it: every such miss landed on `nat64_frag_dropped` /
+/// `nat_frag_untranslated_dropped` alongside reorders, TTL straddles, shard
+/// evictions and config-generation bumps.
+///
+/// Those causes are not interchangeable to an operator. A reorder or TTL straddle
+/// is a path-MTU / cache-pressure story; a refused alias is a TRAFFIC story, and
+/// the only one of the group that can indicate an attempt to ride another
+/// domain's association. One drop counter answers neither question — the same
+/// failure as a diagnostic that names the wrong condition.
+///
+/// TWO counters, not one "alias refused" total, because they are different
+/// operator stories:
+///
+///   - `CROSS_DOMAIN` — a same-datagram entry exists under a DIFFERENT ingress
+///     `FragAuthority`: the #5798 defect proper, a fragment in one security
+///     domain probing an association minted in another.
+///   - `PROTOCOL_ALIAS` — same authority, different upper-layer protocol: a TCP
+///     and a UDP datagram colliding on `(src, dst, ident)`, which required-fix
+///     #2 added `protocol` to the key to separate.
+///
+/// Cumulative and process-global, like `INTERFACE_SNAT_PAT_COLLISIONS`, so tests
+/// read them as a delta.
+pub(crate) static NAT64_FRAG_CROSS_DOMAIN_MISSES: AtomicU64 = AtomicU64::new(0);
+
+/// See `NAT64_FRAG_CROSS_DOMAIN_MISSES`.
+pub(crate) static NAT64_FRAG_PROTOCOL_ALIAS_MISSES: AtomicU64 = AtomicU64::new(0);
+
 const NAT64_FRAG_SHARDS: usize = 16;
 /// Fixed per-shard entry cap (LRU eviction on overflow). Total ceiling is
 /// `NAT64_FRAG_SHARDS * NAT64_FRAG_CAP_PER_SHARD` = 1024 entries; each entry is
@@ -751,7 +784,44 @@ impl Nat64FragAssoc {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         shard.retain(|e| e.deadline_ns > now_ns);
-        let pos = shard.iter().position(|e| e.key == *key)?;
+        let Some(pos) = shard.iter().position(|e| e.key == *key) else {
+            // #7056 (#5798 required-fix #5): classify the miss before returning
+            // it. A full-key miss has several causes with very different
+            // meanings, and until now every one landed on the same
+            // `nat64_frag_dropped` / `nat_frag_untranslated_dropped` counter: a
+            // reorder, a TTL straddle, a shard eviction, a config-generation
+            // bump — and an ALIASING ATTEMPT the #5798 key deliberately refused.
+            //
+            // The last is the only one that says something about the TRAFFIC
+            // rather than about cache pressure, and the one required-fix #5 asks
+            // to be distinguishable.
+            //
+            // The scan is single-shard BY CONSTRUCTION, which is why it belongs
+            // here rather than at a call site: `nat64_frag_shard_index`
+            // deliberately digests only `(family, src, dst, ident)`, excluding
+            // `authority` and `protocol` precisely so same-datagram candidates
+            // stay CO-LOCATED. Every alias candidate is already in the bucket
+            // this function has locked and just scanned.
+            //
+            // Ordering matters: this runs only on a FULL-KEY miss, so the
+            // generation and owner-RG fences below cannot reach it. A
+            // config-generation eviction is an ordinary commit invalidating the
+            // cache and must NOT be reported as an alias.
+            let alias = shard.iter().find(|e| {
+                e.key.addr_family == key.addr_family
+                    && e.key.src == key.src
+                    && e.key.dst == key.dst
+                    && e.key.ident == key.ident
+            });
+            if let Some(e) = alias {
+                if e.key.authority != key.authority {
+                    NAT64_FRAG_CROSS_DOMAIN_MISSES.fetch_add(1, Ordering::Relaxed);
+                } else if e.key.protocol != key.protocol {
+                    NAT64_FRAG_PROTOCOL_ALIAS_MISSES.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            return None;
+        };
         // Config-generation guard (#5624): a match minted under a stale config
         // generation is evicted and reported as a miss, so a commit that
         // changed deny/NAT64 rules invalidates the association instead of

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -6667,3 +6667,179 @@ fn nat64_6982_charge_uses_the_allocators_own_capacity_formula() {
     // The values are non-trivial, so the agreement above is not two zeros.
     assert!(nat64_prefix_charge(1).port_capacity > 60_000);
 }
+
+// ---- #7056 (#5798 required-fix #5): the distinct refused-alias counters ----
+
+fn frag_alias_counts_7056() -> (u64, u64) {
+    (
+        NAT64_FRAG_CROSS_DOMAIN_MISSES.load(std::sync::atomic::Ordering::Relaxed),
+        NAT64_FRAG_PROTOCOL_ALIAS_MISSES.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
+fn frag_key_7056(protocol: u8, authority: FragAuthority) -> Nat64FragKey {
+    Nat64FragKey {
+        addr_family: libc::AF_INET6 as u8,
+        src: IpAddr::V6("2001:db8::1".parse().unwrap()),
+        dst: IpAddr::V6("64:ff9b::0808:0808".parse().unwrap()),
+        ident: 0xfeed,
+        protocol,
+        authority,
+    }
+}
+
+/// #7056: a fragment-association miss has several causes with very different
+/// meanings, and before this they all landed on the same drop counter. This is
+/// the table that separates them, and the MIDDLE ROW is what makes it a test
+/// rather than a demonstration: an ordinary miss — no entry at all — must count
+/// as NEITHER. A classifier that simply counted every miss would satisfy the two
+/// interesting rows and fail this one.
+#[test]
+fn refused_alias_misses_are_counted_distinctly_7056() {
+    let decision = frag_test_decision(Nat64State::forward_decision(
+        Ipv4Addr::new(198, 51, 100, 1),
+        Ipv4Addr::new(8, 8, 8, 8),
+        5000,
+    ));
+
+    // (1) CROSS-DOMAIN: installed under one authority, consulted under another.
+    let cache = Nat64FragAssoc::new();
+    cache.install(
+        frag_key_7056(PROTO_UDP, frag_test_authority()),
+        decision,
+        None,
+        1_000,
+        1,
+        0,
+    );
+    let (x0, p0) = frag_alias_counts_7056();
+    let hit = cache.lookup(
+        &frag_key_7056(PROTO_UDP, frag_other_authority()),
+        2_000,
+        1,
+        |_| true,
+    );
+    let (x1, p1) = frag_alias_counts_7056();
+    assert!(
+        hit.is_none(),
+        "precondition: a cross-domain consult must MISS (the #5798 fail-closed \
+         behaviour); if it hits, this test is measuring the wrong thing"
+    );
+    assert_eq!(
+        (x1 - x0, p1 - p0),
+        (1, 0),
+        "a cross-domain refusal must advance the CROSS-DOMAIN counter and only \
+         that one — it is the one miss cause that describes the traffic rather \
+         than cache pressure (#7056)"
+    );
+
+    // (2) PROTOCOL ALIAS: same authority, TCP vs UDP on one (src, dst, ident).
+    let cache = Nat64FragAssoc::new();
+    cache.install(
+        frag_key_7056(PROTO_UDP, frag_test_authority()),
+        decision,
+        None,
+        1_000,
+        1,
+        0,
+    );
+    let (x0, p0) = frag_alias_counts_7056();
+    let hit = cache.lookup(
+        &frag_key_7056(PROTO_TCP, frag_test_authority()),
+        2_000,
+        1,
+        |_| true,
+    );
+    let (x1, p1) = frag_alias_counts_7056();
+    assert!(hit.is_none(), "precondition: a protocol-aliased consult must MISS");
+    assert_eq!(
+        (x1 - x0, p1 - p0),
+        (0, 1),
+        "a protocol-alias refusal must advance the PROTOCOL counter and only that \
+         one. Folding the two into a single \"alias refused\" total would answer \
+         neither operator question: cross-domain means another security domain's \
+         association was probed, protocol-alias means TCP and UDP collided on \
+         (src, dst, ident) (#7056)"
+    );
+
+    // (3) THE MIDDLE ROW — an ordinary miss, no entry at all. Neither counter.
+    let cache = Nat64FragAssoc::new();
+    let (x0, p0) = frag_alias_counts_7056();
+    let hit = cache.lookup(
+        &frag_key_7056(PROTO_UDP, frag_test_authority()),
+        2_000,
+        1,
+        |_| true,
+    );
+    let (x1, p1) = frag_alias_counts_7056();
+    assert!(hit.is_none(), "precondition: an empty cache must miss");
+    assert_eq!(
+        (x1 - x0, p1 - p0),
+        (0, 0),
+        "an ORDINARY miss — reorder, TTL straddle, eviction, cold cache — must \
+         advance NEITHER counter. This is the row that distinguishes a real \
+         classifier from one that counts every miss, and counting every miss is \
+         exactly the lumping #7056 exists to undo"
+    );
+
+    // (4) A HIT must not count either, or the counters measure consult volume.
+    let cache = Nat64FragAssoc::new();
+    let key = frag_key_7056(PROTO_UDP, frag_test_authority());
+    cache.install(key, decision, None, 1_000, 1, 0);
+    let (x0, p0) = frag_alias_counts_7056();
+    let hit = cache.lookup(&key, 2_000, 1, |_| true);
+    let (x1, p1) = frag_alias_counts_7056();
+    assert!(hit.is_some(), "precondition: the matching consult must HIT");
+    assert_eq!(
+        (x1 - x0, p1 - p0),
+        (0, 0),
+        "a HIT must advance neither counter"
+    );
+}
+
+/// #7056: the classification must survive the entry it is classifying against
+/// being evicted for an unrelated reason. A config-generation bump evicts the
+/// entry and returns a miss BEFORE the alias scan would run, so that miss is a
+/// generation miss — not a refused alias — even though the stale entry differed
+/// in authority too.
+///
+/// Without this, the classifier could attribute every generation-fenced miss to
+/// cross-domain aliasing on a box that had simply committed a config change,
+/// which is the false-positive direction: it would make the one counter that is
+/// supposed to mean "something is probing another domain" fire on an ordinary
+/// commit.
+#[test]
+fn a_generation_fenced_miss_is_not_reported_as_an_alias_7056() {
+    let decision = frag_test_decision(Nat64State::forward_decision(
+        Ipv4Addr::new(198, 51, 100, 1),
+        Ipv4Addr::new(8, 8, 8, 8),
+        5000,
+    ));
+    let cache = Nat64FragAssoc::new();
+    cache.install(
+        frag_key_7056(PROTO_UDP, frag_test_authority()),
+        decision,
+        None,
+        1_000,
+        1, // generation 1
+        0,
+    );
+    let (x0, p0) = frag_alias_counts_7056();
+    // SAME key, but the config generation moved on.
+    let hit = cache.lookup(
+        &frag_key_7056(PROTO_UDP, frag_test_authority()),
+        2_000,
+        2, // generation 2
+        |_| true,
+    );
+    let (x1, p1) = frag_alias_counts_7056();
+    assert!(hit.is_none(), "precondition: a stale-generation entry must miss");
+    assert_eq!(
+        (x1 - x0, p1 - p0),
+        (0, 0),
+        "a CONFIG-GENERATION miss must not be reported as a refused alias — it is \
+         an ordinary commit invalidating the cache, and attributing it to \
+         cross-domain probing would make that counter fire on every config \
+         change (#7056)"
+    );
+}

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -280,6 +280,18 @@ pub(crate) struct ProcessStatus {
     /// reverse identity. Additive + `default`ed (#1961).
     #[serde(rename = "interface_snat_pat_collisions_total", default)]
     pub interface_snat_pat_collisions_total: u64,
+    /// #7056 (#5798 required-fix #5): fragment-association misses caused by the
+    /// key refusing a CROSS-DOMAIN alias — a same-datagram entry under a
+    /// different ingress security domain. Previously indistinguishable from a
+    /// reorder / TTL straddle / eviction on `nat64_frag_dropped`. Additive +
+    /// `default`ed (#1961), so an older helper that does not emit it decodes 0.
+    #[serde(rename = "nat64_frag_cross_domain_misses_total", default)]
+    pub nat64_frag_cross_domain_misses_total: u64,
+    /// #7056: the sibling leg — same domain, PROTOCOL alias (TCP vs UDP on one
+    /// `(src, dst, ident)`). Distinct from the cross-domain counter on purpose.
+    /// Additive + `default`ed (#1961).
+    #[serde(rename = "nat64_frag_protocol_alias_misses_total", default)]
+    pub nat64_frag_protocol_alias_misses_total: u64,
     /// #6751 PR 2/3: interface-mode SNAT admissions that failed CLOSED with no
     /// free translated identity — a completed full-cycle PAT probe, a port-less
     /// protocol whose single identity is owned, or a peer-synced import whose

--- a/userspace-dp/src/server/helpers/status.rs
+++ b/userspace-dp/src/server/helpers/status.rs
@@ -127,6 +127,12 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // fail-closed exhaustion modes it can hit.
     state.status.interface_snat_pat_collisions_total =
         state.afxdp.interface_snat_pat_collisions_total();
+    // #7056: the two refused-alias legs, kept apart so an operator can tell a
+    // cross-domain probe from a TCP/UDP ident collision.
+    state.status.nat64_frag_cross_domain_misses_total =
+        state.afxdp.nat64_frag_cross_domain_misses_total();
+    state.status.nat64_frag_protocol_alias_misses_total =
+        state.afxdp.nat64_frag_protocol_alias_misses_total();
     state.status.interface_snat_identity_exhaustion_total =
         state.afxdp.interface_snat_identity_exhaustion_total();
     state

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -241,6 +241,8 @@ pub(crate) fn run() -> Result<(), String> {
             nat_reverse_key_shared_displacements_total: 0,
             // #6751 PR 2/3: interface-mode SNAT identity registry counters.
             interface_snat_pat_collisions_total: 0,
+            nat64_frag_cross_domain_misses_total: 0,
+            nat64_frag_protocol_alias_misses_total: 0,
             interface_snat_identity_exhaustion_total: 0,
             interface_snat_sync_identity_conflict_drops_total: 0,
             interface_snat_registry_cap_exhaustion_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -888,6 +888,8 @@
     "last_snapshot_generation": 0,
     "manager_neighbor_generation": 0,
     "max_sessions": 0,
+    "nat64_frag_cross_domain_misses_total": 0,
+    "nat64_frag_protocol_alias_misses_total": 0,
     "nat_reverse_key_collisions": 0,
     "nat_reverse_key_collisions_distinct_src": 0,
     "nat_reverse_key_shared_displacements_total": 0,


### PR DESCRIPTION
Closes #7056

Delivers #5798 **required-fix #5** (the distinct cross-domain counter). Required-fix
#1 (modular `fragment_assoc/`) is **measured and deliberately not done** — see the
recommendation at the bottom, which is a *schedule it*, not a decline.

## What actually remained at current master

Measured first, because a "residuals" issue goes stale fast and several NAT64
changes landed the same day:

- **No** `fragment_assoc/` component. The cache is still `nat64.rs` (4391 lines)
  plus `afxdp/poll_descriptor/frag_assoc.rs` (444).
- **No** cross-domain counter — `grep cross_domain` returns nothing outside tests.

Both parts genuinely remained.

## The defect

#6835 delivered the fail-closed half: a cross-domain or protocol-aliased fragment
builds a different key, misses, and dies on the Pref64 gate or the #6122
discriminator. The **distinct counter** was not delivered, so such a miss was
indistinguishable from a reorder, a TTL straddle, a shard eviction or a
config-generation bump — all of them land on `nat64_frag_dropped` /
`nat_frag_untranslated_dropped`.

Those causes are not interchangeable. A reorder or TTL straddle is a path-MTU /
cache-pressure story. **A refused alias is a traffic story** — the only one of the
group that can indicate an attempt to ride another security domain's association.

## Why the classification lives in `lookup`

The scan is single-shard **by construction**, and the code already documents why:
`nat64_frag_shard_index` digests only `(family, src, dst, ident)`, excluding
`authority` and `protocol` precisely so same-datagram candidates stay co-located —

> It keeps same-datagram candidates CO-LOCATED, so a cross-domain aliasing
> attempt is observable with a single-shard scan rather than a walk of all
> `NAT64_FRAG_SHARDS` buckets.

So this costs one pass over a bucket `lookup` has already locked and just walked.

## Two counters, not one

`CROSS_DOMAIN` (a same-datagram entry under a different ingress `FragAuthority` —
the #5798 defect proper) and `PROTOCOL_ALIAS` (same domain, TCP vs UDP colliding
on `(src, dst, ident)` — what required-fix #2 added `protocol` to the key to
separate). Folding them would answer neither question, which is the same defect
one level up.

## Placement is load-bearing

The classification runs only on a **full-key** miss, so the generation and
owner-RG fences below it cannot reach it. A config-generation eviction is an
ordinary commit invalidating the cache and must **not** be reported as
cross-domain probing — that would make the one counter meaning "something is
probing another domain" fire on every config change. Bound by
`a_generation_fenced_miss_is_not_reported_as_an_alias_7056`, which holds on both
sides of the change (an over-counting guard, not a defect test).

## The middle row

`refused_alias_misses_are_counted_distinctly_7056` carries four rows, and the
third is what makes it a test rather than a demonstration: **an ordinary miss,
no entry at all, must advance NEITHER counter.** A classifier that simply counted
every miss satisfies both interesting rows and fails only that one — and counting
every miss is exactly the lumping this issue exists to undo. The fourth row
asserts a HIT counts nothing, so the counters cannot degenerate into consult
volume.

**Red-on-revert:** removing the classification reds the main table. (Verified
after committing the fix — `git checkout --` had already eaten one uncommitted
copy of it, which is why the rule is commit-then-mutate.)

## Surfacing

Rust atomic → coordinator status accessor → `server/helpers/status.rs` →
`protocol/control.rs` (additive + `default`, #1961) → Go `ProcessStatus` → two
Prometheus series, emitted unconditionally like the sibling SNAT counters
(a published 0 means "no alias was ever refused", not an absent series).

`TestEmitUserspaceDynamicBufferMetrics` caught the addition **twice**, both times
working as designed: first a nil-Desc panic (the fixture enumerates every Desc
that function touches — note that is a panic with **zero** named failing tests,
which a FAIL-count harness would score VOID), then the metric **census**
(want 46, got 48). The census is bumped with a note that the pair is deliberately
two series. A census bump alone is the weak repair — it passes against emits
wired to the wrong field — so both series also get value assertions with
**distinct** fixture values (23 / 29), which is what makes a swapped pair
observable.

## Required-fix #1 — the seam survives the move, but the timing is wrong

Checked rather than assumed: `Nat64FragKey` is **already family-agnostic**
(`addr_family`, `src`, `dst`, `ident`, `protocol`, `authority` — nothing
NAT64-specific), and `Nat64FragEntry`'s only NAT64-flavoured field is
`reverse: Option<Nat64ReverseInfo>`, already `Option` because the same-family NAT
arm leaves it `None`. **The data model is already the shared thing; only the
module name says otherwise.**

So this is not a split that scatters the property it names — it would concentrate
one that is already true and mislabelled. That argues *for* doing it.

What argues against doing it **now** is churn, not design: a rename+move across a
4391-line file with call sites in `afxdp/poll_descriptor/`, in an area where two
other lanes have been landing changes today. A pure-motion PR there maximises
conflict surface for zero behaviour change.

**Recommendation: schedule it when `nat64.rs` is quiet, as a motion-only PR.**
Not declined.

## Wire golden — regenerated, diff classified against MASTER

The two counters ride `ProcessStatus`, so they land in the default specimen and
`protocol::tests::wire_invariant_default_specimens` drifted.

**Final diff vs `origin/master`:**

```diff
+    "nat64_frag_cross_domain_misses_total": 0,
+    "nat64_frag_protocol_alias_misses_total": 0,
```

**2 keys added, both value 0. 0 keys removed. 0 values changed.** The benign
additive signature.

### Classifying against HEAD would have hidden a deleted field

Regenerating on the branch as it stood produced this instead:

```diff
-    "nat64_frag_assoc_evicted": 0,
+    "nat64_frag_cross_domain_misses_total": 0,
+    "nat64_frag_protocol_alias_misses_total": 0,
```

The branch was **36 commits behind**, and `5bac3bdeb` ("count fragment-association
evictions of LIVE entries") had added `nat64_frag_assoc_evicted` to the golden in
the meantime. Regeneration writes the fixture from the **local tree**, which does
not carry that lane's counter — so merging would have deleted their field from
the wire fixture.

A HEAD-relative classification cannot see this. The regen overwrote the file from
this tree, so a diff against this tree'"'"'s own HEAD is additive **by construction**:
it can only show keys this branch adds, never a key this branch never had. The
classification has to be against the **merge target**.

Merged `origin/master` first (clean, no unmerged paths), then regenerated.
`nat64_frag_assoc_evicted` is preserved.

### Skew contract, both sides

So an older peer decodes a missing field as 0 rather than failing the status
parse (#1961 additive-counter rule):

- **Rust** — `#[serde(rename = "...", default)]` on both fields
  (`protocol/control.rs`)
- **Go** — `json:"...,omitempty"` on both fields (`protocol_status.go`)

### Both fields are READ, not merely published

Not the #7087 shape: each feeds a `prometheus.MustNewConstMetric` in
`metrics_userspace.go:776` / `:781`, surfacing as
`xpf_userspace_nat64_frag_cross_domain_misses_total` and
`xpf_userspace_nat64_frag_protocol_alias_misses_total`.

## Validation

- `cargo build` clean; `go build ./...` ok
- `cargo test --bin xpf-userspace-dp -- --test-threads=1 _7056` — **2 passed**
- `go test -count=1 ./pkg/api/ ./pkg/dataplane/userspace/` — **ok, ok**
