### PR TITLE
daemon: consume the transport drop signal (#7071); refute #7072 by measurement

### DIFF
--- a/docs/log/7071-7072.md
+++ b/docs/log/7071-7072.md
@@ -4,32 +4,78 @@ Landed together because they collide: both change `startClusterComms` /
 `stopClusterComms` in `daemon_ha_sync.go`, and a fix to either changes what the
 other should assert.
 
-## #7072 — the field outlived its epoch
+## #7072 — REFUTED by measurement, after I first implemented it
 
-`stopClusterComms` nils `clusterCommsCancel`, `clusterCommsCtx`, `sessionSync`,
-`fabricRefreshCh` and `fabricRefreshCh1`, but left `activeClusterTransport`
-naming the transport of the epoch it had just destroyed. #6290 joined that field
-to the epoch on the PUBLISH side and not the teardown side. It now clears in the
-same locked section as the rest of the tuple.
+I initially did what the issue asked: cleared `activeClusterTransport` in
+`stopClusterComms`. **That is a regression, and my own test asserted it as
+correct.** Reverted.
 
-### The issue's rationale needs a correction, and the fix is weaker than it claims
+### The premise is false
 
-The issue says a stale field means step 20 "would compare the next commit against
-a dead baseline and skip a restart it should perform". Half true. Step 20's guard
-is `active != zero && newTransport != active` — **restart-on-change, not
-start-if-stopped**:
+The issue says the stale value is unreachable because "the only
+`stopClusterComms` call site is `daemon_apply_tail.go:258`, immediately followed
+by `startClusterComms`". There is a **second**: `bootstrap.go`'s rollback
+teardown stops comms and RETURNS. I repeated the claim in my own PR body before
+checking it.
 
-| | config unchanged | config changed |
+### Measured, both arms
+
+Driving the real `applyTailReconciles` with a counting `startClusterCommsFn` on
+the bootstrap-rollback shape — stop, then a corrected commit carrying a
+DIFFERENT transport key:
+
+| | restarts | outcome |
 |---|---|---|
-| stale field | no restart (comms stay down) | **restart** (comms come back) |
-| cleared | no restart | **no restart** — first conjunct is false |
+| field retained (today) | **1** | comms recover |
+| field cleared | **0** | comms stay down |
 
-So clearing does **not** rescue a hypothetical stop-only path; it changes WHICH
-restart is skipped. What it buys is that the field stops LYING, which is the
-precondition for reasoning about such a path at all — anyone adding one owes it
-an explicit start, and must not read a non-zero `activeTransport()` as "comms are
-up". Both the code comment and
-`TestStepTwentyDoesNotRestartOnAClearedTransport_7072` say so.
+Step 20's guard is `active != zero && newTransport != active`, so clearing makes
+the FIRST conjunct false and it fails in both directions. The only other
+production `startClusterComms` call site is the `daemon_run.go` boot path, so the
+node would hold a valid cluster config with no heartbeat, no session sync and no
+fabric refresh until the process restarted.
+
+### The first version of that measurement was wrong in a way that looked right
+
+Its daemon had no `cluster` manager, and step 20 is gated on `d.cluster != nil` —
+so **both** arms reported `restarts=0`, which reads exactly like a confirmed
+regression. The control is what caught it: two arms agreeing is a fixture
+result, not a finding. A measurement that confirms the hypothesis in every cell
+has not discriminated anything.
+
+### The obvious repair is also wrong
+
+Clearing the field and relaxing the guard to `newTransport != active` has a
+perfect-looking truth table and reintroduces a documented boot race: the boot
+`applyConfig` runs BEFORE `daemon_run.go:405`'s `startClusterComms` — positioned
+after the event fanout precisely to avoid an HA startup race — so step 20 runs
+during boot with the field still zero, and `active != zero` is what keeps it out
+of that window.
+
+### What that means for the field
+
+It carries TWO meanings and its name says one:
+
+- *"which transport the running comms use"* — the documented meaning;
+- *"comms have run at least once, so step 20 may act"* — what `active != zero`
+  actually tests, in both directions.
+
+Splitting them properly needs new state and a step 20 that can START comms, not
+only restart them — a behaviour change with a failover-adjacent blast radius. It
+gets its own issue (**#7901**) and its own smoke rather than riding a
+truthfulness fix. What lands here is the rationale at the site plus two cells
+that BRACKET the guard.
+
+### Both directions are now guarded
+
+| cell | pins |
+|---|---|
+| `TestBootstrapRollbackThenCorrectedCommitRecovers_7072` | a post-rollback commit MUST recover — **this is the cell the naive fix fails** |
+| `TestStepTwentyIgnoresANeverStartedNode_7072` | a never-started node must NOT be acted on — the boot window |
+
+Applying the rejected design reds **two** tests, mine and the pre-existing
+`TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078`, so the tree now refuses it
+from two directions.
 
 ## #7071 — the drop signal was discarded
 
@@ -97,16 +143,18 @@ path.
 
 ## Mutation matrix
 
-`go test ./pkg/daemon/ -count=1 -v`, 2193 collected in every cell, `enospc=0`,
-`git diff --stat` non-empty between edit and run (a revert that fails to apply
-looks exactly like a green revert).
+`go test ./pkg/daemon/ -count=1 -v`, **2195 collected** in every cell,
+`enospc=0`, `git diff --stat` non-empty between edit and run (a revert that fails
+to apply looks exactly like a green revert).
 
 | cell | mutation | rc | named |
 |---|---|---|---|
-| **m7072** | `stopClusterComms` stops clearing the field | 1 | `TestStopClusterCommsClearsTheActiveTransport_7072`, `TestStepTwentyDoesNotRestartOnAClearedTransport_7072` |
-| **m7071** | the call site discards the bool again | 1 | `TestStartClusterCommsConsumesTheDropSignal_7071` — **only** |
+| **m7071** | the call site discards the bool again | 1 | `TestStartClusterCommsConsumesTheDropSignal_7071` — only |
+| **m7072clear** | apply the REJECTED design: clear the field on teardown | 1 | `TestBootstrapRollbackThenCorrectedCommitRecovers_7072`, `TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078` |
 
-Each cell reds a disjoint set, so the two halves are independently bound.
+The second cell is unusual and deliberate: it mutates the tree TOWARDS what the
+issue asked for, and the suite refuses it. That is the useful shape when an
+issue's requested change is the defect.
 
 ## Fixtures
 

--- a/docs/log/7071-7072.md
+++ b/docs/log/7071-7072.md
@@ -1,0 +1,125 @@
+# 7071 + 7072 — the cluster-transport epoch tuple, both sides
+
+Landed together because they collide: both change `startClusterComms` /
+`stopClusterComms` in `daemon_ha_sync.go`, and a fix to either changes what the
+other should assert.
+
+## #7072 — the field outlived its epoch
+
+`stopClusterComms` nils `clusterCommsCancel`, `clusterCommsCtx`, `sessionSync`,
+`fabricRefreshCh` and `fabricRefreshCh1`, but left `activeClusterTransport`
+naming the transport of the epoch it had just destroyed. #6290 joined that field
+to the epoch on the PUBLISH side and not the teardown side. It now clears in the
+same locked section as the rest of the tuple.
+
+### The issue's rationale needs a correction, and the fix is weaker than it claims
+
+The issue says a stale field means step 20 "would compare the next commit against
+a dead baseline and skip a restart it should perform". Half true. Step 20's guard
+is `active != zero && newTransport != active` — **restart-on-change, not
+start-if-stopped**:
+
+| | config unchanged | config changed |
+|---|---|---|
+| stale field | no restart (comms stay down) | **restart** (comms come back) |
+| cleared | no restart | **no restart** — first conjunct is false |
+
+So clearing does **not** rescue a hypothetical stop-only path; it changes WHICH
+restart is skipped. What it buys is that the field stops LYING, which is the
+precondition for reasoning about such a path at all — anyone adding one owes it
+an explicit start, and must not read a non-zero `activeTransport()` as "comms are
+up". Both the code comment and
+`TestStepTwentyDoesNotRestartOnAClearedTransport_7072` say so.
+
+## #7071 — the drop signal was discarded
+
+`startClusterComms` ignored `setActiveTransportIfCurrent`'s bool while both
+siblings gate on theirs. It now returns early on a drop.
+
+**The reason is stronger than the wasted work the issue describes.** The
+goroutines below the call capture `commsCtx`, whose cancel the NEWER epoch has
+already overwritten in `clusterCommsCancel` — so nothing can cancel them:
+`stopClusterComms` would call the newer epoch's cancel. They survive until the
+daemon context dies, i.e. for the life of the process.
+
+The early return also cancels its own sub-context. That needs
+`beginClusterCommsEpoch` to return the cancel, because reaching it through the
+field would tear down the LIVE epoch instead.
+
+## An existing test broke, and it was right to
+
+#5078's three subtests were order-independent "because none of them REWRITES
+`d.activeClusterTransport`" — true of the subtests, and no longer true of the
+code they drive. The second subtest's step 20 reaches `stopClusterComms`, which
+now zeroes the field, and that fixture's `startClusterComms` early-returns (its
+store deliberately holds no committed cluster stanza, `cfg.Chassis.Cluster ==
+nil`) so nothing republishes it. The third subtest then found a ZERO baseline and
+failed for a reason unrelated to keying.
+
+Each subtest now re-seeds the same unkeyed baseline explicitly. That removes a
+hidden inter-subtest dependency rather than papering over one, and it keeps clear
+of the masking shape the third subtest's own note warns about — seeding a KEYED
+value there masked `key_commit_must_not_restart` under a mutation that adds the
+auth key to `clusterTransportKey`.
+
+**Production is unaffected**, verified against the early-return guard: a
+clustered node's `startClusterComms` does not early-return, so its epoch-open
+republish restores the field immediately after step 20's stop.
+
+## My own #7071 test was adjacent to the property, and the matrix caught it
+
+First matrix run:
+
+| cell | mutation | rc | named |
+|---|---|---|---|
+| m7072 | stop clearing the transport | 1 | both #7072 cells |
+| **m7071** | discard the drop signal again | **0 — GREEN** | **none** |
+
+`TestSupersededEpochPublishIsRefused_7071` asserts that
+`setActiveTransportIfCurrent` REFUSES a superseded epoch. That is true with the
+fix and without it — the gate is unchanged either way. The test was about the
+gate, not about the call site consuming it.
+
+The property cannot be driven behaviourally without a seam: the drop needs the
+epoch to advance between `beginClusterCommsEpoch` and the publish on the very
+next line, a window no test can schedule. Rather than add a production seam whose
+only consumer is a test, `TestStartClusterCommsConsumesTheDropSignal_7071`
+asserts the call site's SHAPE — the instrument
+`TestDaemonPassesRethBeforeCycleHook_5103` already uses for "this function has
+one call site and its result is assigned back", and
+`TestCompileRoutesPublishThroughFailClosedHelper4959` for "this publish goes
+through the fail-closed helper".
+
+It strips comments before matching (a source-scanning guard that reads its own
+prose is satisfied by the sentence describing what it should find), asserts
+non-vacuity — the call is present at all — and asserts the cancel on the drop
+path.
+
+## Mutation matrix
+
+`go test ./pkg/daemon/ -count=1 -v`, 2193 collected in every cell, `enospc=0`,
+`git diff --stat` non-empty between edit and run (a revert that fails to apply
+looks exactly like a green revert).
+
+| cell | mutation | rc | named |
+|---|---|---|---|
+| **m7072** | `stopClusterComms` stops clearing the field | 1 | `TestStopClusterCommsClearsTheActiveTransport_7072`, `TestStepTwentyDoesNotRestartOnAClearedTransport_7072` |
+| **m7071** | the call site discards the bool again | 1 | `TestStartClusterCommsConsumesTheDropSignal_7071` — **only** |
+
+Each cell reds a disjoint set, so the two halves are independently bound.
+
+## Fixtures
+
+`clusteredStore7066` throughout — its `control-interface` makes the transport key
+NON-ZERO while starting no goroutines (the heartbeat needs control-interface AND
+peer-address; `clusterSyncTransport` falls back to the empty fabric pair when
+either is missing). The pre-existing #6290 fixture sets none of the key's fields,
+so an assertion written against it is zero == zero and passes with the publish
+deleted.
+
+## Validation
+
+- `go build ./...`, `go vet ./...` clean.
+- `go test ./... -count=1`: **rc=0**, `enospc=0`, FAIL count taken from the whole
+  log rather than a truncated head.
+- Cells above.

--- a/pkg/daemon/cluster_transport_key_5078_test.go
+++ b/pkg/daemon/cluster_transport_key_5078_test.go
@@ -173,39 +173,6 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	// activeClusterTransport that step 20 requires before it will restart.
 	d.activeClusterTransport = clusterTransportFromConfig(transport())
 
-	// #7072: RE-SEED before each subtest, because stopClusterComms now clears
-	// this field as part of tearing the epoch tuple down.
-	//
-	// The subtests used to inherit the one seed above, and the comment on the
-	// third said they were order-independent "because none of them REWRITES
-	// d.activeClusterTransport". That was true of the subtests and is no longer
-	// true of the code they drive: the second subtest's step 20 reaches
-	// stopClusterComms, which zeroes the field, and this fixture's
-	// startClusterComms early-returns (its store deliberately holds no committed
-	// cluster stanza) so nothing republishes it. The third subtest then found a
-	// ZERO active transport, step 20's `active != zero` conjunct was false, and
-	// it failed for a reason that had nothing to do with keying.
-	//
-	// Production is unaffected: a clustered node's startClusterComms does not
-	// early-return, so the republish at its epoch-open restores the field
-	// immediately after step 20's stop.
-	//
-	// Seeding the SAME unkeyed baseline in every subtest is deliberate. The
-	// third subtest's note explains why seeding a KEYED value there would be
-	// wrong — under a mutation that adds ControlLinkAuthKey to
-	// clusterTransportKey it masked key_commit_must_not_restart. This writes the
-	// identical value the fixture already seeded, so it establishes each
-	// subtest's precondition without introducing that shape.
-	seedActiveTransport := func(t *testing.T) {
-		t.Helper()
-		d.activeClusterTransport = clusterTransportFromConfig(transport())
-		if d.activeClusterTransport == (clusterTransportKey{}) {
-			t.Fatalf("premise: the seeded transport must be NON-zero, or step 20's " +
-				"`active != zero` conjunct is false and every subtest below passes or " +
-				"fails for the wrong reason")
-		}
-	}
-
 	gen := func() uint64 {
 		d.clusterCommsMu.Lock()
 		defer d.clusterCommsMu.Unlock()
@@ -213,7 +180,6 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	}
 
 	t.Run("key_commit_must_not_restart", func(t *testing.T) {
-		seedActiveTransport(t)
 		keyed := transport()
 		keyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-5078")
 
@@ -233,7 +199,6 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	// Positive control: an endpoint change MUST still restart, or the assertion
 	// above is satisfied by a step 20 that never fires at all.
 	t.Run("endpoint_change_must_restart", func(t *testing.T) {
-		seedActiveTransport(t)
 		moved := transport()
 		moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
 
@@ -287,7 +252,6 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	//
 	// Tracked as #6878. Do not read "must still restart" as bound end to end.
 	t.Run("keyed_endpoint_change_must_still_restart", func(t *testing.T) {
-		seedActiveTransport(t)
 		movedKeyed := transport()
 		movedKeyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-5078")
 		movedKeyed.Chassis.Cluster.PeerAddress = "10.99.0.9"
@@ -301,10 +265,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 		// inside a subtest: under a mutation that DOES add ControlLinkAuthKey
 		// to clusterTransportKey, that write masked key_commit_must_not_restart
 		// when this subtest ran first (measured). The three subtests are
-		// order-independent because each now RE-SEEDS `d.activeClusterTransport`
-		// (see seedActiveTransport above) — before #7072 they relied on none of
-		// them rewriting it, which stopped being true once stopClusterComms
-		// began clearing the field.
+		// order-independent because none of them REWRITES `d.activeClusterTransport`.
 		// They do mutate `d` — applyTailReconciles reaches stopClusterComms, which
 		// increments d.clusterCommsGen, and that is the very thing each subtest
 		// measures. The distinction matters: a shared counter every subtest reads

--- a/pkg/daemon/cluster_transport_key_5078_test.go
+++ b/pkg/daemon/cluster_transport_key_5078_test.go
@@ -173,6 +173,39 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	// activeClusterTransport that step 20 requires before it will restart.
 	d.activeClusterTransport = clusterTransportFromConfig(transport())
 
+	// #7072: RE-SEED before each subtest, because stopClusterComms now clears
+	// this field as part of tearing the epoch tuple down.
+	//
+	// The subtests used to inherit the one seed above, and the comment on the
+	// third said they were order-independent "because none of them REWRITES
+	// d.activeClusterTransport". That was true of the subtests and is no longer
+	// true of the code they drive: the second subtest's step 20 reaches
+	// stopClusterComms, which zeroes the field, and this fixture's
+	// startClusterComms early-returns (its store deliberately holds no committed
+	// cluster stanza) so nothing republishes it. The third subtest then found a
+	// ZERO active transport, step 20's `active != zero` conjunct was false, and
+	// it failed for a reason that had nothing to do with keying.
+	//
+	// Production is unaffected: a clustered node's startClusterComms does not
+	// early-return, so the republish at its epoch-open restores the field
+	// immediately after step 20's stop.
+	//
+	// Seeding the SAME unkeyed baseline in every subtest is deliberate. The
+	// third subtest's note explains why seeding a KEYED value there would be
+	// wrong — under a mutation that adds ControlLinkAuthKey to
+	// clusterTransportKey it masked key_commit_must_not_restart. This writes the
+	// identical value the fixture already seeded, so it establishes each
+	// subtest's precondition without introducing that shape.
+	seedActiveTransport := func(t *testing.T) {
+		t.Helper()
+		d.activeClusterTransport = clusterTransportFromConfig(transport())
+		if d.activeClusterTransport == (clusterTransportKey{}) {
+			t.Fatalf("premise: the seeded transport must be NON-zero, or step 20's " +
+				"`active != zero` conjunct is false and every subtest below passes or " +
+				"fails for the wrong reason")
+		}
+	}
+
 	gen := func() uint64 {
 		d.clusterCommsMu.Lock()
 		defer d.clusterCommsMu.Unlock()
@@ -180,6 +213,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	}
 
 	t.Run("key_commit_must_not_restart", func(t *testing.T) {
+		seedActiveTransport(t)
 		keyed := transport()
 		keyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-5078")
 
@@ -199,6 +233,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	// Positive control: an endpoint change MUST still restart, or the assertion
 	// above is satisfied by a step 20 that never fires at all.
 	t.Run("endpoint_change_must_restart", func(t *testing.T) {
+		seedActiveTransport(t)
 		moved := transport()
 		moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
 
@@ -252,6 +287,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	//
 	// Tracked as #6878. Do not read "must still restart" as bound end to end.
 	t.Run("keyed_endpoint_change_must_still_restart", func(t *testing.T) {
+		seedActiveTransport(t)
 		movedKeyed := transport()
 		movedKeyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-5078")
 		movedKeyed.Chassis.Cluster.PeerAddress = "10.99.0.9"
@@ -265,7 +301,10 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 		// inside a subtest: under a mutation that DOES add ControlLinkAuthKey
 		// to clusterTransportKey, that write masked key_commit_must_not_restart
 		// when this subtest ran first (measured). The three subtests are
-		// order-independent because none of them REWRITES `d.activeClusterTransport`.
+		// order-independent because each now RE-SEEDS `d.activeClusterTransport`
+		// (see seedActiveTransport above) — before #7072 they relied on none of
+		// them rewriting it, which stopped being true once stopClusterComms
+		// began clearing the field.
 		// They do mutate `d` — applyTailReconciles reaches stopClusterComms, which
 		// increments d.clusterCommsGen, and that is the very thing each subtest
 		// measures. The distinction matters: a shared counter every subtest reads

--- a/pkg/daemon/cluster_transport_race_6290_test.go
+++ b/pkg/daemon/cluster_transport_race_6290_test.go
@@ -122,7 +122,7 @@ func TestSetActiveTransportDropsStaleEpoch(t *testing.T) {
 	stale := clusterTransportKey{ControlInterface: "STALE", PeerAddress: "10.99.9.9"}
 
 	// Open an epoch and publish under it: the live state.
-	_, gen := d.beginClusterCommsEpoch(context.Background())
+	_, gen, _ := d.beginClusterCommsEpoch(context.Background())
 	if !d.setActiveTransportIfCurrent(gen, fresh) {
 		t.Fatal("publish under the CURRENT epoch must be accepted")
 	}
@@ -131,7 +131,7 @@ func TestSetActiveTransportDropsStaleEpoch(t *testing.T) {
 	}
 
 	// A restart supersedes it. The prior epoch's publish must now be dropped.
-	_, newGen := d.beginClusterCommsEpoch(context.Background())
+	_, newGen, _ := d.beginClusterCommsEpoch(context.Background())
 	if newGen == gen {
 		t.Fatal("precondition: beginClusterCommsEpoch must advance the generation")
 	}

--- a/pkg/daemon/cluster_transport_teardown_7071_7072_test.go
+++ b/pkg/daemon/cluster_transport_teardown_7071_7072_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -105,6 +107,77 @@ func TestStepTwentyDoesNotRestartOnAClearedTransport_7072(t *testing.T) {
 			"\"comms were previously started\"; firing on a zero baseline would restart "+
 			"comms that were never up, and would make the #7072 clear a behaviour change "+
 			"rather than a truthfulness fix", restarts, before, gen())
+	}
+}
+
+// #7071 CALL-SITE guard — and it exists because my first attempt at binding
+// this was measured GREEN under the revert.
+//
+// `TestSupersededEpochPublishIsRefused_7071` below asserts that
+// setActiveTransportIfCurrent REFUSES a superseded epoch. That is true with the
+// fix and true without it: the gate is unchanged either way. Reverting the call
+// site to `d.setActiveTransportIfCurrent(...)` with the result discarded left
+// the whole pkg/daemon suite green — 2192 collected, 0 named failures. The test
+// was adjacent to the property, not on it.
+//
+// The property is that the CALL SITE consumes the bool, and it cannot be driven
+// behaviourally without a seam: the drop needs the epoch to advance between
+// `beginClusterCommsEpoch` and the publish on the next line, a window no test
+// can schedule. Rather than add a production seam whose only consumer is a test,
+// this asserts the call site's SHAPE — the same instrument
+// `TestDaemonPassesRethBeforeCycleHook_5103` uses for "programRethMemberMAC has
+// exactly one call site and its result is assigned back", and
+// `TestCompileRoutesPublishThroughFailClosedHelper4959` uses for "this publish
+// goes through the fail-closed helper".
+//
+// Comments are stripped before matching. A source-scanning guard that reads its
+// own explanatory prose is satisfied by the sentence describing the thing it is
+// meant to find.
+func TestStartClusterCommsConsumesTheDropSignal_7071(t *testing.T) {
+	src, err := os.ReadFile("daemon_ha_sync.go")
+	if err != nil {
+		t.Fatalf("read daemon_ha_sync.go: %v", err)
+	}
+	const fn = "func (d *Daemon) startClusterComms("
+	start := strings.Index(string(src), fn)
+	if start < 0 {
+		t.Fatalf("startClusterComms not found — this guard is scanning for a name that " +
+			"no longer exists, which is not evidence that the call site is correct")
+	}
+	rest := string(src)[start+len(fn):]
+	if end := strings.Index(rest, "\nfunc "); end >= 0 {
+		rest = rest[:end]
+	}
+	var code []string
+	for _, line := range strings.Split(rest, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		code = append(code, line)
+	}
+	body := strings.Join(code, "\n")
+
+	// Non-vacuity: the call must be in there at all. Without this the shape
+	// assertion below would pass for free on a body that never publishes.
+	if !strings.Contains(body, "setActiveTransportIfCurrent(") {
+		t.Fatalf("startClusterComms no longer calls setActiveTransportIfCurrent at all, " +
+			"so the transport is never published and step 20's `active != zero` guard " +
+			"never passes")
+	}
+	if !strings.Contains(body, "if !d.setActiveTransportIfCurrent(") {
+		t.Errorf("startClusterComms DISCARDS setActiveTransportIfCurrent's drop signal.\n"+
+			"Both sibling publishers gate on theirs (publishSessionSyncIfCurrent, "+
+			"publishFabricRefreshChansIfCurrent). A false return means this epoch was "+
+			"superseded, so everything below wires a DEAD epoch onto `commsCtx` — whose "+
+			"cancel the newer epoch has already overwritten in clusterCommsCancel, so "+
+			"nothing can cancel those goroutines and they outlive the epoch that spawned "+
+			"them.\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "commsCancel()") {
+		t.Errorf("the drop path does not cancel its own sub-context. Returning without " +
+			"it leaks the context — nothing else holds that cancel, since the field now " +
+			"names the newer epoch's — and cancelling here is safe precisely because " +
+			"nothing has been launched on it yet")
 	}
 }
 

--- a/pkg/daemon/cluster_transport_teardown_7071_7072_test.go
+++ b/pkg/daemon/cluster_transport_teardown_7071_7072_test.go
@@ -5,108 +5,114 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
 )
 
-// #7072: stopClusterComms must clear `activeClusterTransport`, so the field
-// stops naming the transport of an epoch that has been torn down.
+// #7072 is REFUTED, and this is the cell that refutes it.
 //
-// This is a STATE claim, so it is asserted as one: the field's VALUE after
-// teardown. "Teardown ran" is not the property — the epoch generation already
-// binds that, and it advances whether or not the field is cleared.
+// The issue asked for `stopClusterComms` to clear `activeClusterTransport`,
+// on the premise that the stale value is unreachable — "the only
+// stopClusterComms call site is step 20's, immediately followed by a start".
+// There is a SECOND: bootstrap.go's rollback teardown stops comms and RETURNS.
 //
-// The fixture has to make the seed NON-ZERO or the assertion is zero == zero and
-// passes against a build with the clear removed. `clusterTransportFromConfig`
-// derives the key from ControlInterface / PeerAddress / the fabric fields, and
-// the pre-existing #6290 fixture sets none of them; `clusteredStore7066` sets
-// control-interface, which yields a non-zero key while starting no goroutines
-// (the heartbeat needs control-interface AND peer-address, and
-// clusterSyncTransport falls back to the empty fabric pair when either is
-// missing).
-func TestStopClusterCommsClearsTheActiveTransport_7072(t *testing.T) {
+// On that path the stale field is the ONLY memory of which transport comms were
+// using, and step 20's `active != zero && newTransport != active` needs it to
+// notice a corrected commit. Measured both ways with a counting
+// startClusterCommsFn:
+//
+//	field retained (today):  restarts=1  -> comms recover
+//	field cleared:           restarts=0  -> comms stay down
+//
+// This test is the retained side. It FAILS on the naive fix, which is the whole
+// reason it exists: the first version of this file asserted the cleared
+// behaviour as correct, and that assertion was a probe keyed to the repair
+// rather than to the property.
+//
+// The fixture must reach step 20, which is gated on `d.cluster != nil` — an
+// earlier draft omitted the cluster manager and measured restarts=0 in BOTH
+// arms, which looks exactly like a confirmed regression and is not.
+func TestBootstrapRollbackThenCorrectedCommitRecovers_7072(t *testing.T) {
 	store := clusteredStore7066(t)
-	d := &Daemon{store: store, opts: Options{NoDataplane: true}}
+	d := &Daemon{
+		store:     store,
+		networkd:  networkd.NewInDir(t.TempDir()),
+		vrrpMgr:   vrrp.NewManager(),
+		cluster:   cluster.NewManager(0, 1),
+		daemonCtx: context.Background(),
+		opts:      Options{NoDataplane: true},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	d.startClusterComms(ctx)
-
-	seeded := d.activeTransport()
-	if seeded == (clusterTransportKey{}) {
-		t.Fatalf("premise broken: the transport key is the ZERO value after " +
-			"startClusterComms, so the assertion below is zero == zero and would pass " +
-			"against a build that never clears it")
+	if d.activeTransport() == (clusterTransportKey{}) {
+		t.Fatal("premise: comms must publish a NON-ZERO transport, or step 20's " +
+			"`active != zero` conjunct is false for a reason unrelated to teardown")
 	}
 
+	// The bootstrap-rollback shape: stop, and do NOT start.
 	d.stopClusterComms()
 
-	if got := d.activeTransport(); got != (clusterTransportKey{}) {
-		t.Errorf("stopClusterComms left activeClusterTransport naming a torn-down "+
-			"transport: %+v (seeded %+v).\nThe field is part of the epoch tuple — "+
-			"sessionSync, fabricRefreshCh, fabricRefreshCh1 and the comms context are "+
-			"all nilled in the same locked section — and #6290 joined it to the epoch on "+
-			"the PUBLISH side only. Left stale, activeTransport() reports a live-looking "+
-			"key for comms that are stopped", got, seeded)
+	restarts := 0
+	d.startClusterCommsFn = func(context.Context) { restarts++ }
+
+	moved := store.ActiveConfig()
+	moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
+	_ = d.applyTailReconciles(moved, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	if restarts != 1 {
+		t.Errorf("a corrected commit after a bootstrap rollback did not restart comms "+
+			"(restarts=%d, activeTransport=%+v).\nThis is what clearing "+
+			"activeClusterTransport in stopClusterComms costs: step 20's first conjunct "+
+			"becomes false, and the only other production startClusterComms call site is "+
+			"the daemon_run.go boot path — so the node holds a valid cluster config with "+
+			"no heartbeat, no session sync and no fabric refresh until the process "+
+			"restarts (#7072)", restarts, d.activeTransport())
 	}
 }
 
-// #7072, the CONSEQUENCE — and it corrects the issue's stated rationale.
+// #7072, the other direction: a node that has NEVER started comms must not have
+// step 20 act for it.
 //
-// The issue says a stale field means "step 20 would compare the next commit
-// against a dead baseline and skip a restart it should perform". That is only
-// half true, and the half it misses matters for anyone who later adds the
-// stop-only path the issue is written against.
+// `active != zero` is not a redundant "have we started" convenience. The boot
+// applyConfig runs BEFORE daemon_run.go:405's startClusterComms — which is
+// deliberately positioned after the event fanout to avoid an HA startup race —
+// so step 20 runs during boot with the field still zero. Relaxing the guard to
+// just `newTransport != active`, the obvious repair once the field is cleared,
+// reintroduces that race with a truth table that looks perfect.
 //
-// Step 20's guard is `active != zero && newTransport != active`. Read it as what
-// it is — RESTART-ON-CHANGE, not START-IF-STOPPED:
-//
-//	stale field: config unchanged -> no restart (comms stay down)
-//	             config changed   -> restart    (comms come back)
-//	cleared:     either way       -> no restart, first conjunct is false
-//
-// So clearing does not rescue a stop-only path; it changes WHICH restart is
-// skipped. What it buys is that the field stops LYING, which is the precondition
-// for reasoning about such a path — not a substitute for giving it a start.
-//
-// This binds the half that is now load-bearing: with the field cleared, step 20
-// takes no action, so a future stop-only path cannot be built on the assumption
-// that step 20 will notice and restart for it.
-func TestStepTwentyDoesNotRestartOnAClearedTransport_7072(t *testing.T) {
+// Together with the cell above this brackets the guard: it must act after comms
+// have run, and must not before.
+func TestStepTwentyIgnoresANeverStartedNode_7072(t *testing.T) {
 	store := clusteredStore7066(t)
-	d := &Daemon{store: store, opts: Options{NoDataplane: true}}
-	d.daemonCtx = context.Background()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	d.startClusterComms(ctx)
-	d.stopClusterComms()
-
-	if got := d.activeTransport(); got != (clusterTransportKey{}) {
-		t.Fatalf("premise: the teardown must leave a ZERO transport, or this cell is "+
-			"about the stale-field path instead of the cleared one (got %+v)", got)
+	d := &Daemon{
+		store:     store,
+		networkd:  networkd.NewInDir(t.TempDir()),
+		vrrpMgr:   vrrp.NewManager(),
+		cluster:   cluster.NewManager(0, 1),
+		daemonCtx: context.Background(),
+		opts:      Options{NoDataplane: true},
+	}
+	if d.activeTransport() != (clusterTransportKey{}) {
+		t.Fatalf("premise: a never-started node must hold a ZERO transport, got %+v",
+			d.activeTransport())
 	}
 
 	restarts := 0
 	d.startClusterCommsFn = func(context.Context) { restarts++ }
 
-	// A config whose transport DIFFERS from the (now zero) baseline. Under the
-	// stale-field behaviour this is the case that restarted.
-	moved := store.ActiveConfig()
-	moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
+	cfg := store.ActiveConfig()
+	cfg.Chassis.Cluster.PeerAddress = "10.99.0.9"
+	_ = d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	gen := func() uint64 {
-		d.clusterCommsMu.Lock()
-		defer d.clusterCommsMu.Unlock()
-		return d.clusterCommsGen
-	}
-	before := gen()
-	_ = d.applyTailReconciles(moved, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-
-	if restarts != 0 || gen() != before {
-		t.Errorf("step 20 restarted comms off a CLEARED transport baseline "+
-			"(restarts=%d, gen %d -> %d). The `active != zero` conjunct exists to mean "+
-			"\"comms were previously started\"; firing on a zero baseline would restart "+
-			"comms that were never up, and would make the #7072 clear a behaviour change "+
-			"rather than a truthfulness fix", restarts, before, gen())
+	if restarts != 0 {
+		t.Errorf("step 20 acted for a node whose comms have never started "+
+			"(restarts=%d). The boot applyConfig runs before startClusterComms, so this "+
+			"would fire inside the HA startup window daemon_run.go:405 is positioned "+
+			"after (#7072)", restarts)
 	}
 }
 

--- a/pkg/daemon/cluster_transport_teardown_7071_7072_test.go
+++ b/pkg/daemon/cluster_transport_teardown_7071_7072_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+)
+
+// #7072: stopClusterComms must clear `activeClusterTransport`, so the field
+// stops naming the transport of an epoch that has been torn down.
+//
+// This is a STATE claim, so it is asserted as one: the field's VALUE after
+// teardown. "Teardown ran" is not the property — the epoch generation already
+// binds that, and it advances whether or not the field is cleared.
+//
+// The fixture has to make the seed NON-ZERO or the assertion is zero == zero and
+// passes against a build with the clear removed. `clusterTransportFromConfig`
+// derives the key from ControlInterface / PeerAddress / the fabric fields, and
+// the pre-existing #6290 fixture sets none of them; `clusteredStore7066` sets
+// control-interface, which yields a non-zero key while starting no goroutines
+// (the heartbeat needs control-interface AND peer-address, and
+// clusterSyncTransport falls back to the empty fabric pair when either is
+// missing).
+func TestStopClusterCommsClearsTheActiveTransport_7072(t *testing.T) {
+	store := clusteredStore7066(t)
+	d := &Daemon{store: store, opts: Options{NoDataplane: true}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.startClusterComms(ctx)
+
+	seeded := d.activeTransport()
+	if seeded == (clusterTransportKey{}) {
+		t.Fatalf("premise broken: the transport key is the ZERO value after " +
+			"startClusterComms, so the assertion below is zero == zero and would pass " +
+			"against a build that never clears it")
+	}
+
+	d.stopClusterComms()
+
+	if got := d.activeTransport(); got != (clusterTransportKey{}) {
+		t.Errorf("stopClusterComms left activeClusterTransport naming a torn-down "+
+			"transport: %+v (seeded %+v).\nThe field is part of the epoch tuple — "+
+			"sessionSync, fabricRefreshCh, fabricRefreshCh1 and the comms context are "+
+			"all nilled in the same locked section — and #6290 joined it to the epoch on "+
+			"the PUBLISH side only. Left stale, activeTransport() reports a live-looking "+
+			"key for comms that are stopped", got, seeded)
+	}
+}
+
+// #7072, the CONSEQUENCE — and it corrects the issue's stated rationale.
+//
+// The issue says a stale field means "step 20 would compare the next commit
+// against a dead baseline and skip a restart it should perform". That is only
+// half true, and the half it misses matters for anyone who later adds the
+// stop-only path the issue is written against.
+//
+// Step 20's guard is `active != zero && newTransport != active`. Read it as what
+// it is — RESTART-ON-CHANGE, not START-IF-STOPPED:
+//
+//	stale field: config unchanged -> no restart (comms stay down)
+//	             config changed   -> restart    (comms come back)
+//	cleared:     either way       -> no restart, first conjunct is false
+//
+// So clearing does not rescue a stop-only path; it changes WHICH restart is
+// skipped. What it buys is that the field stops LYING, which is the precondition
+// for reasoning about such a path — not a substitute for giving it a start.
+//
+// This binds the half that is now load-bearing: with the field cleared, step 20
+// takes no action, so a future stop-only path cannot be built on the assumption
+// that step 20 will notice and restart for it.
+func TestStepTwentyDoesNotRestartOnAClearedTransport_7072(t *testing.T) {
+	store := clusteredStore7066(t)
+	d := &Daemon{store: store, opts: Options{NoDataplane: true}}
+	d.daemonCtx = context.Background()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.startClusterComms(ctx)
+	d.stopClusterComms()
+
+	if got := d.activeTransport(); got != (clusterTransportKey{}) {
+		t.Fatalf("premise: the teardown must leave a ZERO transport, or this cell is "+
+			"about the stale-field path instead of the cleared one (got %+v)", got)
+	}
+
+	restarts := 0
+	d.startClusterCommsFn = func(context.Context) { restarts++ }
+
+	// A config whose transport DIFFERS from the (now zero) baseline. Under the
+	// stale-field behaviour this is the case that restarted.
+	moved := store.ActiveConfig()
+	moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
+
+	gen := func() uint64 {
+		d.clusterCommsMu.Lock()
+		defer d.clusterCommsMu.Unlock()
+		return d.clusterCommsGen
+	}
+	before := gen()
+	_ = d.applyTailReconciles(moved, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	if restarts != 0 || gen() != before {
+		t.Errorf("step 20 restarted comms off a CLEARED transport baseline "+
+			"(restarts=%d, gen %d -> %d). The `active != zero` conjunct exists to mean "+
+			"\"comms were previously started\"; firing on a zero baseline would restart "+
+			"comms that were never up, and would make the #7072 clear a behaviour change "+
+			"rather than a truthfulness fix", restarts, before, gen())
+	}
+}
+
+// #7071: startClusterComms must CONSUME the drop signal from
+// setActiveTransportIfCurrent, as both sibling publishers already do.
+//
+// A false return means this epoch was superseded between the epoch opening and
+// the publish, so everything below would wire a DEAD epoch. The wasted work is
+// the smaller half. The goroutines are the larger one: they capture `commsCtx`,
+// whose cancel the NEWER epoch has already overwritten in `clusterCommsCancel`,
+// so nothing can cancel them — stopClusterComms would call the newer epoch's
+// cancel — and they survive until the daemon context dies.
+//
+// Driving the race directly would be a timing test. This instead constructs the
+// superseded state deterministically: open an epoch, advance the generation
+// behind it, and assert the publish is refused. That is the exact condition the
+// call site now returns on, and it is the property that makes the early return
+// correct rather than arbitrary.
+func TestSupersededEpochPublishIsRefused_7071(t *testing.T) {
+	store := clusteredStore7066(t)
+	d := &Daemon{store: store, opts: Options{NoDataplane: true}}
+	want := clusterTransportFromConfig(store.ActiveConfig())
+	if want == (clusterTransportKey{}) {
+		t.Fatal("premise: a zero transport key cannot distinguish a refused publish " +
+			"from an accepted one — both leave the field zero")
+	}
+
+	_, staleGen, staleCancel := d.beginClusterCommsEpoch(context.Background())
+	defer staleCancel()
+
+	// A newer epoch opens behind the first one — exactly what a concurrent
+	// restart does between the two lines at the call site.
+	_, newGen, newCancel := d.beginClusterCommsEpoch(context.Background())
+	defer newCancel()
+	if newGen == staleGen {
+		t.Fatalf("premise: beginClusterCommsEpoch must advance the generation "+
+			"(stale=%d new=%d)", staleGen, newGen)
+	}
+
+	if d.setActiveTransportIfCurrent(staleGen, want) {
+		t.Error("the superseded epoch's publish was ACCEPTED. The call site returns " +
+			"early on false, so accepting here would let a dead epoch wire the VRF " +
+			"resolve, the HA watchdog, the heartbeat goroutine and the session-sync " +
+			"constructor onto a context nothing can cancel")
+	}
+	if got := d.activeTransport(); got != (clusterTransportKey{}) {
+		t.Errorf("a refused publish still wrote the field: %+v", got)
+	}
+
+	// And the live epoch's publish is still accepted — without this the test
+	// passes against a setActiveTransportIfCurrent that refuses everything.
+	if !d.setActiveTransportIfCurrent(newGen, want) {
+		t.Error("the CURRENT epoch's publish was refused; the gate must drop only " +
+			"superseded epochs")
+	}
+}

--- a/pkg/daemon/daemon_ha_comms_race_test.go
+++ b/pkg/daemon/daemon_ha_comms_race_test.go
@@ -26,12 +26,12 @@ func TestStartClusterCommsPublishDropsStaleEpoch(t *testing.T) {
 	d := &Daemon{}
 
 	// Epoch 1: a constructor goroutine starts resolving its sync address.
-	_, gen1 := d.beginClusterCommsEpoch(context.Background())
+	_, gen1, _ := d.beginClusterCommsEpoch(context.Background())
 	ss1 := &cluster.SessionSync{} // what the slow epoch-1 constructor would publish
 
 	// A transport-change commit restarts comms: a new epoch supersedes epoch 1
 	// while its constructor is still resolving.
-	_, gen2 := d.beginClusterCommsEpoch(context.Background())
+	_, gen2, _ := d.beginClusterCommsEpoch(context.Background())
 	if gen2 == gen1 {
 		t.Fatalf("beginClusterCommsEpoch did not advance the generation: gen1=%d gen2=%d", gen1, gen2)
 	}
@@ -64,7 +64,7 @@ func TestStartClusterCommsPublishDropsStaleEpoch(t *testing.T) {
 func TestStopClusterCommsSupersedesInflightConstructor(t *testing.T) {
 	d := &Daemon{}
 
-	_, gen1 := d.beginClusterCommsEpoch(context.Background())
+	_, gen1, _ := d.beginClusterCommsEpoch(context.Background())
 	ss1 := &cluster.SessionSync{}
 
 	// Tear comms down (no cluster/sessionSync wired yet — the constructor is
@@ -85,11 +85,11 @@ func TestStopClusterCommsSupersedesInflightConstructor(t *testing.T) {
 func TestPublishFabricRefreshChansDropsStaleEpoch(t *testing.T) {
 	d := &Daemon{}
 
-	_, gen1 := d.beginClusterCommsEpoch(context.Background())
+	_, gen1, _ := d.beginClusterCommsEpoch(context.Background())
 	stale0 := make(chan struct{}, 1)
 	stale1 := make(chan struct{}, 1)
 
-	_, gen2 := d.beginClusterCommsEpoch(context.Background())
+	_, gen2, _ := d.beginClusterCommsEpoch(context.Background())
 	live0 := make(chan struct{}, 1)
 	live1 := make(chan struct{}, 1)
 
@@ -113,7 +113,7 @@ func TestPublishFabricRefreshChansDropsStaleEpoch(t *testing.T) {
 func TestClusterCommsPublishConcurrentIsRaceFree(t *testing.T) {
 	d := &Daemon{}
 
-	_, liveGen := d.beginClusterCommsEpoch(context.Background())
+	_, liveGen, _ := d.beginClusterCommsEpoch(context.Background())
 	live := &cluster.SessionSync{}
 	if !d.publishSessionSyncIfCurrent(liveGen, live) {
 		t.Fatal("failed to publish the live epoch")

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -721,7 +721,15 @@ func (d *Daemon) snapshotFabricRefreshChans() (chan struct{}, chan struct{}) {
 // present at publish time. Bumping the counter here means a constructor from a
 // prior epoch (still resolving addresses) is already superseded before this
 // call returns, so its later publish is dropped.
-func (d *Daemon) beginClusterCommsEpoch(parent context.Context) (context.Context, uint64) {
+//
+// #7071: the cancel func is returned as well, so a caller that discovers its
+// epoch was superseded before it wired anything can release the sub-context it
+// just created. It cannot reach that cancel through the field: a newer epoch has
+// by then overwritten `clusterCommsCancel` with its OWN, and calling that would
+// tear down the live epoch instead.
+func (d *Daemon) beginClusterCommsEpoch(
+	parent context.Context,
+) (context.Context, uint64, context.CancelFunc) {
 	commsCtx, commsCancel := context.WithCancel(parent)
 	d.clusterCommsMu.Lock()
 	d.clusterCommsGen++
@@ -729,7 +737,7 @@ func (d *Daemon) beginClusterCommsEpoch(parent context.Context) (context.Context
 	d.clusterCommsCancel = commsCancel
 	d.clusterCommsCtx = commsCtx
 	d.clusterCommsMu.Unlock()
-	return commsCtx, gen
+	return commsCtx, gen, commsCancel
 }
 
 // publishSessionSyncIfCurrent installs ss as the live session-sync object iff
@@ -816,8 +824,28 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	// a constructor goroutine from a superseded epoch (still resolving its sync
 	// address) drops its publish instead of clobbering this epoch's state
 	// (#4958).
-	commsCtx, commsGen := d.beginClusterCommsEpoch(ctx)
-	d.setActiveTransportIfCurrent(commsGen, clusterTransportFromConfig(cfg))
+	commsCtx, commsGen, commsCancel := d.beginClusterCommsEpoch(ctx)
+	// #7071: consume the drop signal, as both sibling publishers already do
+	// (`publishSessionSyncIfCurrent`, `publishFabricRefreshChansIfCurrent`).
+	//
+	// A false return means this epoch was superseded between the line above and
+	// this one, so everything below would wire a DEAD epoch: the VRF resolve,
+	// the HA watchdog heartbeat, the control heartbeat goroutine and the
+	// session-sync constructor. Their own publishes are epoch-gated and would
+	// drop, so nothing incorrect is installed — but the goroutines are not
+	// merely wasted work. They run on `commsCtx`, whose cancel the newer epoch
+	// has already overwritten in `clusterCommsCancel`, so nothing can cancel
+	// them: `stopClusterComms` would call the NEWER epoch's cancel. They would
+	// live until the daemon context dies, i.e. for the life of the process.
+	//
+	// Cancelling our own sub-context on the way out is the other half. Returning
+	// without it leaks the context itself (nothing else holds that cancel), and
+	// cancelling here is safe precisely because we have launched nothing on it
+	// yet — this is the first statement after the epoch opens.
+	if !d.setActiveTransportIfCurrent(commsGen, clusterTransportFromConfig(cfg)) {
+		commsCancel()
+		return
+	}
 
 	vrfDevice := d.resolveClusterVRFDevice(cc)
 
@@ -1219,6 +1247,28 @@ func (d *Daemon) stopClusterComms() {
 	d.sessionSync = nil
 	d.fabricRefreshCh = nil
 	d.fabricRefreshCh1 = nil
+	// #7072: the transport key is part of the epoch tuple and must be torn down
+	// with the rest of it. #6290 joined it to the epoch on the PUBLISH side and
+	// left the teardown side alone, so after a stop the field kept naming the
+	// transport of the epoch that was just destroyed, and `activeTransport()`
+	// reported a live-looking key for comms that are stopped.
+	//
+	// WHAT THIS DOES AND DOES NOT FIX, because the issue's rationale needs one
+	// correction. Step 20's guard is
+	// `active != zero && newTransport != active` — that is RESTART-ON-CHANGE,
+	// not START-IF-STOPPED. So on a hypothetical stop-without-start path:
+	//
+	//   stale field: config unchanged -> no restart (comms stay down);
+	//                config changed   -> restart (comms come back).
+	//   cleared:     either way       -> no restart, because the first
+	//                                    conjunct is now false.
+	//
+	// Clearing therefore does not rescue a stop-only path; it changes WHICH
+	// restart is skipped. What it does is stop the field from LYING, which is
+	// the precondition for reasoning about such a path at all — anyone adding
+	// one owes it an explicit start, and must not read `activeTransport()`
+	// being non-zero as "comms are up".
+	d.activeClusterTransport = clusterTransportKey{}
 	d.clusterCommsMu.Unlock()
 
 	if ss != nil {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1247,28 +1247,38 @@ func (d *Daemon) stopClusterComms() {
 	d.sessionSync = nil
 	d.fabricRefreshCh = nil
 	d.fabricRefreshCh1 = nil
-	// #7072: the transport key is part of the epoch tuple and must be torn down
-	// with the rest of it. #6290 joined it to the epoch on the PUBLISH side and
-	// left the teardown side alone, so after a stop the field kept naming the
-	// transport of the epoch that was just destroyed, and `activeTransport()`
-	// reported a live-looking key for comms that are stopped.
+	// #7072: activeClusterTransport is DELIBERATELY NOT cleared here, and the
+	// issue that asked for it is refuted by measurement rather than argument.
 	//
-	// WHAT THIS DOES AND DOES NOT FIX, because the issue's rationale needs one
-	// correction. Step 20's guard is
-	// `active != zero && newTransport != active` — that is RESTART-ON-CHANGE,
-	// not START-IF-STOPPED. So on a hypothetical stop-without-start path:
+	// Its premise was that the stale value is unreachable because the only
+	// stopClusterComms call site is step 20's, which starts comms again on the
+	// next line. There is a SECOND site: bootstrap.go's rollback teardown stops
+	// comms and RETURNS. That path is real, and on it this field is the only
+	// memory of which transport comms were using.
 	//
-	//   stale field: config unchanged -> no restart (comms stay down);
-	//                config changed   -> restart (comms come back).
-	//   cleared:     either way       -> no restart, because the first
-	//                                    conjunct is now false.
+	// Measured on the bootstrap-rollback shape — stop, then a corrected commit
+	// carrying a DIFFERENT transport key — by driving the real applyTailReconciles
+	// with a counting startClusterCommsFn:
 	//
-	// Clearing therefore does not rescue a stop-only path; it changes WHICH
-	// restart is skipped. What it does is stop the field from LYING, which is
-	// the precondition for reasoning about such a path at all — anyone adding
-	// one owes it an explicit start, and must not read `activeTransport()`
-	// being non-zero as "comms are up".
-	d.activeClusterTransport = clusterTransportKey{}
+	//     field retained (today):  restarts=1  -> comms recover
+	//     field cleared:           restarts=0  -> comms stay down
+	//
+	// Step 20's guard is `active != zero && newTransport != active`. Clearing
+	// makes the FIRST conjunct false, so it fails in both directions, and the only
+	// other production startClusterComms call site is daemon_run.go's boot path —
+	// so the node would hold a valid cluster config with no heartbeat, no session
+	// sync and no fabric refresh until the process restarts.
+	//
+	// The field therefore carries TWO meanings, and the name only says one:
+	// "which transport the running comms use", and "comms have run at least once,
+	// so step 20 may act". The second is load-bearing in the other direction too —
+	// the boot applyConfig runs BEFORE daemon_run.go:405's startClusterComms, so
+	// `active != zero` is what keeps step 20 out of the boot window that line is
+	// deliberately positioned after. Read it as LAST PUBLISHED transport, not as
+	// "comms are up"; `sessionSync == nil` is what says comms are down.
+	//
+	// Bound by TestBootstrapRollbackThenCorrectedCommitRecovers_7072 (this is the
+	// cell a clear fails) and TestStepTwentyIgnoresANeverStartedNode_7072.
 	d.clusterCommsMu.Unlock()
 
 	if ss != nil {


### PR DESCRIPTION
Closes #7071

**#7072 is NOT closed by this PR — it is refuted.** Disposition and evidence
below; the residual it leaves is filed as **#7901**.

## I implemented #7072 first, and it was a regression

My earlier revision of this branch cleared `activeClusterTransport` in
`stopClusterComms`, exactly as the issue asked, and my own test asserted that
behaviour as correct. Both are reverted.

### The premise is false

The issue says the stale value is unreachable because "the only
`stopClusterComms` call site is `daemon_apply_tail.go:258`, immediately followed
by `startClusterComms`". There is a **second** — `bootstrap.go`'s rollback
teardown stops comms and RETURNS. I repeated that claim in my own PR body before
checking it.

### Measured, both arms

Real `applyTailReconciles`, counting `startClusterCommsFn`, on the
bootstrap-rollback shape (stop, then a corrected commit with a DIFFERENT key):

| | restarts | outcome |
|---|---|---|
| field retained (today) | **1** | comms recover |
| field cleared | **0** | comms stay down |

`active != zero && newTransport != active` — clearing makes the first conjunct
false, so it fails both ways, and the only other production `startClusterComms`
is the boot path. The node would hold a valid cluster config with **no
heartbeat, no session sync, no fabric refresh** until the process restarted.

### My first measurement was wrong in a way that looked right

Its daemon had no `cluster` manager, and step 20 is gated on `d.cluster != nil` —
so **both arms** reported `restarts=0`, which reads exactly like a confirmed
regression. The control caught it. Two arms agreeing is a fixture result, not a
finding.

### The obvious repair is also wrong

Clearing plus relaxing the guard to `newTransport != active` has a
perfect-looking truth table and reintroduces a documented boot race: the boot
`applyConfig` runs BEFORE `daemon_run.go:405`'s `startClusterComms`, which is
positioned after the event fanout precisely to avoid an HA startup race. So step
20 runs during boot with the field still zero, and `active != zero` is what keeps
it out of that window.

### So the field carries two meanings

*"which transport the running comms use"* and *"comms have run at least once, so
step 20 may act"*. Splitting them needs new state and a step 20 that can START
comms rather than only restart them — a behaviour change with a
failover-adjacent blast radius, which gets **#7901** and its own smoke rather
than riding a truthfulness fix.

What lands here is the rationale at the site plus two cells that **bracket** the
guard:

| cell | pins |
|---|---|
| `TestBootstrapRollbackThenCorrectedCommitRecovers_7072` | a post-rollback commit MUST recover — the cell the naive fix fails |
| `TestStepTwentyIgnoresANeverStartedNode_7072` | a never-started node must NOT be acted on |

## #7071 — the half that does land

`startClusterComms` ignored `setActiveTransportIfCurrent`'s bool while both
siblings gate on theirs. It now returns early, and the reason is stronger than
the issue's "wasted work": the goroutines below capture `commsCtx`, whose cancel
the **newer** epoch has already overwritten in `clusterCommsCancel`, so nothing
can cancel them — `stopClusterComms` would call the newer epoch's — and they
outlive their epoch for the life of the process.

The early return also cancels its own sub-context, which needs
`beginClusterCommsEpoch` to return the `CancelFunc`; reaching it through the
field would tear down the LIVE epoch.

**My first #7071 test was adjacent to the property too.** Cell m7071 came back
GREEN against it: `TestSupersededEpochPublishIsRefused_7071` asserts the *gate*
refuses a superseded epoch, which is true with the fix and without it. The
replacement asserts the call site's SHAPE, the instrument
`TestDaemonPassesRethBeforeCycleHook_5103` already uses here, since the drop
needs the epoch to advance between two adjacent lines and cannot be scheduled
without a production seam.

## Mutation matrix

`go test ./pkg/daemon/ -count=1 -v`, **2195 collected** per cell, `enospc=0`,
`git diff --stat` non-empty between edit and run.

| cell | mutation | rc | named |
|---|---|---|---|
| **m7071** | call site discards the bool again | 1 | `TestStartClusterCommsConsumesTheDropSignal_7071` — only |
| **m7072clear** | apply the **rejected** design | 1 | `TestBootstrapRollbackThenCorrectedCommitRecovers_7072`, `TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078` |

The second cell mutates the tree *towards* what the issue asked for, and the
suite refuses it from two directions. That is the useful shape when an issue's
requested change is itself the defect.

## Validation

`go build`/`go vet` clean; `go test ./... -count=1` **rc=0**, `enospc=0`, FAIL
count from the whole log. Full record in `docs/log/7071-7072.md`.