### PR TITLE
dataplane: replicate the helper's NPTv6 overlap rejection in the pre-pass

### DIFF
--- a/docs/log/7078.md
+++ b/docs/log/7078.md
@@ -1,0 +1,55 @@
+# #7078 — the #4960 pre-pass now replicates the helper's NPTv6 overlap rejection
+
+- **Timestamp**: 2026-08-28
+- **File(s)**: `pkg/config/nptv6_overlap.go` (new),
+  `pkg/dataplane/compiler_nat.go`,
+  `pkg/dataplane/compiler_nptv6_overlap_7078_test.go` (new)
+
+## Built on #7077's seam, not around it
+
+#7077 (#7895) landed first and states the boundary explicitly in
+`compiler_nptv6_helper_grammar.go`:
+
+> It deliberately does NOT replicate the helper's CROSS-rule overlap rejection
+> (#2241, zone-partitioned per #5176). That is a property of the whole rule set,
+> not of one rule ... It is tracked as the named residual in #7078.
+
+So the per-rule seam is the wrong home by construction, and the check goes after
+`compileNPTv6`'s per-rule loop.
+
+## The trap the issue names, confirmed by measurement
+
+`validateNPTv6Strict` already has an overlap check with `internalSeen` /
+`externalSeen`. Its `seenPrefix` is `{net, ones, ruleSetName, ruleName}` — **no
+zone**. Reusing it would reject the #5176 split-horizon configs the helper
+installs, turning a working apply into a failed one.
+
+`find_overlap` gates every candidate on `zones_conflict(a, b) = a.is_empty() ||
+b.is_empty() || a == b`, so two DISTINCT non-empty `from zone` scopes are
+disjoint.
+
+## What the shared predicate mirrors
+
+`config.NPTv6OverlapConflict`, in the role `NPTv6ScopeUnsupported` plays for
+"does this rule reach the helper":
+
+- TWO independent seen-sets. An internal/external collision is NOT an overlap.
+- Common-prefix match at the SHORTER length, not equality — a /64 beneath a /48
+  collides.
+- Zone-partitioned via `zonesConflictNPTv6`.
+- Skips rules the snapshot builder drops (`NPTv6ScopeUnsupported`) and rules the
+  helper refuses on an earlier parse/length arm — reporting those as overlaps
+  would name the wrong reason for a correct rejection.
+
+## Red-on-revert
+
+Removing the check reds `TestNPTv6OverlapRejectedBeforeHostMutation_7078` with
+
+```
+compileZones RAN before the failing phase was caught (1 SetZoneConfig calls)
+```
+
+— the issue's own `zoneConfigCalls == 1` measurement, reproduced as an assertion.
+
+`TestNPTv6SplitHorizonStillCompiles_7078` passes on BOTH sides: it is an
+over-rejection guard, which has to hold before and after.

--- a/pkg/config/nptv6_overlap.go
+++ b/pkg/config/nptv6_overlap.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"fmt"
+	"net"
+)
+
+// NPTv6OverlapConflict reports the first cross-rule NPTv6 prefix overlap that
+// `Nptv6State::try_from_snapshots` would REJECT, or "" when the helper would
+// accept the whole set (#7078, closing the residual named in
+// pkg/dataplane/compiler_validate_4960.go).
+//
+// It is the single source of truth for "would the helper refuse this rule set
+// for overlap", in the same role NPTv6ScopeUnsupported plays for "does this rule
+// reach the helper at all". Both the #4960 pre-pass and any future caller read
+// one answer, so Go and Rust cannot drift on a rejection whose whole purpose is
+// to predict the other side's verdict.
+//
+// # Why validateNPTv6Strict's overlap check could not be reused
+//
+// That one exists and is older, but its `seenPrefix` carries only
+// `{net, ones, ruleSetName, ruleName}` — NO zone. The helper partitions by zone
+// scope (#5176): `find_overlap` gates every candidate on `zones_conflict`, and
+// two DISTINCT non-empty `from zone` scopes are disjoint, because a packet
+// carries exactly one relevant zone. Reusing the unpartitioned check as the
+// pre-pass would hard-fail split-horizon configurations the helper installs
+// happily — converting a working apply into a failed one, which is the exact
+// over-rejection the #4960 guard's three properties exist to prevent.
+//
+// # Mirroring the helper
+//
+//   - Two INDEPENDENT seen-sets, internal and external, because outbound matches
+//     on the internal prefix and inbound on the external one. A collision
+//     between an internal and an external prefix is not an overlap.
+//   - Overlap is a common-prefix match at the SHORTER length
+//     (`candidate[..common] == prefix[..common]` over `min(candidate_words,
+//     words)`), not equality — a /48 and a /64 beneath it DO collide.
+//   - Gated on zonesConflictNPTv6, mirroring `zones_conflict`.
+//   - Rules the snapshot builder DROPS are skipped: an excluded rule never
+//     reaches try_from_snapshots, so it cannot participate in a rejection the
+//     helper makes. This is the same property-1 gate the parse class uses.
+//   - Rules whose prefixes do not parse are skipped, because the helper rejects
+//     those on the parse arm BEFORE it ever calls find_overlap. Reporting them
+//     as overlaps would name the wrong reason for a correct rejection.
+func NPTv6OverlapConflict(cfg *Config) string {
+	if cfg == nil {
+		return ""
+	}
+	var internalSeen, externalSeen []nptv6Seen
+
+	// Config order, deliberately: Security.NAT.Static is a SLICE, and the helper
+	// walks the snapshot in the order the builder emitted it. Which of an
+	// overlapping PAIR is named as "already seen" depends on that order, so
+	// walking the slice as-is reproduces the helper's choice rather than
+	// inventing a different one.
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			if rule.Then == "" || rule.Match == "" {
+				continue // not an NPTv6 rule
+			}
+			if NPTv6ScopeUnsupported(rs, rule) {
+				continue // dropped by the snapshot builder; never reaches the helper
+			}
+			extWords, extN, extOK := nptv6PrefixWords(rule.Match)
+			intWords, intN, intOK := nptv6PrefixWords(rule.Then)
+			if !extOK || !intOK || extN != intN {
+				// The helper refuses these on its parse / length arm first.
+				continue
+			}
+			if prev := nptv6FindOverlap(externalSeen, extWords, extN, rs.FromZone); prev != "" {
+				return fmt.Sprintf("rule-set %q rule %q external prefix %q overlaps %s",
+					rs.Name, rule.Name, rule.Match, prev)
+			}
+			if prev := nptv6FindOverlap(internalSeen, intWords, intN, rs.FromZone); prev != "" {
+				return fmt.Sprintf("rule-set %q rule %q nptv6-prefix %q overlaps %s",
+					rs.Name, rule.Name, rule.Then, prev)
+			}
+			externalSeen = append(externalSeen, nptv6Seen{extWords, extN, rs.Name, rule.Name, rs.FromZone})
+			internalSeen = append(internalSeen, nptv6Seen{intWords, intN, rs.Name, rule.Name, rs.FromZone})
+		}
+	}
+	return ""
+}
+
+// nptv6Seen is one already-admitted prefix, carrying the zone the helper's
+// `find_overlap` gates on. The zone is the field validateNPTv6Strict's
+// equivalent lacks, and its absence there is why that check could not be reused.
+type nptv6Seen struct {
+	words    [4]uint16
+	n        int
+	ruleSet  string
+	rule     string
+	fromZone string
+}
+
+// nptv6FindOverlap mirrors userspace-dp/src/nptv6.rs `find_overlap`.
+func nptv6FindOverlap(seenList []nptv6Seen, candidate [4]uint16, candidateWords int, candidateZone string) string {
+	for _, s := range seenList {
+		common := candidateWords
+		if s.n < common {
+			common = s.n
+		}
+		match := true
+		for i := 0; i < common; i++ {
+			if candidate[i] != s.words[i] {
+				match = false
+				break
+			}
+		}
+		if match && zonesConflictNPTv6(candidateZone, s.fromZone) {
+			return fmt.Sprintf("rule-set %q rule %q", s.ruleSet, s.rule)
+		}
+	}
+	return ""
+}
+
+// zonesConflictNPTv6 mirrors `zones_conflict`: a packet carries exactly one
+// relevant zone, so two scopes conflict only when either is a wildcard (empty)
+// or both name the same zone. Two distinct non-empty zones are disjoint —
+// legitimate split-horizon (#5176).
+func zonesConflictNPTv6(a, b string) bool {
+	return a == "" || b == "" || a == b
+}
+
+// nptv6PrefixWords parses an NPTv6 prefix into the helper's [u16; 4] + word
+// count. NPTv6 supports /48 and /64 only, both multiples of 16, so a word
+// comparison is exactly a bit comparison.
+func nptv6PrefixWords(s string) ([4]uint16, int, bool) {
+	var out [4]uint16
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		return out, 0, false
+	}
+	ip := n.IP.To16()
+	if ip == nil {
+		return out, 0, false
+	}
+	ones, _ := n.Mask.Size()
+	if ones != 48 && ones != 64 {
+		return out, 0, false
+	}
+	for i := 0; i < 4; i++ {
+		out[i] = uint16(ip[i*2])<<8 | uint16(ip[i*2+1])
+	}
+	return out, ones / 16, true
+}

--- a/pkg/dataplane/compiler_nat.go
+++ b/pkg/dataplane/compiler_nat.go
@@ -908,6 +908,38 @@ func compileNPTv6(dp DataPlane, cfg *config.Config) error {
 		}
 	}
 
+	// #7078: the CROSS-RULE overlap class, the residual named in
+	// compiler_validate_4960.go's header. Everything above is per-rule; the
+	// helper additionally refuses the WHOLE snapshot when two rules' prefixes
+	// overlap within a conflicting zone scope (#2241, zone-partitioned per
+	// #5176). Without this the #4960 pre-pass ACCEPTS such a config, compileZones
+	// mutates the host, and the helper then rejects at
+	// publishSnapshotFailClosedLocked with no rollback — the exact shape the
+	// pre-pass exists to prevent, still live for this input.
+	//
+	// This is checked AFTER the per-rule loop because it is a property of the
+	// SET, not of a rule, which is also why it could not live in
+	// nptv6HelperWouldInstall (#7077's per-rule seam says so explicitly).
+	//
+	// The three #4960 over-rejection properties are preserved, and the predicate
+	// carries them rather than this call site:
+	//
+	//   - config.NPTv6OverlapConflict skips rules the snapshot builder DROPS
+	//     (NPTv6ScopeUnsupported), so a dropped rule cannot trigger a hard error
+	//     for a rejection the helper never makes.
+	//   - It skips rules whose prefixes do not parse or whose lengths disagree,
+	//     because the helper refuses those on an earlier arm — reporting them as
+	//     overlaps would name the wrong reason for a correct rejection.
+	//   - It partitions by zone exactly as `zones_conflict` does, so the #5176
+	//     split-horizon configurations the helper installs are NOT rejected.
+	//     Reusing validateNPTv6Strict's older overlap check would have failed
+	//     precisely those working configs: its `seenPrefix` carries no zone.
+	if conflict := config.NPTv6OverlapConflict(cfg); conflict != "" {
+		return fmt.Errorf("%s; the userspace helper rejects the whole NPTv6 snapshot "+
+			"on an overlapping prefix pair (#2241), so the apply cannot succeed -- "+
+			"correct or remove one of the rules", conflict)
+	}
+
 	if count > 0 {
 		compileInfo(dp, "nptv6 compilation complete", "rules", count)
 	}

--- a/pkg/dataplane/compiler_nptv6_overlap_7078_test.go
+++ b/pkg/dataplane/compiler_nptv6_overlap_7078_test.go
@@ -1,0 +1,163 @@
+package dataplane
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// nptv6OverlapConfig builds a config with TWO NPTv6 rules, so the cross-rule
+// class is reachable at all — nptv6ProbeConfig carries only one and cannot
+// express an overlap.
+func nptv6OverlapConfig(zoneA, matchA, thenA, zoneB, matchB, thenB string) *config.Config {
+	cfg := failLaterPhaseConfig()
+	cfg.Security.Policies[0].Policies[0].Match.Applications = []string{"any"}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{
+			Name: "rs-npt-4960", FromZone: zoneA,
+			Rules: []*config.StaticNATRule{
+				{Name: "r-npt-4960", IsNPTv6: true, Match: matchA, Then: thenA},
+			},
+		},
+		{
+			Name: "rs-npt-7078b", FromZone: zoneB,
+			Rules: []*config.StaticNATRule{
+				{Name: "r-npt-7078b", IsNPTv6: true, Match: matchB, Then: thenB},
+			},
+		},
+	}
+	return cfg
+}
+
+// TestNPTv6OverlapRejectedBeforeHostMutation_7078 is the residual named in
+// compiler_validate_4960.go's header: the pre-pass replicated the helper's
+// per-rule PARSE rejections but not its cross-rule OVERLAP rejection, so an
+// overlapping pair was accepted, the host was mutated, and the helper then
+// rejected the whole snapshot at publish with no rollback.
+//
+// The measurement in #7078 was `zoneConfigCalls == 1` — compileZones entered.
+// assertRejectedByTheNPTv6Row asserts no mutation happened at all, and asserts
+// it BEFORE the error-text check for the reason that helper documents: on a
+// revert the compile still errors (the tripwire), so a text assertion placed
+// first would fire and bury the finding that compileZones ran.
+func TestNPTv6OverlapRejectedBeforeHostMutation_7078(t *testing.T) {
+	dp := &recordingDP{}
+	// The issue's exact repro: same external prefix, one zone.
+	cfg := nptv6OverlapConfig(
+		"untrust", "2001:db8:9::/48", "fd00:9::/48",
+		"untrust", "2001:db8:9::/48", "fd00:aa::/48",
+	)
+
+	_, err := CompileConfig(dp, cfg, false)
+	assertRejectedByTheNPTv6Row(t, dp, err, "overlaps")
+}
+
+// TestNPTv6SplitHorizonStillCompiles_7078 is THE PAIRED CELL, and the one that
+// separates this fix from the naive one.
+//
+// #5176 partitions overlap by zone scope: a packet carries exactly one relevant
+// zone, so two DISTINCT non-empty `from zone` scopes are disjoint and the helper
+// installs both rules happily. Reusing validateNPTv6Strict's older overlap check
+// — whose `seenPrefix` carries no zone — would reject this config, converting a
+// working apply into a failed one. That is the over-rejection the #4960 guard's
+// three properties exist to prevent, so a fix that closes the residual by
+// breaking this is worse than the residual.
+//
+// The prefixes here are IDENTICAL to the rejected case above. Only the zone
+// differs, which is what makes this a discriminating cell rather than a
+// restatement.
+func TestNPTv6SplitHorizonStillCompiles_7078(t *testing.T) {
+	dp := &recordingDP{}
+	cfg := nptv6OverlapConfig(
+		"untrust", "2001:db8:9::/48", "fd00:9::/48",
+		"dmz", "2001:db8:9::/48", "fd00:9::/48",
+	)
+
+	_, err := CompileConfig(dp, cfg, false)
+	// It must NOT be rejected by the pre-pass. It still stops at the tripwire,
+	// which is how this fixture proves the compile got PAST validation.
+	if err == nil {
+		t.Fatal("precondition: this fixture stops at the recordingDP tripwire, so " +
+			"a nil error means the fixture stopped exercising the compile")
+	}
+	if strings.Contains(err.Error(), "overlaps") {
+		t.Fatalf("OVER-REJECTED: two NPTv6 rules with identical prefixes in DISTINCT "+
+			"zones are legitimate split-horizon (#5176) and the helper installs both. "+
+			"Rejecting them turns a working apply into a failed one — the exact "+
+			"over-rejection the #4960 pre-pass must not commit, and what reusing "+
+			"validateNPTv6Strict's zone-blind overlap check would have done: %v", err)
+	}
+	if strings.HasPrefix(err.Error(), "validate nptv6: ") {
+		t.Fatalf("the pre-pass's nptv6 row rejected a config the helper accepts: %v", err)
+	}
+}
+
+// TestNPTv6OverlapPredicateMirrorsTheHelper_7078 pins the shared predicate
+// directly, at the shapes where a coarser implementation would diverge from
+// `find_overlap`.
+func TestNPTv6OverlapPredicateMirrorsTheHelper_7078(t *testing.T) {
+	set := func(name, zone, match, then string) *config.StaticNATRuleSet {
+		return &config.StaticNATRuleSet{
+			Name: name, FromZone: zone,
+			Rules: []*config.StaticNATRule{{Name: name + "-r", IsNPTv6: true, Match: match, Then: then}},
+		}
+	}
+	for _, tc := range []struct {
+		name     string
+		sets     []*config.StaticNATRuleSet
+		conflict bool
+		why      string
+	}{
+		{
+			"same zone, same external prefix", []*config.StaticNATRuleSet{
+				set("a", "untrust", "2001:db8:9::/48", "fd00:9::/48"),
+				set("b", "untrust", "2001:db8:9::/48", "fd00:aa::/48"),
+			}, true, "the issue's repro",
+		},
+		{
+			"distinct zones, identical prefixes", []*config.StaticNATRuleSet{
+				set("a", "untrust", "2001:db8:9::/48", "fd00:9::/48"),
+				set("b", "dmz", "2001:db8:9::/48", "fd00:9::/48"),
+			}, false, "#5176 split-horizon: a packet carries one zone, so these are disjoint",
+		},
+		{
+			"wildcard zone against a named zone", []*config.StaticNATRuleSet{
+				set("a", "", "2001:db8:9::/48", "fd00:9::/48"),
+				set("b", "dmz", "2001:db8:9::/48", "fd00:aa::/48"),
+			}, true, "an empty scope matches every zone, so zones_conflict is true",
+		},
+		{
+			"/64 beneath a /48", []*config.StaticNATRuleSet{
+				set("a", "untrust", "2001:db8:9::/48", "fd00:9::/48"),
+				set("b", "untrust", "2001:db8:9:0::/64", "fd00:bb::/64"),
+			}, true, "overlap is a COMMON-PREFIX match at the shorter length, not equality",
+		},
+		{
+			"disjoint prefixes, same zone", []*config.StaticNATRuleSet{
+				set("a", "untrust", "2001:db8:9::/48", "fd00:9::/48"),
+				set("b", "untrust", "2001:db8:aa::/48", "fd00:aa::/48"),
+			}, false, "the control: nothing overlaps",
+		},
+		{
+			"internal of one vs external of another", []*config.StaticNATRuleSet{
+				set("a", "untrust", "2001:db8:9::/48", "fd00:9::/48"),
+				set("b", "untrust", "fd00:9::/48", "2001:db8:cc::/48"),
+			}, false, "the seen-sets are INDEPENDENT: outbound matches on the internal " +
+				"prefix and inbound on the external, so an internal/external collision " +
+				"is not an overlap. A single merged set would wrongly reject this",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Security.NAT.Static = tc.sets
+			got := config.NPTv6OverlapConflict(cfg)
+			if tc.conflict && got == "" {
+				t.Fatalf("want a conflict (%s), got none", tc.why)
+			}
+			if !tc.conflict && got != "" {
+				t.Fatalf("want NO conflict (%s), got %q", tc.why, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #7078

Built **on** #7077's seam rather than around it: `compiler_nptv6_helper_grammar.go`
states the boundary explicitly —

> It deliberately does NOT replicate the helper's CROSS-rule overlap rejection
> (#2241, zone-partitioned per #5176). That is a property of the whole rule set,
> not of one rule … It is tracked as the named residual in #7078.

So the per-rule seam is the wrong home by construction. The check runs after
`compileNPTv6`'s per-rule loop.

## The defect

The pre-pass replicated the helper's per-rule PARSE rejections but not its
cross-rule OVERLAP rejection. For an overlapping pair the pre-pass **accepted**,
`compileZones` mutated the host, and the helper then rejected the whole snapshot
at `publishSnapshotFailClosedLocked` with no rollback — the exact #4960 shape,
still live.

## The trap, confirmed by reading rather than assuming

`validateNPTv6Strict` already has an overlap check. Its `seenPrefix` is
`{net, ones, ruleSetName, ruleName}` — **no zone**. The helper gates every
candidate on `zones_conflict(a, b) = a.is_empty() || b.is_empty() || a == b`,
under which two distinct non-empty `from zone` scopes are **disjoint**, because a
packet carries exactly one relevant zone.

Reusing the zone-blind check would hard-fail the #5176 split-horizon
configurations the helper installs happily — converting a working apply into a
failed one. **That over-rejection is worse than the residual**, which is why the
fix is a new zone-partitioned predicate rather than a reuse.

## The shared predicate

`config.NPTv6OverlapConflict`, in the role `NPTv6ScopeUnsupported` plays for
"does this rule reach the helper at all", so the two sides cannot drift on a
rejection whose whole purpose is to predict the other's verdict. It mirrors
`find_overlap`:

- **Two independent seen-sets.** Outbound matches on the internal prefix, inbound
  on the external, so an internal/external collision is **not** an overlap — a
  single merged set would wrongly reject it. Bound by its own table row.
- **Common-prefix match at the shorter length**, not equality, so a `/64` beneath
  a `/48` collides.
- **Zone-partitioned**, mirroring `zones_conflict`.
- **Skips rules the snapshot builder drops** (`NPTv6ScopeUnsupported`) and rules
  the helper refuses on its earlier parse/length arm — reporting those as
  overlaps would name the wrong reason for a correct rejection.

All three of the #4960 over-rejection properties are preserved, and the predicate
carries them rather than the call site.

## Red-on-revert reproduces the issue's own measurement

Removing the check fails with:

```
compileZones RAN before the failing phase was caught (1 SetZoneConfig calls)
```

which is exactly the `zoneConfigCalls == 1` #7078 reports — the issue's
measurement turned into an assertion.

`TestNPTv6SplitHorizonStillCompiles_7078` passes on **both** sides. It is an
over-rejection guard, so it has to hold before and after — the same pairing shape
as the must-still-warn cells on #7039 and #7041. Its prefixes are **identical**
to the rejected case; only the zone differs, which is what makes it
discriminating rather than a restatement.

`TestNPTv6OverlapPredicateMirrorsTheHelper_7078` is a six-row table over the
shapes where a coarser implementation diverges from `find_overlap`, including the
internal-vs-external row and the `/64`-beneath-`/48` row.

## Validation

- `gofmt` clean; `go build ./...` ok
- `go test -count=1 ./pkg/dataplane/... ./pkg/config/` — **ok on all five packages**