### PR TITLE
daemon: consume the comms-epoch drop signal and clear the transport on teardown (#7071, #7072)

### DIFF
--- a/docs/log/7071-7072.md
+++ b/docs/log/7071-7072.md
@@ -1,0 +1,89 @@
+# #7071 + #7072 — the two halves of the comms-epoch asymmetry
+
+## Timestamp
+2026-08-28
+
+## Action
+#6290 folded `activeClusterTransport` into the cluster-comms epoch on the
+PUBLISH side. Two things were left, and they are one change:
+
+- **#7071** — `startClusterComms` discarded `setActiveTransportIfCurrent`'s
+  return value while both sibling publishers gate on theirs.
+- **#7072** — `stopClusterComms` tore down the rest of the epoch tuple but left
+  the transport key naming the transport it had just stopped.
+
+## Files
+- `pkg/daemon/daemon_ha_sync.go` — the early return + cancel, the
+  `beginClusterCommsEpoch` signature, the teardown clear, the test seam call
+- `pkg/daemon/daemon.go` — `afterEpochBeginForTest`
+- `pkg/daemon/cluster_transport_epoch_teardown_7071_7072_test.go` (new)
+- `pkg/daemon/cluster_transport_key_5078_test.go` — per-subtest re-seat
+- `pkg/daemon/cluster_transport_race_6290_test.go`,
+  `daemon_ha_comms_race_test.go` — call-site arity
+- `pkg/daemon/README.md`
+
+## Both issues were wrong about severity, in the same direction
+
+**#7071 says "Not a runtime defect".** It is one, in a narrow interleaving.
+`stopClusterComms` cancels only the CURRENT `clusterCommsCancel`. If epoch N is
+superseded by another `beginClusterCommsEpoch` (rather than by a stop), N's
+cancel has been overwritten and N's context can never be cancelled by anything.
+`startHAWatchdogHeartbeat` binds a 500ms ticker goroutine to that context, so
+continuing past the dropped publish leaves it running for the life of the
+daemon, writing for an epoch nobody owns. The interleaving needs two
+`startClusterComms` with no stop between — reachable because the boot
+`startClusterComms` races a DHCP-lease-driven step 20, which is the same
+concurrency #6290 documents.
+
+**#7072 says "unreachable today".** It is reachable: `bootstrap.go`'s
+`relinquishClusterForBootstrap` is a stop-only site, added since the issue was
+filed — exactly the trigger it predicted.
+
+The issue's stated consequence is also the wrong one. It expects a SKIPPED
+restart; measured, the reachable consequence is a RESURRECTION:
+
+| bootstrap rollback, then a commit | before | after |
+|---|---|---|
+| UNCHANGED transport | no restart | no restart |
+| CHANGED transport | **restart — comms come back** | no restart |
+
+Step 20 restarts on `active != zero && new != active`. With the stale key the
+changed case passed both halves and put the node back to heartbeating and
+session-syncing with a dataplane the rollback is detaching — the hybrid
+`relinquishClusterForBootstrap` exists to prevent.
+
+**Out of scope, stated rather than assumed:** clearing does not make step 20
+START comms after a stop-only teardown; `active != zero` fails either way, and
+the only other `startClusterComms` is at daemon boot. If something should
+restart comms after a rollback, step 20 is not it, before or after this change.
+
+## The #7071 cells escaped their first mutation, and why
+
+The first version opened two epochs by hand, cancelled one, and asserted the
+context was Done. Both mutations — discard the drop signal, and return early
+WITHOUT cancelling — left it green. It was asserting a property of
+`context.WithCancel` at a site `startClusterComms` never executes.
+
+The drop only happens when a supersession lands BETWEEN
+`beginClusterCommsEpoch` and the publish, two consecutive statements, so no
+external caller can reach it. `afterEpochBeginForTest` (same idiom as
+`startClusterCommsFn`) makes it deterministic, and the fixture must COMMIT a
+cluster config because `startClusterComms` early-returns without one — which is
+why every existing harness in this package could not reach the path at all.
+
+## The #5078 fixture had to change, and the reason is a real one
+Its three subtests share a daemon and were order-independent only because
+nothing cleared `activeClusterTransport`. The teardown clear makes a subtest
+whose step 20 restarts leave the field zero for the next one, and step 20 will
+not restart from a zero baseline. In production the restart's
+`startClusterComms` republishes immediately; that fixture's store deliberately
+holds no committed cluster config so `startClusterComms` early-returns. Each
+subtest now re-seats the UNKEYED transport — seating a KEYED one was measured
+(by the fixture's own author) to mask `key_commit_must_not_restart` under the
+mutation that adds `ControlLinkAuthKey` to `clusterTransportKey`. Cell P4
+confirms that mutation still reds with the re-seat in place.
+
+## Validation
+- `go test -count=1 ./pkg/daemon/` — ok
+- `go test -count=1 ./...` — see PR body
+- 5-cell mutation matrix, full-suite, green control — see PR body

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -959,7 +959,30 @@ are read/written only under that lock; every reader goes through
   constructor), cancels the context, **joins the constructor** via
   `clusterCommsWG`, then nils the shared state and `Stop()`s the old session
   sync. The join runs outside the lock (the constructor's publish path also
-  takes it), so there is no deadlock.
+  takes it), so there is no deadlock. Since **#7072** the nilled state includes
+  `activeClusterTransport`: the field means "the transport the comms CURRENTLY
+  RUNNING use", so a non-zero value after a teardown is false. It is not only an
+  inaccuracy — step 20 restarts on `active != zero && new != active`, so a commit
+  landing after a **stop-only** teardown with a CHANGED transport used to pass
+  both halves and bring comms back up. The stop-only site is
+  `relinquishClusterForBootstrap`, which stops comms precisely so the peer stops
+  seeing a healthy node whose dataplane is about to be detached; restarting them
+  re-creates that hybrid. Clearing does NOT make step 20 start comms after a
+  stop-only teardown — `active != zero` fails either way — and nothing else does
+  either; if that should change, it is a separate question from this field.
+- `startClusterComms` **consumes** the publish's drop signal since **#7071**,
+  matching its two sibling publishers. A `false` return means another epoch
+  superseded this one between `beginClusterCommsEpoch` and the publish, so it
+  cancels its own sub-context and returns. The cancel matters beyond skipping
+  dead work: when the supersession came from another `beginClusterCommsEpoch`
+  rather than a `stopClusterComms`, the newer epoch has already overwritten
+  `clusterCommsCancel`, so **no later `stopClusterComms` can cancel this
+  context** — and `startHAWatchdogHeartbeat` binds a 500ms ticker goroutine to
+  it. `beginClusterCommsEpoch` therefore returns the `CancelFunc` too; the field
+  cannot supply it, and calling what the field holds would tear down the LIVE
+  epoch. The drop path is reachable from a test only through the
+  `afterEpochBeginForTest` seam, because the window is between two consecutive
+  statements inside the function.
 
 - `activeClusterTransport` joined the epoch in **#6290** and publishes the same
   way, via `setActiveTransportIfCurrent(gen, key)`. It had been written by

--- a/pkg/daemon/cluster_transport_epoch_teardown_7071_7072_test.go
+++ b/pkg/daemon/cluster_transport_epoch_teardown_7071_7072_test.go
@@ -41,6 +41,30 @@ func transportTestDaemon7071(t *testing.T) *Daemon {
 	return d
 }
 
+// commitClusterCfg7071 commits a cluster config so startClusterComms gets past
+// its `d.store.ActiveConfig()` guard.
+func commitClusterCfg7071(t *testing.T, d *Daemon, ctl string) {
+	t.Helper()
+	if err := d.store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	// The auth key is required at commit (the control channel fails open
+	// without one) and is deliberately NOT part of clusterTransportKey (#5078),
+	// so it does not disturb what this fixture measures.
+	sets := "set chassis cluster control-interface " + ctl + "\n" +
+		"set chassis cluster authentication-key a-real-cluster-psk-7071\n"
+	if _, err := d.store.LoadSet(sets); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := d.store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if cfg := d.store.ActiveConfig(); cfg == nil || cfg.Chassis.Cluster == nil {
+		t.Fatal("precondition: startClusterComms early-returns without a committed " +
+			"cluster config, so the drop path would be unreachable")
+	}
+}
+
 func clusterCfgCtl7071(ctl string) *config.Config {
 	cfg := &config.Config{}
 	cfg.Chassis.Cluster = &config.ClusterConfig{ControlInterface: ctl}
@@ -123,48 +147,54 @@ func TestStopOnlyTeardownDoesNotResurrectComms_7072(t *testing.T) {
 
 // --- #7071: the drop signal is consumed -------------------------------------
 
-// TestSupersededStartClusterCommsReleasesItsContext_7071 is the half that made
-// this worth doing beyond matching the siblings.
+// TestSupersededStartClusterCommsReleasesItsContext_7071 drives the REAL
+// startClusterComms through its drop path.
 //
-// When an epoch is superseded by ANOTHER beginClusterCommsEpoch rather than by a
-// stopClusterComms, its context is ORPHANED: the newer epoch has overwritten
-// clusterCommsCancel with its own, so no later stopClusterComms can cancel this
-// one. startHAWatchdogHeartbeat binds a 500ms ticker goroutine to that context,
-// so continuing past the dropped publish leaves it running for the life of the
-// daemon, writing for an epoch nobody owns.
+// It has to, and that is the point. An earlier version of this cell opened two
+// epochs by hand and cancelled one — and stayed GREEN with both the early return
+// and the cancel deleted, because it was asserting a property of
+// context.WithCancel at a site production never executes. The supersession must
+// land BETWEEN beginClusterCommsEpoch and the publish, a window no external
+// caller can hit, which is what afterEpochBeginForTest exists for.
 //
-// The assertion is that the superseded context ends up CANCELLED, which is what
-// makes the leak impossible rather than merely unlikely.
+// The assertion is that the epoch's context ends up CANCELLED. When the
+// supersession comes from another beginClusterCommsEpoch rather than a
+// stopClusterComms, the newer epoch has overwritten clusterCommsCancel with its
+// own, so nothing else can ever cancel this one — and startHAWatchdogHeartbeat
+// binds a 500ms ticker goroutine to it. Leaving it live leaks that goroutine for
+// the life of the daemon.
 func TestSupersededStartClusterCommsReleasesItsContext_7071(t *testing.T) {
 	d := transportTestDaemon7071(t)
+	// startClusterComms early-returns unless a cluster config is COMMITTED, so
+	// the drop path is unreachable without one. control-interface only: a
+	// non-zero transport key that still starts no heartbeat (needs peer-address
+	// too) and no session sync (falls back to fabric, which is empty).
+	commitClusterCfg7071(t, d, "em0")
 
-	// Epoch N, as startClusterComms opens it.
-	ctxN, genN, cancelN := d.beginClusterCommsEpoch(context.Background())
-	// Epoch N+1 supersedes it WITHOUT a stopClusterComms, so cancelN is now
-	// unreachable through the field — the shape that orphans the context.
-	if _, genNext, _ := d.beginClusterCommsEpoch(context.Background()); genNext <= genN {
-		t.Fatalf("precondition: the second epoch must supersede the first (%d <= %d)",
-			genNext, genN)
+	var epochCtx context.Context
+	d.afterEpochBeginForTest = func(ctx context.Context, gen uint64) {
+		epochCtx = ctx
+		// Supersede WITHOUT a stopClusterComms: that is the shape that orphans
+		// the context, because stopClusterComms would have cancelled it.
+		d.beginClusterCommsEpoch(context.Background())
+	}
+
+	d.startClusterComms(context.Background())
+
+	if epochCtx == nil {
+		t.Fatal("startClusterComms never opened an epoch — it early-returned before " +
+			"the drop path, so this cell measured nothing")
 	}
 	select {
-	case <-ctxN.Done():
-		t.Fatal("precondition: the superseded context must still be live here; if it is " +
-			"already cancelled this test cannot tell a released context from an orphaned one")
-	default:
+	case <-epochCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the superseded epoch's context is still live after startClusterComms " +
+			"returned. Nothing else can cancel it — the newer epoch overwrote " +
+			"clusterCommsCancel — so any goroutine bound to it, including the " +
+			"watchdog's 500ms ticker, runs for the life of the daemon (#7071)")
 	}
-
-	// What startClusterComms now does on a dropped publish.
-	if d.setActiveTransportIfCurrent(genN, clusterTransportFromConfig(clusterCfgCtl7071("em0"))) {
-		t.Fatal("precondition: the publish for a superseded epoch must be dropped")
-	}
-	cancelN()
-
-	select {
-	case <-ctxN.Done():
-	case <-time.After(time.Second):
-		t.Fatal("the superseded epoch's context is still live. Nothing else can cancel it " +
-			"— the newer epoch overwrote clusterCommsCancel — so any goroutine bound to it " +
-			"runs for the life of the daemon (#7071)")
+	if got := d.activeTransport(); got != (clusterTransportKey{}) {
+		t.Fatalf("the superseded epoch published its transport key anyway: %+v", got)
 	}
 }
 

--- a/pkg/daemon/cluster_transport_epoch_teardown_7071_7072_test.go
+++ b/pkg/daemon/cluster_transport_epoch_teardown_7071_7072_test.go
@@ -1,0 +1,186 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// cluster_transport_epoch_teardown_7071_7072_test.go — #7071 and #7072.
+//
+// Two halves of one asymmetry. #6290 folded activeClusterTransport into the
+// comms epoch on the PUBLISH side; these close the two things that were left:
+// the publish's drop signal was discarded by its caller (#7071), and the field
+// was not cleared on the TEARDOWN side (#7072).
+//
+// A NOTE ON FIXTURES, because the obvious one is vacuous. clusterTransportFromConfig
+// builds the key from ControlInterface / PeerAddress / the fabric fields. A
+// fixture that sets NONE of them produces the ZERO key, so a value assertion
+// against it is zero-equals-zero and passes with the write deleted. Every case
+// below sets `control-interface` and ONLY that: it yields a non-zero key while
+// starting no goroutines, because the heartbeat is gated on control-interface
+// AND peer-address, and the sync path falls back to fabric and finds it empty.
+
+func transportTestDaemon7071(t *testing.T) *Daemon {
+	t.Helper()
+	d := &Daemon{
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+	d.setDataplane(&runtimeOnlyApplyTestDP{})
+	d.cluster = &cluster.Manager{}
+	d.daemonCtx = context.Background()
+	return d
+}
+
+func clusterCfgCtl7071(ctl string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Chassis.Cluster = &config.ClusterConfig{ControlInterface: ctl}
+	return cfg
+}
+
+// --- #7072: the field is torn down with the rest of the epoch ---------------
+
+// TestStopClusterCommsClearsActiveTransport_7072 is the state claim: after a
+// teardown the field must not name the transport that was just torn down.
+//
+// The fixture publishes a NON-ZERO key first, which is the whole difficulty —
+// against a zero-key fixture this assertion holds whether or not the clear
+// exists.
+func TestStopClusterCommsClearsActiveTransport_7072(t *testing.T) {
+	d := transportTestDaemon7071(t)
+	_, gen, _ := d.beginClusterCommsEpoch(context.Background())
+	if !d.setActiveTransportIfCurrent(gen, clusterTransportFromConfig(clusterCfgCtl7071("em0"))) {
+		t.Fatal("precondition: the publish must be accepted for the current epoch")
+	}
+	if got := d.activeTransport(); got.ControlInterface != "em0" {
+		t.Fatalf("precondition: active transport is %q, want em0 — a zero-key fixture "+
+			"would make the assertion below vacuous", got.ControlInterface)
+	}
+
+	d.stopClusterComms()
+
+	if got := d.activeTransport(); got != (clusterTransportKey{}) {
+		t.Fatalf("after stopClusterComms the active transport is still %+v. The field "+
+			"documents itself as the transport used by the comms CURRENTLY RUNNING, and "+
+			"nothing is running after a teardown, so a non-zero value is false (#7072)", got)
+	}
+}
+
+// TestStopOnlyTeardownDoesNotResurrectComms_7072 binds the CONSEQUENCE, and it
+// is the cell a future reader needs.
+//
+// Apply-tail step 20 restarts comms on `active != zero && new != active`. With
+// the stale key left in place, a commit landing after a stop-only teardown with
+// a CHANGED transport passed both halves and restarted comms that were torn down
+// deliberately. The one stop-only site is the bootstrap rollback
+// (relinquishClusterForBootstrap -> stopClusterComms, no start), which stops them
+// precisely so the peer stops seeing a healthy node whose dataplane is about to
+// be detached — so the restart re-creates the hybrid that rollback exists to
+// prevent.
+//
+// Both transports are exercised because only one of them could ever reach the
+// restart: with an UNCHANGED key the second half of the guard already blocked it,
+// so a same-key-only fixture passes with the clear deleted.
+func TestStopOnlyTeardownDoesNotResurrectComms_7072(t *testing.T) {
+	for _, tc := range []struct{ name, before, after string }{
+		{"changed_transport", "em0", "em1"},
+		{"unchanged_transport", "em0", "em0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := transportTestDaemon7071(t)
+			restarts := 0
+			d.startClusterCommsFn = func(context.Context) { restarts++ }
+
+			_, gen, _ := d.beginClusterCommsEpoch(context.Background())
+			if !d.setActiveTransportIfCurrent(gen, clusterTransportFromConfig(clusterCfgCtl7071(tc.before))) {
+				t.Fatal("precondition: publish must be accepted")
+			}
+			// The stop-only path: bootstrap rollback tears comms down and returns.
+			d.stopClusterComms()
+
+			if err := d.applyTailReconciles(clusterCfgCtl7071(tc.after),
+				nil, nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+				t.Fatalf("apply tail: %v", err)
+			}
+			if restarts != 0 {
+				t.Fatalf("step 20 restarted cluster comms %d time(s) after a stop-only "+
+					"teardown. The rollback stopped them deliberately; restarting puts the "+
+					"node back to heartbeating and session-syncing with a dataplane the "+
+					"rollback is detaching (#7072)", restarts)
+			}
+		})
+	}
+}
+
+// --- #7071: the drop signal is consumed -------------------------------------
+
+// TestSupersededStartClusterCommsReleasesItsContext_7071 is the half that made
+// this worth doing beyond matching the siblings.
+//
+// When an epoch is superseded by ANOTHER beginClusterCommsEpoch rather than by a
+// stopClusterComms, its context is ORPHANED: the newer epoch has overwritten
+// clusterCommsCancel with its own, so no later stopClusterComms can cancel this
+// one. startHAWatchdogHeartbeat binds a 500ms ticker goroutine to that context,
+// so continuing past the dropped publish leaves it running for the life of the
+// daemon, writing for an epoch nobody owns.
+//
+// The assertion is that the superseded context ends up CANCELLED, which is what
+// makes the leak impossible rather than merely unlikely.
+func TestSupersededStartClusterCommsReleasesItsContext_7071(t *testing.T) {
+	d := transportTestDaemon7071(t)
+
+	// Epoch N, as startClusterComms opens it.
+	ctxN, genN, cancelN := d.beginClusterCommsEpoch(context.Background())
+	// Epoch N+1 supersedes it WITHOUT a stopClusterComms, so cancelN is now
+	// unreachable through the field — the shape that orphans the context.
+	if _, genNext, _ := d.beginClusterCommsEpoch(context.Background()); genNext <= genN {
+		t.Fatalf("precondition: the second epoch must supersede the first (%d <= %d)",
+			genNext, genN)
+	}
+	select {
+	case <-ctxN.Done():
+		t.Fatal("precondition: the superseded context must still be live here; if it is " +
+			"already cancelled this test cannot tell a released context from an orphaned one")
+	default:
+	}
+
+	// What startClusterComms now does on a dropped publish.
+	if d.setActiveTransportIfCurrent(genN, clusterTransportFromConfig(clusterCfgCtl7071("em0"))) {
+		t.Fatal("precondition: the publish for a superseded epoch must be dropped")
+	}
+	cancelN()
+
+	select {
+	case <-ctxN.Done():
+	case <-time.After(time.Second):
+		t.Fatal("the superseded epoch's context is still live. Nothing else can cancel it " +
+			"— the newer epoch overwrote clusterCommsCancel — so any goroutine bound to it " +
+			"runs for the life of the daemon (#7071)")
+	}
+}
+
+// TestSupersededStartClusterCommsPublishesNothing_7071 pins the drop itself: a
+// superseded epoch must not leave its transport key behind as the live one.
+func TestSupersededStartClusterCommsPublishesNothing_7071(t *testing.T) {
+	d := transportTestDaemon7071(t)
+	_, genLive, _ := d.beginClusterCommsEpoch(context.Background())
+	if !d.setActiveTransportIfCurrent(genLive, clusterTransportFromConfig(clusterCfgCtl7071("em0"))) {
+		t.Fatal("precondition: publish must be accepted for the live epoch")
+	}
+	stale := genLive - 1
+	if d.setActiveTransportIfCurrent(stale, clusterTransportFromConfig(clusterCfgCtl7071("em9"))) {
+		t.Fatal("a superseded epoch's publish was accepted")
+	}
+	if got := d.activeTransport(); got.ControlInterface != "em0" {
+		t.Fatalf("the superseded publish overwrote the live transport: %q, want em0", got.ControlInterface)
+	}
+}

--- a/pkg/daemon/cluster_transport_key_5078_test.go
+++ b/pkg/daemon/cluster_transport_key_5078_test.go
@@ -171,7 +171,27 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	}
 	// Comms are "already up" on the base transport — the non-zero
 	// activeClusterTransport that step 20 requires before it will restart.
-	d.activeClusterTransport = clusterTransportFromConfig(transport())
+	// #7072: stopClusterComms now clears activeClusterTransport as part of the
+	// epoch teardown, so the seat is no longer a once-per-test setup — a subtest
+	// whose step 20 restarts comms leaves the field ZERO for the next one, and
+	// step 20 will not restart from a zero baseline. In production the restart's
+	// startClusterComms republishes the key immediately; this fixture's store
+	// deliberately holds no committed cluster config (see above), so the real
+	// startClusterComms early-returns and never republishes. Re-seat per subtest
+	// instead, which is what makes them order-independent now.
+	//
+	// The seat is deliberately the UNKEYED transport, the same value the
+	// once-per-test seat used. Seating a KEYED one was measured to MASK
+	// key_commit_must_not_restart under the mutation that adds
+	// ControlLinkAuthKey to clusterTransportKey; seating the unkeyed value
+	// leaves that mutation visible, because the keyed candidate still differs
+	// from the unkeyed active exactly as it did before.
+	seatActiveTransport := func() {
+		d.clusterCommsMu.Lock()
+		d.activeClusterTransport = clusterTransportFromConfig(transport())
+		d.clusterCommsMu.Unlock()
+	}
+	seatActiveTransport()
 
 	gen := func() uint64 {
 		d.clusterCommsMu.Lock()
@@ -180,6 +200,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	}
 
 	t.Run("key_commit_must_not_restart", func(t *testing.T) {
+		seatActiveTransport()
 		keyed := transport()
 		keyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-5078")
 
@@ -199,6 +220,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	// Positive control: an endpoint change MUST still restart, or the assertion
 	// above is satisfied by a step 20 that never fires at all.
 	t.Run("endpoint_change_must_restart", func(t *testing.T) {
+		seatActiveTransport()
 		moved := transport()
 		moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
 
@@ -252,6 +274,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 	//
 	// Tracked as #6878. Do not read "must still restart" as bound end to end.
 	t.Run("keyed_endpoint_change_must_still_restart", func(t *testing.T) {
+		seatActiveTransport()
 		movedKeyed := transport()
 		movedKeyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-5078")
 		movedKeyed.Chassis.Cluster.PeerAddress = "10.99.0.9"
@@ -265,7 +288,8 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 		// inside a subtest: under a mutation that DOES add ControlLinkAuthKey
 		// to clusterTransportKey, that write masked key_commit_must_not_restart
 		// when this subtest ran first (measured). The three subtests are
-		// order-independent because none of them REWRITES `d.activeClusterTransport`.
+		// order-independent because each RE-SEATS `d.activeClusterTransport` to the
+		// same unkeyed value on entry (#7072 made the teardown clear it).
 		// They do mutate `d` — applyTailReconciles reaches stopClusterComms, which
 		// increments d.clusterCommsGen, and that is the very thing each subtest
 		// measures. The distinction matters: a shared counter every subtest reads

--- a/pkg/daemon/cluster_transport_race_6290_test.go
+++ b/pkg/daemon/cluster_transport_race_6290_test.go
@@ -122,7 +122,7 @@ func TestSetActiveTransportDropsStaleEpoch(t *testing.T) {
 	stale := clusterTransportKey{ControlInterface: "STALE", PeerAddress: "10.99.9.9"}
 
 	// Open an epoch and publish under it: the live state.
-	_, gen := d.beginClusterCommsEpoch(context.Background())
+	_, gen, _ := d.beginClusterCommsEpoch(context.Background())
 	if !d.setActiveTransportIfCurrent(gen, fresh) {
 		t.Fatal("publish under the CURRENT epoch must be accepted")
 	}
@@ -131,7 +131,7 @@ func TestSetActiveTransportDropsStaleEpoch(t *testing.T) {
 	}
 
 	// A restart supersedes it. The prior epoch's publish must now be dropped.
-	_, newGen := d.beginClusterCommsEpoch(context.Background())
+	_, newGen, _ := d.beginClusterCommsEpoch(context.Background())
 	if newGen == gen {
 		t.Fatal("precondition: beginClusterCommsEpoch must advance the generation")
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1030,6 +1030,19 @@ type Daemon struct {
 	// nil selects the real method; production never sets it.
 	startClusterCommsFn func(context.Context)
 
+	// afterEpochBeginForTest, when non-nil, runs inside startClusterComms
+	// immediately after beginClusterCommsEpoch and before the transport
+	// publish, receiving that epoch's context and generation.
+	//
+	// It exists because the #7071 drop path is otherwise unreachable from a
+	// test: the publish only drops when another epoch supersedes this one
+	// BETWEEN those two statements, a window no external caller can hit
+	// deterministically. A test that opens two epochs by hand and cancels one
+	// proves a property of context.WithCancel, not of this function — measured:
+	// such a test stays green with the early return AND the cancel both
+	// deleted. Same seam idiom as startClusterCommsFn above.
+	afterEpochBeginForTest func(context.Context, uint64)
+
 	// clusterCommsMu guards the cluster-comms epoch state that is published
 	// asynchronously by the startClusterComms constructor goroutine and torn
 	// down by stopClusterComms: sessionSync, fabricRefreshCh/fabricRefreshCh1,

--- a/pkg/daemon/daemon_ha_comms_race_test.go
+++ b/pkg/daemon/daemon_ha_comms_race_test.go
@@ -26,12 +26,12 @@ func TestStartClusterCommsPublishDropsStaleEpoch(t *testing.T) {
 	d := &Daemon{}
 
 	// Epoch 1: a constructor goroutine starts resolving its sync address.
-	_, gen1 := d.beginClusterCommsEpoch(context.Background())
+	_, gen1, _ := d.beginClusterCommsEpoch(context.Background())
 	ss1 := &cluster.SessionSync{} // what the slow epoch-1 constructor would publish
 
 	// A transport-change commit restarts comms: a new epoch supersedes epoch 1
 	// while its constructor is still resolving.
-	_, gen2 := d.beginClusterCommsEpoch(context.Background())
+	_, gen2, _ := d.beginClusterCommsEpoch(context.Background())
 	if gen2 == gen1 {
 		t.Fatalf("beginClusterCommsEpoch did not advance the generation: gen1=%d gen2=%d", gen1, gen2)
 	}
@@ -64,7 +64,7 @@ func TestStartClusterCommsPublishDropsStaleEpoch(t *testing.T) {
 func TestStopClusterCommsSupersedesInflightConstructor(t *testing.T) {
 	d := &Daemon{}
 
-	_, gen1 := d.beginClusterCommsEpoch(context.Background())
+	_, gen1, _ := d.beginClusterCommsEpoch(context.Background())
 	ss1 := &cluster.SessionSync{}
 
 	// Tear comms down (no cluster/sessionSync wired yet — the constructor is
@@ -85,11 +85,11 @@ func TestStopClusterCommsSupersedesInflightConstructor(t *testing.T) {
 func TestPublishFabricRefreshChansDropsStaleEpoch(t *testing.T) {
 	d := &Daemon{}
 
-	_, gen1 := d.beginClusterCommsEpoch(context.Background())
+	_, gen1, _ := d.beginClusterCommsEpoch(context.Background())
 	stale0 := make(chan struct{}, 1)
 	stale1 := make(chan struct{}, 1)
 
-	_, gen2 := d.beginClusterCommsEpoch(context.Background())
+	_, gen2, _ := d.beginClusterCommsEpoch(context.Background())
 	live0 := make(chan struct{}, 1)
 	live1 := make(chan struct{}, 1)
 
@@ -113,7 +113,7 @@ func TestPublishFabricRefreshChansDropsStaleEpoch(t *testing.T) {
 func TestClusterCommsPublishConcurrentIsRaceFree(t *testing.T) {
 	d := &Daemon{}
 
-	_, liveGen := d.beginClusterCommsEpoch(context.Background())
+	_, liveGen, _ := d.beginClusterCommsEpoch(context.Background())
 	live := &cluster.SessionSync{}
 	if !d.publishSessionSyncIfCurrent(liveGen, live) {
 		t.Fatal("failed to publish the live epoch")

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -824,6 +824,9 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	// address) drops its publish instead of clobbering this epoch's state
 	// (#4958).
 	commsCtx, commsGen, commsCancel := d.beginClusterCommsEpoch(ctx)
+	if hook := d.afterEpochBeginForTest; hook != nil {
+		hook(commsCtx, commsGen)
+	}
 	if !d.setActiveTransportIfCurrent(commsGen, clusterTransportFromConfig(cfg)) {
 		// #7071: consume the drop signal, as both sibling publishers already do
 		// (publishSessionSyncIfCurrent, publishFabricRefreshChansIfCurrent).

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -721,7 +721,14 @@ func (d *Daemon) snapshotFabricRefreshChans() (chan struct{}, chan struct{}) {
 // present at publish time. Bumping the counter here means a constructor from a
 // prior epoch (still resolving addresses) is already superseded before this
 // call returns, so its later publish is dropped.
-func (d *Daemon) beginClusterCommsEpoch(parent context.Context) (context.Context, uint64) {
+// #7071: the CancelFunc is returned as well, so a caller that learns its epoch
+// was superseded before it wired anything can release the sub-context it just
+// created. It cannot reach that cancel through the field: by then a newer epoch
+// has overwritten clusterCommsCancel with its OWN, and calling that would tear
+// down the LIVE epoch instead of this dead one.
+func (d *Daemon) beginClusterCommsEpoch(
+	parent context.Context,
+) (context.Context, uint64, context.CancelFunc) {
 	commsCtx, commsCancel := context.WithCancel(parent)
 	d.clusterCommsMu.Lock()
 	d.clusterCommsGen++
@@ -729,7 +736,7 @@ func (d *Daemon) beginClusterCommsEpoch(parent context.Context) (context.Context
 	d.clusterCommsCancel = commsCancel
 	d.clusterCommsCtx = commsCtx
 	d.clusterCommsMu.Unlock()
-	return commsCtx, gen
+	return commsCtx, gen, commsCancel
 }
 
 // publishSessionSyncIfCurrent installs ss as the live session-sync object iff
@@ -816,8 +823,32 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	// a constructor goroutine from a superseded epoch (still resolving its sync
 	// address) drops its publish instead of clobbering this epoch's state
 	// (#4958).
-	commsCtx, commsGen := d.beginClusterCommsEpoch(ctx)
-	d.setActiveTransportIfCurrent(commsGen, clusterTransportFromConfig(cfg))
+	commsCtx, commsGen, commsCancel := d.beginClusterCommsEpoch(ctx)
+	if !d.setActiveTransportIfCurrent(commsGen, clusterTransportFromConfig(cfg)) {
+		// #7071: consume the drop signal, as both sibling publishers already do
+		// (publishSessionSyncIfCurrent, publishFabricRefreshChansIfCurrent).
+		//
+		// A false return means another epoch superseded this one between the
+		// beginClusterCommsEpoch above and this line. Everything below wires
+		// state for THIS epoch, and the later publishes are themselves
+		// epoch-gated, so continuing installs nothing — but it is not merely
+		// wasted work. startHAWatchdogHeartbeat and startHeartbeatWithRetry
+		// launch goroutines bound to commsCtx, and when the supersession came
+		// from another beginClusterCommsEpoch rather than a stopClusterComms,
+		// this context is ORPHANED: the newer epoch overwrote
+		// clusterCommsCancel with its own, so no later stopClusterComms can
+		// ever cancel this one. The watchdog's 500ms ticker would then run for
+		// the life of the daemon, writing for an epoch nobody owns.
+		//
+		// Cancelling here is what releases it, and it is safe precisely because
+		// the epoch is dead: nothing else holds this context. On the live path
+		// the cancel is NOT called — it stays in clusterCommsCancel for
+		// stopClusterComms, exactly as before.
+		commsCancel()
+		slog.Debug("cluster: comms epoch superseded before wiring, dropping start",
+			"generation", commsGen)
+		return
+	}
 
 	vrfDevice := d.resolveClusterVRFDevice(cc)
 
@@ -1219,6 +1250,26 @@ func (d *Daemon) stopClusterComms() {
 	d.sessionSync = nil
 	d.fabricRefreshCh = nil
 	d.fabricRefreshCh1 = nil
+	// #7072: the transport key is part of the epoch tuple and is torn down
+	// with it. activeClusterTransport documents itself as "the transport
+	// config used by the comms that are currently running", so after this
+	// teardown a non-zero value is simply false — nothing is running.
+	//
+	// Leaving it set had a consequence, not just an inaccuracy: apply-tail
+	// step 20 restarts comms on `active != zero && new != active`, so a
+	// commit landing after a stop-only teardown with a CHANGED transport
+	// would RESURRECT comms that were deliberately torn down. The one
+	// stop-only site is the bootstrap rollback
+	// (relinquishClusterForBootstrap), which stops comms precisely so the
+	// peer stops seeing a healthy node whose dataplane is about to be
+	// detached; bringing them back re-creates that hybrid.
+	//
+	// What this does NOT do is make step 20 start comms after a stop-only
+	// teardown: `active != zero` fails either way, so an unchanged-transport
+	// commit does not restart them before this change or after it. If
+	// something ought to restart comms post-rollback, it is not step 20 —
+	// that is a separate question and out of scope here.
+	d.activeClusterTransport = clusterTransportKey{}
 	d.clusterCommsMu.Unlock()
 
 	if ss != nil {


### PR DESCRIPTION
Closes #7071
Closes #7072

Two halves of the same asymmetry: #6290 folded `activeClusterTransport` into the
cluster-comms epoch on the **publish** side, leaving the call site's drop signal
discarded (#7071) and the **teardown** side not clearing the field (#7072). One
change, because #7072's test needs #7071's fixture and both touch the same
lifecycle.

## Both issues understate severity, in the same direction

**#7071 says "Not a runtime defect."** It is one, in a narrow interleaving.
`stopClusterComms` cancels only the *current* `clusterCommsCancel`. When epoch N
is superseded by another `beginClusterCommsEpoch` rather than by a stop, N's
cancel has already been overwritten — so **nothing can ever cancel N's context**
— and `startHAWatchdogHeartbeat` has bound a 500ms ticker goroutine to it.
Continuing past the dropped publish leaves that goroutine running for the life of
the daemon, writing for an epoch nobody owns. Reachable because the boot
`startClusterComms` races a DHCP-lease-driven step 20 — the same concurrency
#6290 documents.

That is why the fix is *return early **and** cancel*, and why
`beginClusterCommsEpoch` now hands the `CancelFunc` back: the field cannot supply
it, and calling what the field holds would tear down the **live** epoch.

**#7072 says "unreachable today."** It is reachable —
`relinquishClusterForBootstrap` (`bootstrap.go`) is a **stop-only** site, added
since the issue was filed. Exactly the trigger it predicted.

And the reachable consequence is not the one the issue names. It expects a
*skipped* restart; measured, it is a **resurrection**:

| bootstrap rollback, then a commit | before | after |
|---|---|---|
| UNCHANGED transport | no restart | no restart |
| CHANGED transport | **restart — comms come back up** | no restart |

Step 20 restarts on `active != zero && new != active`. With the stale key, the
changed case passed both halves and put the node back to heartbeating and
session-syncing with a dataplane the rollback is detaching — the hybrid that
rollback exists to prevent ("the peer keeps seeing a healthy node…").

**Out of scope, stated rather than assumed:** clearing does **not** make step 20
*start* comms after a stop-only teardown — `active != zero` fails either way, and
the only other `startClusterComms` is at daemon boot. If something should restart
comms after a rollback, step 20 is not it, before or after this change. That is a
separate change with a different risk profile.

## The #7071 cells escaped their first mutation

Worth reporting because the first version looked reasonable. It opened two epochs
by hand, cancelled one, and asserted the context was `Done`. **Both** mutations —
discard the drop signal, and return early *without* cancelling — left it green:
it was asserting a property of `context.WithCancel` at a site
`startClusterComms` never executes.

The drop only occurs when a supersession lands **between**
`beginClusterCommsEpoch` and the publish — two consecutive statements — so no
external caller can reach it. `afterEpochBeginForTest` (same seam idiom as
`startClusterCommsFn`) makes it deterministic, and the fixture must **commit** a
cluster config, because `startClusterComms` early-returns without one. That is
why no existing harness in this package could reach the path at all.

## The #5078 fixture change is caused, not incidental

Its three subtests share a daemon and were order-independent only because nothing
cleared `activeClusterTransport` — its own comment says so. The teardown clear
makes a subtest whose step 20 restarts leave the field zero for the next, and step
20 will not restart from a zero baseline. In production the restart's
`startClusterComms` republishes immediately; that fixture's store deliberately
holds none so it early-returns.

Each subtest now re-seats the **unkeyed** transport. Seating a *keyed* one was
measured by that fixture's author to mask `key_commit_must_not_restart` under the
mutation that adds `ControlLinkAuthKey` to `clusterTransportKey` — cell P4 below
confirms that mutation still reds with the re-seat in place, so the fixture change
did not buy order-independence by losing sensitivity.

## Validation

- `go test -count=1 ./pkg/daemon/` — ok (Go instrument; this change is Go-only)
- `go test -count=1 ./...` — 68 packages ok, 0 failures, 0 `no space left`
- Mutation matrix, full-suite, green control, fresh log path per cell:

| cell | mutation | named failing tests |
|---|---|---|
| CONTROL | none | 0 (green) |
| P1 | discard the drop signal again (#7071 reverted) | `TestSupersededStartClusterCommsReleasesItsContext_7071` |
| P2 | return early but do NOT cancel | `TestSupersededStartClusterCommsReleasesItsContext_7071` |
| P3 | teardown leaves the transport key set (#7072 reverted) | `TestStopClusterCommsClearsActiveTransport_7072`, `TestStopOnlyTeardownDoesNotResurrectComms_7072` |
| P4 | add `ControlLinkAuthKey` to `clusterTransportKey` | 4, incl. `TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078` |

P1 and P2 are the cells the first test version escaped; both bite against the
rewritten one.

No cluster smoke: no forwarding, VRRP or session-sync behaviour changes — the
epoch lifecycle's observable effect is unchanged except on the two paths above.
