### PR TITLE
cos: correct the loss-priority help that denies its own enforcement

### DIFF
--- a/docs/log/7083.md
+++ b/docs/log/7083.md
@@ -1,0 +1,51 @@
+# docs/log/7083.md — #7083 (CoS loss-priority `?` help)
+
+- **Timestamp**: 2026-08-29
+- **Action**: Correct the four `loss-priority` descriptions that falsely claim
+  the dataplane does not enforce them; bind all seven to the Rust.
+- **File(s)**: `pkg/config/schema_cos.go`,
+  `pkg/config/cos_lp_help_truth_7083_test.go`
+
+## Four of seven, verified individually
+
+The issue warns against a blanket edit and is right to. Measured against the
+Rust rather than taken from the issue:
+
+| node | Rust table | verdict |
+|---|---|---|
+| `classifiers dscp` | `dscp_lp_by_dscp` | ENFORCED — claim false |
+| `classifiers ieee-802.1` | `ieee8021_lp_by_pcp` | ENFORCED — claim false |
+| `classifiers inet-precedence` | `inet_precedence_lp_by_prec` | ENFORCED — claim false |
+| `rewrite-rules dscp` | `dscp_rewrite_by_queue_lp` | ENFORCED — claim false |
+| `rewrite-rules ieee-802.1` | none | inert — claim CORRECT |
+| `rewrite-rules inet-precedence` | none | inert — claim CORRECT |
+| `rewrite-rules exp` | none | inert — claim CORRECT |
+
+`rewrite-rules dscp` is the one the issue flags as "suspect, check it":
+`cos_classify.rs` does `lp.dscp_rewrite_by_queue_lp.get(&(queue_id, plp))`, so
+the egress DSCP is chosen BY loss priority. It is enforced, and it is the fourth
+false claim.
+
+The three inert ones are confirmed in both directions: no rewrite table exists on
+the Rust side, and `docs/cos-validation-notes.md` independently records all three
+as accepted-but-inert.
+
+## Bound as a biconditional, because it has drifted twice
+
+#3995 made the dscp / ieee-802.1 classifier loss priorities live and did not
+update the description. #6847 then added inet-precedence and COPIED the stale
+sibling text onto the new node. A claim that has gone stale twice by the same
+mechanism will go stale a third time.
+
+`TestCoSLossPriorityHelpMatchesTheDataplane_7083` keys on the **Rust identifier's
+existence**, so a family that gains a table must move its help or red. Asserting
+only "these four now say ENFORCED" would have been satisfied by the blanket edit
+the issue warns against.
+
+## The guard's own failure was legible
+
+First run: all seven subtests failed — because `loss-priority` sits under
+`forwarding-class`, not directly under the family. The `t.Fatalf` said exactly
+that ("setSchema has no \"loss-priority\" under \"class-of-service classifiers
+dscp\"") rather than reporting a claim mismatch. A guard whose lookup failure is
+indistinguishable from a subject failure would have sent me to re-check the Rust.

--- a/pkg/config/cos_lp_help_truth_7083_test.go
+++ b/pkg/config/cos_lp_help_truth_7083_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #7083: every class-of-service `loss-priority` node's `?` help must agree with
+// whether the userspace dataplane actually enforces that family's loss priority.
+//
+// The claim had drifted TWICE before this guard existed, in the same direction
+// both times. #3995 made the dscp / ieee-802.1 classifier loss priorities live
+// and did not update the description; #6847 added inet-precedence and COPIED the
+// stale sibling text onto the new node. A claim that has gone stale twice by the
+// same mechanism will go stale a third time, so it is bound rather than merely
+// corrected.
+//
+// The binding is a BICONDITIONAL over the Rust, not a spot-check of the four
+// that were wrong. Asserting only "these say ENFORCED" would be satisfied by a
+// blanket edit — and a blanket edit is exactly what this issue warns against,
+// because three of the seven nodes are correctly marked inert:
+// `rewrite-rules ieee-802.1`, `inet-precedence` and `exp` have no rewrite table
+// on the Rust side at all (docs/cos-validation-notes.md records the same).
+//
+// Keying on the Rust identifier rather than on a hand-kept list is what makes a
+// future family self-reporting: add the table, and the node's help must move
+// with it or this reds.
+func TestCoSLossPriorityHelpMatchesTheDataplane_7083(t *testing.T) {
+	rust := func(rel string) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join("..", "..", "userspace-dp", "src", rel))
+		if err != nil {
+			t.Fatalf("read %s: %v (the #7083 help-truth guard cannot run)", rel, err)
+		}
+		return string(b)
+	}
+	build := rust(filepath.Join("afxdp", "forwarding_build", "cos.rs"))
+	classify := rust(filepath.Join("afxdp", "tx", "cos_classify.rs"))
+
+	const inertClaim = "not enforced by the userspace dataplane"
+
+	for _, tc := range []struct {
+		path  []string // setSchema path to the loss-priority node
+		table string   // the Rust identifier whose EXISTENCE means "enforced"
+		src   string
+	}{
+		{[]string{"class-of-service", "classifiers", "dscp", "forwarding-class", "loss-priority"}, "dscp_lp_by_dscp", build},
+		{[]string{"class-of-service", "classifiers", "ieee-802.1", "forwarding-class", "loss-priority"}, "ieee8021_lp_by_pcp", build},
+		{[]string{"class-of-service", "classifiers", "inet-precedence", "forwarding-class", "loss-priority"}, "inet_precedence_lp_by_prec", build},
+		{[]string{"class-of-service", "rewrite-rules", "dscp", "forwarding-class", "loss-priority"}, "dscp_rewrite_by_queue_lp", classify},
+		// The three the dataplane genuinely does not rewrite. Their absence from
+		// the Rust is the evidence, and it is asserted below rather than assumed:
+		// if one of these ever gains a table, this row flips and the help must
+		// follow.
+		{[]string{"class-of-service", "rewrite-rules", "ieee-802.1", "forwarding-class", "loss-priority"}, "ieee8021_rewrite_by_queue_lp", classify},
+		{[]string{"class-of-service", "rewrite-rules", "inet-precedence", "forwarding-class", "loss-priority"}, "inet_precedence_rewrite_by_queue_lp", classify},
+		{[]string{"class-of-service", "rewrite-rules", "exp", "forwarding-class", "loss-priority"}, "exp_rewrite_by_queue_lp", classify},
+	} {
+		name := strings.Join(tc.path, " ")
+		t.Run(name, func(t *testing.T) {
+			children := setSchema.children
+			var desc string
+			for i, key := range tc.path {
+				n, ok := children[key]
+				if !ok {
+					t.Fatalf("setSchema has no %q under %q — if the schema was reshaped, "+
+						"update this guard rather than deleting it; the claim it binds is "+
+						"still on the operator's screen", key, strings.Join(tc.path[:i], " "))
+				}
+				desc, children = n.desc, n.children
+			}
+
+			enforced := strings.Contains(tc.table, "_") && strings.Contains(tc.src, tc.table)
+			claimsInert := strings.Contains(desc, inertClaim)
+
+			if enforced && claimsInert {
+				t.Errorf("%s: the help says %q, but the dataplane builds %s and uses it. "+
+					"An operator reading this declines to configure a knob that works.\n  desc: %s",
+					name, inertClaim, tc.table, desc)
+			}
+			if !enforced && !claimsInert {
+				t.Errorf("%s: the help does NOT say %q, but no %s exists on the Rust side, so "+
+					"this family's loss priority is accepted and inert. An operator reading "+
+					"this configures a knob that does nothing — the worse direction.\n  desc: %s",
+					name, inertClaim, tc.table, desc)
+			}
+		})
+	}
+}

--- a/pkg/config/schema_cos.go
+++ b/pkg/config/schema_cos.go
@@ -13,14 +13,14 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 	"classifiers": {desc: "Classifiers mapping incoming code points to forwarding classes", children: map[string]*schemaNode{
 		"dscp": {desc: "DSCP classifier", args: 1, multi: true, placeholder: "<classifier-name>", children: map[string]*schemaNode{
 			"forwarding-class": {desc: "Forwarding class to assign to matching code points", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
-				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority for packets matching this code point (ENFORCED: feeds dscp_lp_by_dscp, which selects the egress DSCP rewrite row)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
 					"code-points": {desc: "DSCP code points to match (alias such as ef, af11, cs6, or numeric 0..63)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
 				}},
 			}},
 		}},
 		"ieee-802.1": {desc: "IEEE 802.1p classifier", args: 1, multi: true, placeholder: "<classifier-name>", children: map[string]*schemaNode{
 			"forwarding-class": {desc: "Forwarding class to assign to matching code points", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
-				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority for packets matching this code point (ENFORCED: feeds ieee8021_lp_by_pcp, which selects the egress DSCP rewrite row)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
 					"code-points": {desc: "IEEE 802.1p code points to match (0..7)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
 				}},
 			}},
@@ -33,7 +33,7 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 		// `rewrite-rules inet-precedence` direction below is still inert.
 		"inet-precedence": {desc: "IP-precedence classifier (classify on the 3-bit IP precedence field)", args: 1, multi: true, placeholder: "<classifier-name>", children: map[string]*schemaNode{
 			"forwarding-class": {desc: "Forwarding class to assign to matching code points", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
-				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority for packets matching this precedence (ENFORCED: feeds inet_precedence_lp_by_prec, which selects the egress DSCP rewrite row)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
 					"code-points": {desc: "IP-precedence code points to match (0..7)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
 				}},
 			}},
@@ -42,7 +42,7 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 	"rewrite-rules": {desc: "Egress rewrite rules mapping forwarding classes to code points", children: map[string]*schemaNode{
 		"dscp": {desc: "DSCP rewrite rule", args: 1, multi: true, placeholder: "<rewrite-rule-name>", children: map[string]*schemaNode{
 			"forwarding-class": {desc: "Forwarding class whose packets get the rewritten code point", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
-				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority this rewrite entry applies to (ENFORCED: the egress DSCP is chosen by (queue, loss-priority))", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
 					"code-point":  {desc: "DSCP code point to write (alias such as ef, af11, cs6, or numeric 0..63)", args: 1, placeholder: "<code-point>", children: nil},
 					"code-points": {desc: "DSCP code point to write (alias of code-point; first value is used)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
 				}},


### PR DESCRIPTION
Closes #7083

Seven class-of-service `loss-priority` nodes carried *"accepted for Junos
compatibility; not enforced by the userspace dataplane"* in their `?` help.
**Four are false. Three are correct and are left alone.**

## Verified per node against the Rust, not taken from the issue

| node | Rust table | verdict |
|---|---|---|
| `classifiers dscp` | `dscp_lp_by_dscp` | ENFORCED — claim false |
| `classifiers ieee-802.1` | `ieee8021_lp_by_pcp` | ENFORCED — claim false |
| `classifiers inet-precedence` | `inet_precedence_lp_by_prec` | ENFORCED — claim false |
| `rewrite-rules dscp` | `dscp_rewrite_by_queue_lp` | ENFORCED — claim false |
| `rewrite-rules ieee-802.1` | none | inert — claim **correct** |
| `rewrite-rules inet-precedence` | none | inert — claim **correct** |
| `rewrite-rules exp` | none | inert — claim **correct** |

`rewrite-rules dscp` is the one the issue flags only as *"suspect, check it"*:
`cos_classify.rs` does `lp.dscp_rewrite_by_queue_lp.get(&(queue_id, plp))`, so the
egress DSCP is chosen **by** loss priority. It is the fourth false claim.

The three inert ones are confirmed in both directions — no rewrite table exists
on the Rust side, and `docs/cos-validation-notes.md` independently records all
three as accepted-but-inert.

## Bound as a BICONDITIONAL, because this has drifted twice already

#3995 made the classifier loss priorities live and did not update the
description. #6847 then added inet-precedence and **copied the stale sibling
text** onto the new node. A claim that has gone stale twice by the same mechanism
will go stale a third time.

`TestCoSLossPriorityHelpMatchesTheDataplane_7083` keys on the **existence of the
Rust identifier**, so a family that gains a table must move its help or red — and
one that loses a table must too. Asserting only "these four now say ENFORCED"
would have been satisfied by exactly the blanket edit the issue warns against.

## Mutation matrix

`collected=8`, **0 build errors**, `git diff --stat` non-empty between edit and
run in every cell.

| cell | mutation | FAIL cells | named |
|---|---|---|---|
| M0 | control | 0 | — |
| M1 | revert one ENFORCED desc to the stale claim | 2 | `.../classifiers_dscp_...` **only** |
| M2 | blanket-edit an INERT one to say ENFORCED | 2 | `.../rewrite-rules_ieee-802.1_...` **only** |

**M2 is the cell that matters.** It is the over-correction direction — precisely
what a sweep would have produced — and it reds. Disjoint named failures, so each
cell localises.

## The guard's own failure mode is legible

First run, all seven subtests failed with `setSchema has no "loss-priority" under
"class-of-service classifiers dscp"` — `loss-priority` sits under
`forwarding-class`. That is a **lookup** failure, plainly distinguishable from a
claim mismatch. Had the two been indistinguishable I would have gone back to
re-verify the Rust instead of fixing the path.

## Why it matters, mildly

The claim understates rather than overstates, so the operational cost is an
operator declining to configure a knob that would have worked — but it is the
exact claim class #6847 exists to remove.