### PR TITLE
config: delete the plaintext advisory's unreachable predicate branch (#7090)

### DIFF
--- a/docs/log/7090.md
+++ b/docs/log/7090.md
@@ -1,0 +1,82 @@
+# #7090 — the plaintext advisory's unreachable branch and its stale claim
+
+## Timestamp
+2026-08-28
+
+## Action
+Delete an unreachable filter in `warnSecureTunnelPlaintextUnadjudicatedAST`, and
+correct the justification that three places gave for it.
+
+## Files
+- `pkg/config/compiler_ipsec_plaintext_warn.go` — the branch, the file header's
+  coupling sentence, the inline comment
+- `pkg/config/plaintext_advisory_ifid_implication_7090_test.go` (new)
+- `pkg/config/README.md`
+
+## Why the branch could not fire
+
+The advisory filtered its population twice: on `XFRMIfNameAndID(bindIface)`
+returning a non-zero if_id, and again on `IsSecureTunnelIfName(base)`. The
+second is implied by the first — `XFRMIfNameAndID` returns non-zero only after
+`secureTunnelIndex` succeeds on the base name, and `IsSecureTunnelIfName` IS
+`secureTunnelIndex` on that same base, both splitting on the first `.`.
+
+Measured over 2244 generated names (prefix x index x unit, including bad
+prefixes, out-of-range indices, negatives, non-numerics, empty and multi-dot):
+**no input** produced a non-zero if_id with the predicate false.
+
+## What the test binds, and why it is not the deleted line
+
+A test asserting "the branch is gone" would guard a line, not a property.
+Deleting it is safe only while the implication holds, so
+`TestNonZeroIfIDImpliesSecureTunnelName_7090` binds the implication itself: if
+`XFRMIfNameAndID` ever gains a path to a non-zero id for a name the predicate
+rejects, the advisory's population silently widens and this reds.
+
+Two details that matter:
+- the names are GENERATED, because the claim is about a space; a hand-listed
+  table proves the branch dead for those rows and says nothing about the rest;
+- it asserts NON-VACUITY. A sweep in which nothing produced a non-zero id would
+  satisfy the implication for free, and would keep satisfying it if
+  `XFRMIfNameAndID` were broken to return 0 always.
+
+A second test pins the SURVIVING filter so the deletion cannot be "simplified"
+further: `st0.65535` is accepted by `IsSecureTunnelIfName` and builds no device,
+and warning about it would describe a plaintext path that does not exist. That
+row is also what made the deleted branch look plausible — it is the only place
+the two filters differ, and they differ in the direction the surviving one
+already handles.
+
+## The stale claim was the more dangerous half
+
+Three places said the advisory keys off the SAME predicate as the dataplane
+exclusion "so the two cannot drift":
+
+- the file header (`userspaceSkipsIngressInterface` /
+  `include_userspace_binding_interface`, "both keyed off `IsSecureTunnelIfName`")
+- the inline comment above the deleted branch
+- `pkg/config/README.md`
+
+Untrue since #6691 round 5. The exclusion now runs
+`userspaceSkipsIngressInterface` -> `userspaceUnbindableNetdev` -> the
+`SecureTunnel` class -> `matchesSecureTunnelClass` -> `iface.SecureTunnel`, set
+by `snapshotSecureTunnel`; the Rust mirror `is_secure_tunnel_ifname` was deleted
+in the same round; and `xfrmi.go` says it outright — `IsSecureTunnelIfName` "is
+NOT the ownership test and no longer gates any dataplane set".
+
+The CONCLUSION still holds by a different route: `pkg/routing/xfrm.go` creates
+an xfrmi for exactly `vpn.BindInterface` via `XFRMIfNameAndID` and skips
+`ifID == 0`, so the two populations coincide through the shared if_id. That is
+why this is not a runtime bug — and why the stale reason is the dangerous part,
+since a later reader relies on the reason instead of re-deriving it.
+
+The replacement states what the relationship actually is: a coincidence of
+populations, not a mechanical binding, and a real anti-drift guard would have to
+assert the two populations agree. That cannot live in `pkg/config` —
+`snapshotSecureTunnel` is unexported in `pkg/dataplane/userspace` — so it is
+named as the shape such a guard would need rather than half-built here.
+
+## Validation
+- `go test -count=1 ./pkg/config/` — ok (Go instrument; Go-only change)
+- `go test -count=1 ./...` — see PR body
+- 3-cell mutation matrix, full-suite, green control — see PR body

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1129,9 +1129,16 @@ their security posture, which is worse than an unimplemented feature.
 
 Two wordings, on purpose: a ZONED tunnel reads as an escalation, because a
 specific untrue thing was asserted; an unzoned tunnel gets a plain statement of
-the gap. The advisory keys off the SAME predicate as the dataplane exclusion
-(`IsSecureTunnelIfName`), so the two cannot drift into a state where the
-dataplane adjudicates the tunnel while the warning still says it does not. It
+the gap. The advisory's population is the set of `bind-interface` refs for which
+`XFRMIfNameAndID` builds a device (a non-zero if_id) — the same set
+`pkg/routing/xfrm.go` creates xfrmis for, since it skips `ifID == 0`. It does
+NOT key off `IsSecureTunnelIfName`, and saying so was a stale claim corrected in
+#7090: since #6691 round 5 the dataplane exclusion reads the snapshot's
+`SecureTunnel` flag (`snapshotSecureTunnel`), and `xfrmi.go` states that the
+predicate "is NOT the ownership test and no longer gates any dataplane set". The
+two populations still coincide, but through the shared if_id rather than a
+shared call — a coincidence, not a mechanical binding, and a real anti-drift
+guard would have to be a test asserting the populations agree. It
 fires on all four compile entry points — strict, lenient, and both node-aware
 variants — because the operator who most needs it is the one whose config
 arrives by restart or peer-sync and who never re-commits.

--- a/pkg/config/compiler_ipsec_plaintext_warn.go
+++ b/pkg/config/compiler_ipsec_plaintext_warn.go
@@ -1,8 +1,6 @@
 package config
 
-import (
-	"strings"
-)
+import ()
 
 // compiler_ipsec_plaintext_warn.go carries the #5619 commit-time WARNING that
 // a route-based IPsec VPN's decrypted plaintext is not zone-adjudicated.
@@ -10,9 +8,10 @@ import (
 // The defect it makes visible: route-based IPsec decrypts in the KERNEL XFRM
 // stack, which delivers the plaintext on the xfrmi netdev. xpf's userspace
 // dataplane does not adjudicate that interface — it is excluded from the
-// ingress-adjudication map and the AF_XDP binding plan
-// (userspaceSkipsIngressInterface / include_userspace_binding_interface, both
-// keyed off IsSecureTunnelIfName) because there is no path to hand a plaintext
+// ingress-adjudication map (userspaceSkipsIngressInterface, which reads the
+// snapshot's SecureTunnel flag; #6691 round 5 stopped it calling
+// IsSecureTunnelIfName, and the Rust mirror is_secure_tunnel_ifname was
+// deleted rather than re-derived) because there is no path to hand a plaintext
 // frame back INTO an xfrmi for the egress direction. xpf installs only
 // `hook input` nftables chains and force-enables ip_forward, so the plaintext
 // is forwarded by the kernel with no zone policy, no session, no NAT and no
@@ -74,11 +73,29 @@ import (
 // posture — which is worse than an unimplemented feature, and is what this
 // warning corrects.
 //
-// Coupling. The warning keys off the SAME predicate as the dataplane exclusion
-// (IsSecureTunnelIfName), so the two cannot drift apart into a state where the
-// dataplane adjudicates the tunnel while the warning still claims it does not,
-// or vice versa. When the dataplane learns to own an xfrmi end-to-end, the
-// exclusion arms and this warning are keyed off one name and go together.
+// Coupling, restated in #7090 because the old wording named a mechanism that
+// no longer exists. It said the warning keys off the SAME predicate as the
+// dataplane exclusion (IsSecureTunnelIfName) "so the two cannot drift". That
+// stopped being true in #6691 round 5: the exclusion now runs
+// userspaceSkipsIngressInterface -> userspaceUnbindableNetdev -> the
+// SecureTunnel class -> matchesSecureTunnelClass -> iface.SecureTunnel, which
+// the snapshot builder sets from snapshotSecureTunnel (config ownership via
+// SecureTunnelNetdevForRef, UNION a live xfrm device). xfrmi.go says it
+// outright: IsSecureTunnelIfName "is NOT the ownership test and no longer
+// gates any dataplane set".
+//
+// What actually keeps the two populations coincident is the if_id, not a
+// shared predicate: pkg/routing/xfrm.go creates an xfrmi for exactly
+// vpn.BindInterface via XFRMIfNameAndID and skips ifID == 0, and the
+// dataplane's ownership join reaches the same devices through that id. So the
+// conclusion the old comment drew still holds — it was the stated reason that
+// had gone stale, which is the more dangerous half, because a later reader
+// relies on the reason instead of re-deriving it.
+//
+// This is a coincidence of populations, NOT a mechanical binding. If a real
+// anti-drift guard is wanted it has to be a test asserting the two populations
+// agree; it cannot live here, because snapshotSecureTunnel is unexported in
+// pkg/dataplane/userspace.
 //
 // An AST pre-walk (like validateSecureTunnelBindInterfaceAST) rather than a
 // typed-Config pass, so it runs on the group-expanded, inactive-pruned tree in
@@ -115,20 +132,16 @@ func warnSecureTunnelPlaintextUnadjudicatedAST(nodes []*Node) []string {
 				if ifID == 0 {
 					continue
 				}
-				// Split the unit suffix off exactly as XFRMIfNameAndID does,
-				// so the predicate below sees the same base name the device
-				// derivation does.
-				base := bindIface
-				if i := strings.IndexByte(base, '.'); i >= 0 {
-					base = base[:i]
-				}
-				// Keyed off the SAME predicate as the dataplane exclusion, so
-				// the warning and the behaviour it describes cannot drift.
-				// Today every valid secure tunnel is non-adjudicable; this
-				// stays correct if that ever becomes conditional.
-				if !IsSecureTunnelIfName(base) {
-					continue
-				}
+				// #7090: there is deliberately no IsSecureTunnelIfName check
+				// here. It used to follow, justified as keying the advisory off
+				// the same predicate as the dataplane exclusion — but it could
+				// not fire for any input, because a non-zero ifID ALREADY
+				// implies it: XFRMIfNameAndID returns non-zero only after
+				// secureTunnelIndex succeeds on the base name, and
+				// IsSecureTunnelIfName IS secureTunnelIndex on that same base.
+				// TestNonZeroIfIDImpliesSecureTunnelName_7090 binds the
+				// implication, so if that ever stops holding this population
+				// widens and the test says so.
 				key := inst.name + "\x00" + bindIface
 				if _, dup := seen[key]; dup {
 					continue

--- a/pkg/config/plaintext_advisory_ifid_implication_7090_test.go
+++ b/pkg/config/plaintext_advisory_ifid_implication_7090_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// plaintext_advisory_ifid_implication_7090_test.go — #7090.
+//
+// warnSecureTunnelPlaintextUnadjudicatedAST used to filter its population
+// twice: once on `XFRMIfNameAndID(bindIface)` returning a non-zero if_id, and
+// again on `IsSecureTunnelIfName(base)`. The second filter could not fire for
+// any input, because the first ALREADY implies it — XFRMIfNameAndID returns a
+// non-zero id only after secureTunnelIndex succeeds on the base name, and
+// IsSecureTunnelIfName IS secureTunnelIndex on that same base, both splitting
+// on the first '.'.
+//
+// Deleting a branch is only safe while that implication holds, so this binds
+// the implication rather than the deleted line. If XFRMIfNameAndID ever gains a
+// path to a non-zero id for a name IsSecureTunnelIfName rejects, the advisory's
+// population silently widens — and this reds instead.
+
+// TestNonZeroIfIDImpliesSecureTunnelName_7090 sweeps the name space for the
+// combination the deleted branch existed to catch.
+//
+// The table is generated rather than listed because the question is about a
+// SPACE, not about the handful of names anyone thinks to write down: a
+// hand-picked table proves the branch is dead for those rows and says nothing
+// about the rest. The generators deliberately include names that are rejected
+// for different REASONS — bad prefix, out-of-range index, negative, non-numeric,
+// empty, multi-dot — since a violation would come from exactly such an edge.
+func TestNonZeroIfIDImpliesSecureTunnelName_7090(t *testing.T) {
+	prefixes := []string{"st", "ST", "s", "st-", "st+", "xt", "", "st0", "stx", "et", "gr"}
+	indices := []string{"", "0", "1", "5", "9", "10", "255", "65535", "65536", "99999",
+		"-1", "+5", "0x1", "00", "007", "abc", " 1"}
+	units := []string{"", ".", ".0", ".1", ".255", ".65535", ".65536", ".abc", ".-1",
+		"..", ".0.1", ".+1"}
+
+	var checked, nonZero int
+	for _, p := range prefixes {
+		for _, idx := range indices {
+			for _, u := range units {
+				name := p + idx + u
+				_, ifID := XFRMIfNameAndID(name)
+				checked++
+				if ifID == 0 {
+					continue
+				}
+				nonZero++
+				base := name
+				if i := strings.IndexByte(base, '.'); i >= 0 {
+					base = base[:i]
+				}
+				if !IsSecureTunnelIfName(base) {
+					t.Fatalf("XFRMIfNameAndID(%q) returned if_id %d while "+
+						"IsSecureTunnelIfName(%q) is false.\n"+
+						"The #7090 deletion removed a second filter on exactly this "+
+						"combination, on the grounds that it cannot occur. It just did, so "+
+						"the advisory now warns about a binding the device derivation would "+
+						"not build — restore the predicate check, or narrow XFRMIfNameAndID",
+						name, ifID, base)
+				}
+			}
+		}
+	}
+
+	// Non-vacuity: a sweep in which NOTHING produced a non-zero id would satisfy
+	// the implication for free, and would keep doing so if XFRMIfNameAndID were
+	// broken to return 0 always.
+	if nonZero == 0 {
+		t.Fatalf("swept %d names and none produced a non-zero if_id, so the implication "+
+			"above held vacuously and this test proves nothing", checked)
+	}
+	t.Logf("swept %d names, %d with a non-zero if_id", checked, nonZero)
+}
+
+// TestAdvisoryPopulationIsTheIfIDPopulation_7090 pins the surviving filter, so
+// the deletion cannot be "simplified" further by removing the if_id check too.
+//
+// `st0.65535` is the case that matters: IsSecureTunnelIfName accepts the base,
+// but XFRMIfNameAndID builds no device (the unit is out of range), and
+// pkg/routing/xfrm.go skips exactly those. An advisory that warned here would
+// describe a plaintext path that does not exist — and it is the row that
+// distinguishes the two filters, which is why the deleted one looked plausible.
+func TestAdvisoryPopulationIsTheIfIDPopulation_7090(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		wantDevice bool
+	}{
+		{"st0.0", true},
+		{"st5.1", true},
+		{"st0.65535", false},
+		{"st0.abc", false},
+		{"st65536.0", false},
+		{"ge-0/0/0.0", false},
+	} {
+		_, ifID := XFRMIfNameAndID(tc.name)
+		if got := ifID != 0; got != tc.wantDevice {
+			t.Errorf("XFRMIfNameAndID(%q): builds-a-device = %v, want %v — the advisory's "+
+				"population is exactly this set, so a change here changes which configs "+
+				"are warned about (#7090)", tc.name, got, tc.wantDevice)
+		}
+		if tc.name == "st0.65535" && !IsSecureTunnelIfName("st0") {
+			t.Error("precondition: IsSecureTunnelIfName must ACCEPT st0 here, or this row " +
+				"no longer distinguishes the two filters")
+		}
+	}
+}


### PR DESCRIPTION
Closes #7090

## The branch cannot fire

`warnSecureTunnelPlaintextUnadjudicatedAST` filtered its population twice: on
`XFRMIfNameAndID(bindIface)` returning a non-zero if_id, and again on
`IsSecureTunnelIfName(base)`. The second is **implied** by the first —
`XFRMIfNameAndID` returns non-zero only after `secureTunnelIndex` succeeds on
the base name, and `IsSecureTunnelIfName` *is* `secureTunnelIndex` on that same
base, both splitting on the first `.`.

Swept 2244 generated names (prefix × index × unit, including bad prefixes,
out-of-range indices, negatives, non-numerics, empty and multi-dot): **no input**
produces a non-zero if_id with the predicate false.

## The test binds the implication, not the deleted line

Deleting a branch is safe only while the implication holds, so
`TestNonZeroIfIDImpliesSecureTunnelName_7090` asserts the implication itself: if
`XFRMIfNameAndID` ever gains a path to a non-zero id for a name the predicate
rejects, the advisory's population silently widens and this reds.

Two properties of that test are deliberate:

- **Names are generated, not listed.** The claim is about a space; a hand-picked
  table proves the branch dead for those rows and says nothing about the rest.
- **It asserts non-vacuity.** A sweep in which nothing produced a non-zero id
  would satisfy the implication for free — and would keep satisfying it if
  `XFRMIfNameAndID` were broken to return 0 always.

`TestAdvisoryPopulationIsTheIfIDPopulation_7090` pins the *surviving* filter so
the deletion cannot be "simplified" further. `st0.65535` is the row that matters:
`IsSecureTunnelIfName` accepts the base, `XFRMIfNameAndID` builds no device, and
warning about it would describe a plaintext path that does not exist. It is also
the only place the two filters differ — which is what made the deleted one look
plausible.

## The stale claim was the more dangerous half

Three places said the advisory keys off the SAME predicate as the dataplane
exclusion "so the two cannot drift": the file header, the inline comment, and
`pkg/config/README.md`. Untrue since **#6691 round 5** — the exclusion now runs
`userspaceSkipsIngressInterface` → `userspaceUnbindableNetdev` →
`matchesSecureTunnelClass` → `iface.SecureTunnel`, set by `snapshotSecureTunnel`;
the Rust mirror `is_secure_tunnel_ifname` was deleted in the same round; and
`xfrmi.go` says it outright — `IsSecureTunnelIfName` *"is NOT the ownership test
and no longer gates any dataplane set"*.

The **conclusion** still holds by another route (`pkg/routing/xfrm.go` builds an
xfrmi for exactly `vpn.BindInterface` and skips `ifID == 0`, so the populations
coincide through the shared if_id) — which is why this is not a runtime bug, and
why the stale *reason* is the dangerous part: a later reader relies on the reason
instead of re-deriving it.

The replacement says what the relationship actually is — a **coincidence of
populations, not a mechanical binding** — and names what a real anti-drift guard
would have to be: a test asserting the two populations agree. That cannot live in
`pkg/config`, because `snapshotSecureTunnel` is unexported in
`pkg/dataplane/userspace`; it is named rather than half-built here.

## Validation

- `go test -count=1 ./pkg/config/` — ok (Go instrument; Go-only change)
- `go test -count=1 ./...` — 68 packages ok, 0 failures, 0 `no space left`
- Mutation matrix, full-suite, green control:

| cell | mutation | named failing tests |
|---|---|---|
| CONTROL | none | 0 (green) |
| Q1 | `XFRMIfNameAndID` returns a non-zero id for a name the predicate rejects | `TestNonZeroIfIDImpliesSecureTunnelName_7090` |
| Q2 | an out-of-range unit builds a device | `TestAdvisoryPopulationIsTheIfIDPopulation_7090`, `TestPlaintextWarningSkipsInvalidBindInterface` |

(An earlier pair of these cells came back VOID with build breaks — my mutation
guessed the parameter name. Rerun as Q1b/Q2b after fixing, and both bite.)

No cluster smoke: compiler-side advisory and comments only.
