### PR TITLE
dataplane: run the bpffs cleanups after validation, not before it (#7079)

### DIFF
--- a/docs/log/7079.md
+++ b/docs/log/7079.md
@@ -1,0 +1,111 @@
+# 7079 — bpffs pins removed before validation
+
+## The defect
+
+`CompileConfig` carries the #4960 validate-before-mutate pre-pass. Three host
+mutations ran ahead of it:
+
+| # | mutation | where |
+|---|---|---|
+| 1 | remove every `xdp_*` link pin | first statement of `userspace.Manager.Compile` |
+| 2 | `cleanupUserspaceShimLegacyTCLinks()` | top of `CompileUserspaceShim` |
+| 3 | `cleanupUserspaceShimLegacyOnlyMapPins()` | top of `CompileUserspaceShim` |
+
+So a config the pre-pass REJECTED still left the host with all three removed, for
+an apply that never happened.
+
+## Blast radius — measured, because it decides the shape of the fix
+
+The lead's question was whether this is "move the removal" or "make the removal
+recoverable". It is the first, and the reason is in the code:
+
+- **Forwarding does not drop.** `AttachXDP` keeps the live link in
+  `m.xdpLinks[ifindex]`, so removing the bpffs pin does not detach a running
+  program. A rejected apply never took the dataplane down.
+- **It is self-healing.** `AttachXDP`'s fresh-attach path ends in
+  `l.Pin(pinFile)` (`loader.go:678`), so the next SUCCESSFUL apply re-pins. No
+  restart is needed to recover.
+- **The exposure is a window, not a state.** Between a rejected apply and the
+  next accepted one, an xpfd crash drops the XDP attach entirely instead of the
+  pinned link carrying it across the gap. Also lost in that window is
+  `LoadPinnedLink` reuse, forcing a full detach/attach on the next apply.
+
+Bounded, real, and nowhere near worth an undo mechanism — so the fix moves the
+mutations rather than making them recoverable.
+
+## What the removal was ordered before, and why — the check that mattered
+
+The lead flagged that pin removal ahead of a load is often deliberate. It is, and
+the constraint is real — but it is **narrower than where the code sat**.
+
+The XDP removal's own comment said *"BEFORE CompileUserspaceShim() so AttachXDP
+does a fresh attach"*. `CompileUserspaceShim` is not the constraint; **AttachXDP
+is**, and the attach runs inside `runPostMutationSteps`, below `CompileConfig`.
+The fresh attach is genuinely load-bearing: pinned reuse
+(`existing.Update(prog)`) swaps the program without reinitializing the mlx5 XSK
+RQs, leaving the fill ring unconsumed, which breaks zero-copy.
+
+The two legacy cleanups have no such constraint. They remove pins for kernel
+objects **no program loads after #1476** — `pinnedMaps`' own comment calls them
+stale pins removed "on first boot after upgrade".
+
+And nothing between `CompileConfig` and the new site touches pins:
+`SelectUserspaceXDPShimEntryProgram` picks an entry program, and `CompileConfig`
+runs against `userspaceShimCompileDataplane`, whose dataplane methods are no-ops.
+
+So all three move to immediately after `CompileConfig` succeeds and immediately
+before `runPostMutationSteps`. The XDP removal changes package as well as
+position — into `loader.go`, beside the cleanups it now runs with and in the file
+where `AttachXDP` lives, because "before the attach" is its actual contract.
+
+## Guards — a pair, and the pair is the point
+
+This is a SOURCE-ORDER property. Driving it behaviourally needs a real bpffs, a
+loaded shim, and a config that reaches the pre-pass and is rejected by it. The
+repo already binds this class the same way:
+`TestArmProofIsInvokedFromCompileUserspaceShim` walks this very function for a
+`CallExpr` to assert the arm proof runs after the attach.
+
+- `TestPinCleanupsRunAfterCompileConfig_7079` parses the AST of
+  `CompileUserspaceShim` and requires all three calls to sit between
+  `CompileConfig` and `runPostMutationSteps`. **AST, not string matching**, so a
+  comment naming a cleanup cannot satisfy it — the failure mode a grep-based
+  version would have. Non-vacuity is checked FIRST: a renamed or deleted call
+  would make every ordering assertion pass for free.
+- `TestUserspaceCompileDoesNotRemovePinsBeforeValidation_7079` asserts the
+  removal has not crept BACK into `userspace.Manager.Compile`.
+
+The second is not redundant, and the matrix proves it: a removal re-added at the
+old site leaves the new one in place, so the ordering test stays green while the
+host is again mutated ahead of validation.
+
+## Mutation matrix
+
+`go test ./pkg/dataplane/... ./pkg/refactoraudit/ -count=1 -v`, **2766
+collected** per cell, `enospc=0`, `git diff --stat` non-empty between edit and
+run.
+
+| cell | mutation | rc | named |
+|---|---|---|---|
+| **revert_order** | put the cleanups back above `CompileConfig` | 1 | `TestPinCleanupsRunAfterCompileConfig_7079` — only |
+| **readd_old_site** | re-add an `os.Remove` at the OLD site, leaving the new one | 1 | `TestUserspaceCompileDoesNotRemovePinsBeforeValidation_7079` — only |
+
+Disjoint named sets: each guard covers exactly what the other cannot see.
+
+## A threshold this fix declined to spend
+
+The first draft kept the full blast-radius rationale inline, which pushed
+`loader.go` from 1452 to **1511** LOC and crossed the 1500 `[WATCH]` modularity
+floor — `TestTouchedFileCrossedModularityThreshold` red. Splitting a 1450-line
+file as a rider on an ordering fix is the scope creep the project warns against,
+and recording an accepted crossing for a comment would be worse. The rationale
+moved here instead and the inline note points at it; `loader.go` lands at 1484.
+
+## Validation
+
+- `go build ./...`, `go vet ./...` clean.
+- `go test ./... -count=1`: **rc=0**, `enospc=0`, FAIL count from the whole log.
+- `pkg/refactoraudit` ok — no threshold crossed.
+- Cells above.
+- Go-only change, so the Go suite is the correct instrument; no Rust file is
+  touched.

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -254,13 +254,6 @@ var shimPrePublishLoad = func(m *Manager) error {
 // attaches only the retained userspace XDP shim. This keeps normal AF_XDP
 // startup independent from xdp_main and TC program objects.
 func (m *Manager) CompileUserspaceShim(cfg *config.Config) (*CompileResult, error) {
-	if err := cleanupUserspaceShimLegacyTCLinks(); err != nil {
-		return nil, err
-	}
-	if err := cleanupUserspaceShimLegacyOnlyMapPins(); err != nil {
-		return nil, err
-	}
-
 	m.SelectUserspaceXDPShimEntryProgram()
 	compilerDP := userspaceShimCompileDataplane{Manager: m}
 	result, err := CompileConfig(compilerDP, cfg, m.lastCompile != nil)
@@ -288,6 +281,28 @@ func (m *Manager) CompileUserspaceShim(cfg *config.Config) (*CompileResult, erro
 	// a method value is a SelectorExpr and would silently give that canary
 	// nothing to anchor to. Keeping the call shape keeps the existing guard
 	// intact instead of loosening it to fit this refactor.
+	// #7079: the three bpffs cleanups run HERE — after CompileConfig has accepted
+	// the config, and immediately before the attach they exist for. They used to
+	// run ahead of CompileConfig, so a config the #4960 pre-pass REJECTED still
+	// lost the host's XDP link pins, legacy TC link pins and legacy-only map pins
+	// for an apply that never happened.
+	//
+	// The ordering they must respect is narrower than where they used to sit: the
+	// XDP removal's constraint is "before AttachXDP", not "before
+	// CompileUserspaceShim" as its old comment said. Nothing between CompileConfig
+	// and here touches pins — CompileConfig runs against
+	// userspaceShimCompileDataplane, whose dataplane methods are no-ops.
+	//
+	// Blast radius, and why this MOVES rather than becoming recoverable:
+	// docs/log/7079.md. Bound by TestPinCleanupsRunAfterCompileConfig_7079.
+	if err := cleanupUserspaceShimLegacyTCLinks(); err != nil {
+		return nil, err
+	}
+	if err := cleanupUserspaceShimLegacyOnlyMapPins(); err != nil {
+		return nil, err
+	}
+	removeUserspaceShimXDPLinkPins()
+
 	if err := runPostMutationSteps(result,
 		func(r *CompileResult) error {
 			return m.preflightCheckIfindexCaps(ifindexSet(r.pendingXDP))
@@ -355,6 +370,23 @@ func (m *Manager) attachUserspaceShimXDP(result *CompileResult) error {
 		}
 	}
 	return nil
+}
+
+// removeUserspaceShimXDPLinkPins deletes every `xdp_*` link pin so the attach is
+// a FRESH attach rather than a pinned-link reuse — reuse (`existing.Update`)
+// swaps the program without reinitializing the mlx5 XSK RQs, leaving the fill
+// ring unconsumed, which breaks zero-copy.
+//
+// Relocated here from userspace.Manager.Compile by #7079: it must precede
+// AttachXDP and must NOT precede CompileConfig. Best-effort — a pin already gone
+// is the desired end state, as at the original site.
+func removeUserspaceShimXDPLinkPins() {
+	entries, _ := os.ReadDir(linkPinPath)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "xdp_") {
+			_ = os.Remove(filepath.Join(linkPinPath, e.Name()))
+		}
+	}
 }
 
 type pinnedTCLink interface {

--- a/pkg/dataplane/pin_cleanup_ordering_7079_test.go
+++ b/pkg/dataplane/pin_cleanup_ordering_7079_test.go
@@ -1,0 +1,186 @@
+package dataplane
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// #7079: the bpffs cleanups must run AFTER CompileConfig, not before it.
+//
+// CompileConfig carries the #4960 validate-before-mutate pre-pass. Three host
+// mutations used to run ahead of it — the XDP link pins (from
+// userspace.Manager.Compile) plus the legacy TC link and legacy-only map pin
+// cleanups (from the top of CompileUserspaceShim) — so a config the pre-pass
+// REJECTED still left the host with those pins removed, for an apply that never
+// happened.
+//
+// WHY THIS IS A SOURCE-ORDER ASSERTION RATHER THAN A BEHAVIOURAL ONE. The
+// property is "statement A precedes statement B in this function". Driving it
+// behaviourally means a real bpffs, a loaded shim and a config that reaches the
+// pre-pass and is rejected by it — none of which a unit test has. The repo
+// already binds this class of property this way:
+// TestArmProofIsInvokedFromCompileUserspaceShim walks this very function for a
+// CallExpr and asserts the arm proof runs after the attach, and
+// TestCompileRoutesPublishThroughFailClosedHelper4959 asserts a publish goes
+// through a particular helper.
+//
+// It parses the AST rather than matching strings, so a comment mentioning
+// cleanupUserspaceShimLegacyTCLinks cannot satisfy it — the failure mode a
+// grep-based version of this guard would have.
+func TestPinCleanupsRunAfterCompileConfig_7079(t *testing.T) {
+	const file = "loader.go"
+	fset := token.NewFileSet()
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	parsed, err := parser.ParseFile(fset, file, src, 0) // comments dropped
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var fn *ast.FuncDecl
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		if d, ok := n.(*ast.FuncDecl); ok && d.Name.Name == "CompileUserspaceShim" {
+			fn = d
+		}
+		return fn == nil
+	})
+	if fn == nil {
+		t.Fatalf("CompileUserspaceShim not found in %s — this guard is anchored on a "+
+			"name that no longer exists, which is not evidence of correct ordering", file)
+	}
+
+	// Positions of the calls that matter, by NAME, in source order.
+	pos := map[string]int{}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch f := call.Fun.(type) {
+		case *ast.Ident:
+			name = f.Name
+		case *ast.SelectorExpr:
+			name = f.Sel.Name
+		}
+		if _, seen := pos[name]; !seen && name != "" {
+			pos[name] = fset.Position(call.Pos()).Line
+		}
+		return true
+	})
+
+	compile, ok := pos["CompileConfig"]
+	if !ok {
+		t.Fatal("CompileUserspaceShim no longer calls CompileConfig, so the #4960 " +
+			"pre-pass does not run on this path at all")
+	}
+
+	// Non-vacuity FIRST: absent calls would make every ordering check below pass
+	// for free, which is exactly how this guard would rot if one were renamed.
+	for _, name := range []string{
+		"cleanupUserspaceShimLegacyTCLinks",
+		"cleanupUserspaceShimLegacyOnlyMapPins",
+		"removeUserspaceShimXDPLinkPins",
+		"runPostMutationSteps",
+	} {
+		if _, found := pos[name]; !found {
+			t.Fatalf("%s is not called from CompileUserspaceShim. Either it was renamed "+
+				"— in which case this guard is checking an ordering it can no longer see "+
+				"— or the cleanup was dropped. Calls found: %v", name, keysOf(pos))
+		}
+	}
+
+	attach := pos["runPostMutationSteps"]
+	for _, name := range []string{
+		"cleanupUserspaceShimLegacyTCLinks",
+		"cleanupUserspaceShimLegacyOnlyMapPins",
+		"removeUserspaceShimXDPLinkPins",
+	} {
+		if pos[name] < compile {
+			t.Errorf("%s (line %d) runs BEFORE CompileConfig (line %d). It mutates host "+
+				"bpffs state, so a config the #4960 pre-pass rejects loses those pins for "+
+				"an apply that never happened (#7079)", name, pos[name], compile)
+		}
+		if pos[name] > attach {
+			t.Errorf("%s (line %d) runs AFTER runPostMutationSteps (line %d), which "+
+				"contains the attach. The XDP pin removal exists to force a FRESH attach: "+
+				"pinned reuse (existing.Update) swaps the program without reinitializing "+
+				"the mlx5 XSK RQs, leaving the fill ring unconsumed (#7079)",
+				name, pos[name], attach)
+		}
+	}
+}
+
+func keysOf(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// #7079: the XDP link-pin removal must NOT have crept back into
+// userspace.Manager.Compile, where it ran ahead of the pre-pass.
+//
+// The sibling above pins where it now IS. This pins where it must not be, and
+// the pair matters because a re-added removal at the old site would leave the
+// new one in place — the ordering test would still pass while the host was
+// mutated ahead of validation again.
+func TestUserspaceCompileDoesNotRemovePinsBeforeValidation_7079(t *testing.T) {
+	path := filepath.Join("userspace", "manager_compile.go")
+	fset := token.NewFileSet()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	parsed, err := parser.ParseFile(fset, path, src, 0) // comments dropped
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var fn *ast.FuncDecl
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		if d, ok := n.(*ast.FuncDecl); ok && d.Name.Name == "Compile" && d.Recv != nil {
+			fn = d
+		}
+		return fn == nil
+	})
+	if fn == nil {
+		t.Fatalf("(*Manager).Compile not found in %s", path)
+	}
+
+	var offenders []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, isIdent := sel.X.(*ast.Ident)
+		if !isIdent {
+			return true
+		}
+		if pkg.Name == "os" && (sel.Sel.Name == "Remove" || sel.Sel.Name == "RemoveAll") {
+			offenders = append(offenders,
+				sel.Sel.Name+" at line "+strconv.Itoa(fset.Position(call.Pos()).Line))
+		}
+		return true
+	})
+	if len(offenders) > 0 {
+		t.Errorf("(*Manager).Compile removes host filesystem state before "+
+			"CompileUserspaceShim runs the #4960 pre-pass: %v.\nThat is the #7079 "+
+			"defect — the removal belongs in CompileUserspaceShim after CompileConfig "+
+			"and before the attach, where removeUserspaceShimXDPLinkPins now lives",
+			offenders)
+	}
+}

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -4,9 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -229,20 +226,14 @@ func (m *Manager) SetPolicySchedulerActiveState(activeState map[string]bool) {
 }
 
 func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) {
-	// Delete XDP link pins BEFORE CompileUserspaceShim() so AttachXDP does
-	// a fresh attach. This is critical for zero-copy: fresh attach
-	// triggers mlx5 to initialize XSK buffer pool from fill ring.
-	// Pinned link reuse (l.Update) only swaps the program without
-	// reinitializing XSK RQs, leaving the fill ring unconsumed.
-	if linkPinDir := "/sys/fs/bpf/xpf/links"; true {
-		entries, _ := os.ReadDir(linkPinDir)
-		for _, e := range entries {
-			if strings.HasPrefix(e.Name(), "xdp_") {
-				path := filepath.Join(linkPinDir, e.Name())
-				_ = os.Remove(path)
-			}
-		}
-	}
+	// #7079: the XDP link-pin removal that used to be the first statement of
+	// this function now lives in dataplane.Manager.CompileUserspaceShim, after
+	// CompileConfig has accepted the config and immediately before the attach it
+	// exists for. Here it ran ahead of the #4960 validate-before-mutate
+	// pre-pass, so a config the pre-pass REJECTED still lost the host's pins for
+	// an apply that never happened. Its own comment named
+	// "BEFORE CompileUserspaceShim()" as the requirement, but the real
+	// constraint is "before AttachXDP", and that is satisfied at the new site.
 	caps := deriveUserspaceCapabilities(cfg)
 	// Userspace mode always attaches the retained XDP shim. The shim
 	// redirects to XSK when ctrl=1; when ctrl=0 it only passes proven


### PR DESCRIPTION
Closes #7079

Three host mutations ran ahead of `CompileConfig`, where the #4960
validate-before-mutate pre-pass lives — the XDP link-pin removal at the top of
`userspace.Manager.Compile`, plus the legacy TC-link and legacy-only map-pin
cleanups at the top of `CompileUserspaceShim`. A config the pre-pass **rejected**
still left the host with all three removed, for an apply that never happened.

All three now run after `CompileConfig` succeeds and immediately before
`runPostMutationSteps`, which contains the attach they exist for.

## Blast radius — measured, because it decides the shape of the fix

You asked whether this is "move it" or "make it recoverable". It's the first:

- **Forwarding does not drop.** `AttachXDP` keeps the live link in
  `m.xdpLinks[ifindex]`, so removing the pin does not detach a running program.
- **It is self-healing.** `AttachXDP`'s fresh-attach path ends in
  `l.Pin(pinFile)` (`loader.go:678`), so the next *successful* apply re-pins. No
  restart needed.
- **The exposure is a window, not a state.** Between a rejected apply and the
  next accepted one, an xpfd crash drops the XDP attach instead of the pinned
  link carrying it across.

Bounded, real, nowhere near worth an undo mechanism.

## What the removal was ordered before — the check you flagged

You were right that pin removal ahead of a load is often deliberate. It is here —
**but the constraint is narrower than where the code sat.**

The XDP removal's own comment said *"BEFORE CompileUserspaceShim() so AttachXDP
does a fresh attach"*. `CompileUserspaceShim` is not the constraint; **AttachXDP
is**, and it runs inside `runPostMutationSteps`, below `CompileConfig`. The fresh
attach is genuinely load-bearing — pinned reuse (`existing.Update(prog)`) swaps
the program without reinitializing the mlx5 XSK RQs, leaving the fill ring
unconsumed.

The two legacy cleanups have no such constraint: they remove pins for kernel
objects **no program loads after #1476**, which `pinnedMaps`' own comment calls
stale pins removed "on first boot after upgrade". And nothing between
`CompileConfig` and the new site touches pins — `CompileConfig` runs against
`userspaceShimCompileDataplane`, whose dataplane methods are no-ops.

The XDP removal changes package as well as position, into `loader.go` where
`AttachXDP` lives, because "before the attach" is its real contract.

## Guards — a pair, and the pair is the point

Source-order property, asserted as one: driving it behaviourally needs a real
bpffs, a loaded shim and a config the pre-pass rejects. The repo binds this class
the same way — `TestArmProofIsInvokedFromCompileUserspaceShim` walks this very
function for a `CallExpr`.

- `TestPinCleanupsRunAfterCompileConfig_7079` — **AST, not string matching**, so a
  comment naming a cleanup cannot satisfy it. Non-vacuity checked first: a
  renamed call would make every ordering assertion pass for free.
- `TestUserspaceCompileDoesNotRemovePinsBeforeValidation_7079` — the removal has
  not crept BACK to the old site.

| cell | mutation | rc | named |
|---|---|---|---|
| **revert_order** | cleanups back above `CompileConfig` | 1 | ordering guard — **only** |
| **readd_old_site** | re-add `os.Remove` at the OLD site, leaving the new one | 1 | old-site guard — **only** |

2766 collected per cell, `enospc=0`, disjoint named sets. The second cell is why
the pair exists: a re-added removal leaves the new one in place, so the ordering
test alone stays green while the host is mutated ahead of validation again.

## A threshold this fix declined to spend

Keeping the full rationale inline pushed `loader.go` 1452 → **1511** and crossed
the 1500 `[WATCH]` floor — `TestTouchedFileCrossedModularityThreshold` red.
Splitting a 1450-line file as a rider on an ordering fix is scope creep, and
recording an accepted crossing for a *comment* would be worse. The rationale
moved to `docs/log/7079.md`; `loader.go` lands at **1484**.

## Validation

`go build`/`go vet` clean; `go test ./... -count=1` **rc=0**, `enospc=0`, FAIL
count from the whole log; `pkg/refactoraudit` ok. Go-only change, so the Go suite
is the correct instrument — no Rust file is touched.

**#7091 next.**