### PR TITLE
userspace-dp: delete the dead NAT64 rollback twin and cover the live one (#7094)

### DIFF
--- a/docs/log/7094.md
+++ b/docs/log/7094.md
@@ -1,0 +1,65 @@
+# #7094 — the dead NAT64 rollback twin, and what it was masking
+
+## Timestamp
+2026-08-28
+
+## Action
+Delete `rollback_nat64_allocation` (`#[cfg(test)]`, no caller anywhere) and add
+the two cells its live twin never had.
+
+## Files
+- `userspace-dp/src/nat64.rs` — the deletion; the surviving twin's doc
+- `userspace-dp/src/nat64_tests.rs` — two new cells
+
+## Which is it — dead code, or a missing caller? Both, in that order
+
+**Dead.** All four production call sites use
+`rollback_nat64_allocation_for_worker`; no test called the untracked variant
+either; `cargo check --tests --bins` warned. Deleting does not weaken the #6211
+F2 guard it belonged to — that guard works by making an untracked call fail the
+non-test build, and an UNDEFINED name fails every profile, which is strictly
+stronger than a name that exists under `cfg(test)`.
+
+**And a missing caller, which is the part the dead twin hid.**
+`rollback_nat64_allocation_for_worker` — install-failure, admission-refusal and
+two ICMP-error-bounce paths — had no test caller at all, while its siblings have
+between 6 and 37. Deleting alone would have closed the warning and left the
+production rollback path untested, with the family still looking covered.
+
+## The first fixture was wrong, and the failure was mine not the code's
+
+The holder cell initially built its two holders with two
+`allocate_source_for_worker` calls for one flow. It FAILED — worker 0's rollback
+freed the reservation — and the reason is that the fixture never created a
+second holder: the live-hit path in `allocator.rs` returns the existing
+translation and gives the port it just claimed back, **without** OR-ing in the
+second worker's bit ("Idempotent re-entry for an already-allocated flow"). With
+one holder, freeing on the first rollback is correct.
+
+`reserve_flow` is where workers 2..N accumulate — `slot.holders |= holder.bit()`,
+commented as exactly that — so an **HA-synced** reservation is the only state in
+which "release only THIS worker's hold" is observable. Rebuilt on
+`reserve_synced_nat64_allocation_for_worker`, the cell passes and R1 reds it.
+
+Worth recording because the tempting move on that red was to weaken the
+assertion; the assertion was right about the property and wrong about the state
+it had built.
+
+## Instrument notes
+- Rust change, so the gate is `cargo test` — a Go run proves nothing here. Run
+  single-threaded (`-- --test-threads=1`) and with a private `CARGO_TARGET_DIR`.
+- The harness first scored R1 as a build break: cargo prints
+  `error: test failed, to rerun ...` for ASSERTION failures too, so a bare
+  `^error` grep calls every red a VOID. It now excludes that line and gates on
+  tests-collected first (4826 collected).
+- The `nat64_7094` name filter reported "0 tests, 2 filtered out" from the tail
+  of the output — the main binary's block, which ran both tests, was further up.
+  Read the target's own result line, not the last one printed.
+
+## Validation
+- `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1` — 4896
+  passed, 0 failed
+- `cargo check --tests --bins` — the `never used` warning for the deleted
+  function is gone
+- `go test -count=1 ./...` — 68 packages ok (unchanged; no Go code touched)
+- 3-cell mutation matrix — see PR body

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -1990,33 +1990,20 @@ pub(crate) fn release_nat64_allocation_for_worker(
 
 /// #4381: roll back a NAT64 forward flow's translated pool port on an
 /// install-failure / admission-refusal / ICMP-error-bounce path, mirroring
-/// `rollback_source_nat_allocation`.
-/// Compile-time completeness guard for #6211 F2: this untracked entry point is
-/// TEST-ONLY, so a production caller that forgot to thread its `worker_id` is a
-/// BUILD FAILURE in the non-test profile rather than a silent single-holder
-/// release of a reservation every worker holds. Production uses the
-/// `_for_worker` twin.
-#[cfg(test)]
-pub(crate) fn rollback_nat64_allocation(
-    nat64: &Nat64State,
-    key: &crate::session::SessionKey,
-    nat: NatDecision,
-    is_reverse: bool,
-    now_ns: u64,
-) {
-    release_nat64_allocation_with_mode(
-        nat64,
-        key,
-        nat,
-        is_reverse,
-        now_ns,
-        true,
-        crate::nat::NatHolder::Untracked,
-    );
-}
-
-/// #6211 F2: roll back THIS worker's hold on a NAT64 reservation. The
-/// holder-aware twin of [`rollback_nat64_allocation`].
+/// `rollback_source_nat_allocation_for_worker`.
+///
+/// #7094: this used to have an `Untracked` twin, kept `#[cfg(test)]` as the
+/// #6211 F2 completeness guard — a production caller that forgot to thread its
+/// `worker_id` would fail the non-test build rather than silently release a
+/// reservation every worker holds. The twin had no caller left, in tests or
+/// anywhere else, and rustc warned. Deleting it does not weaken that guard: an
+/// undefined name is a build failure in every profile, which is strictly
+/// stronger than a name that exists under `cfg(test)`.
+///
+/// The holder argument is the whole point and is bound by
+/// `nat64_7094_rollback_for_worker_frees_only_that_holder`: a rollback releases
+/// only THIS worker's hold, so a reservation several workers share survives
+/// until the last one lets go.
 pub(crate) fn rollback_nat64_allocation_for_worker(
     nat64: &Nat64State,
     key: &crate::session::SessionKey,

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -6667,3 +6667,125 @@ fn nat64_6982_charge_uses_the_allocators_own_capacity_formula() {
     // The values are non-trivial, so the agreement above is not two zeros.
     assert!(nat64_prefix_charge(1).port_capacity > 60_000);
 }
+
+// --- #7094: the NAT64 rollback path's holder semantics --------------------
+//
+// `rollback_nat64_allocation_for_worker` had FOUR production call sites
+// (install-failure, admission-refusal and two ICMP-error-bounce paths) and not
+// one test caller. Its `#[cfg(test)]` `Untracked` twin had no caller either,
+// which is what surfaced as a dead-code warning — and the twin's existence made
+// the family look covered when the path production actually takes was not
+// exercised at all. Deleting the twin without adding this would have closed the
+// warning and left that hole exactly where it was.
+//
+// The property is the one the #6211 F2 guard exists to protect: a rollback
+// releases only THIS worker's hold. Every worker that forwarded the flow holds
+// the same reservation, so a single-holder release would free a `(pool_v4,
+// port)` the siblings are still using — the tuple would then be handed to a
+// fresh flow while the original is live, and the 1:N reverse index mis-demuxes
+// the replies.
+
+#[test]
+fn nat64_7094_rollback_for_worker_frees_only_that_holder() {
+    // MULTI-HOLDER STATE COMES FROM THE SYNCED RESERVE, not from two local
+    // allocations, and that distinction is why the first version of this cell
+    // failed. Two `allocate_source_for_worker` calls for one flow do NOT create
+    // two holders: the live-hit path returns the existing translation and gives
+    // back the port it just claimed WITHOUT OR-ing in the second worker's bit
+    // (allocator.rs, "Idempotent re-entry for an already-allocated flow"). So
+    // that fixture had a single holder, the first rollback freeing it was
+    // CORRECT, and the assertion was wrong rather than the code.
+    //
+    // `reserve_flow` is where workers 2..N land — `slot.holders |= holder.bit()`,
+    // commented as exactly that — so the HA-synced reservation is the state in
+    // which "release only THIS worker's hold" is observable at all.
+    let state = Nat64State::from_snapshots(&[single_addr_prefix()]);
+    let snat = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+    let synced_key = nat64_synced_key("2001:db8::1");
+    let synced = Nat64State::forward_decision(snat, dst_v4, 1024);
+
+    assert!(
+        reserve_synced_nat64_allocation_for_worker(&state, &synced_key, synced, false, 0, 0),
+        "precondition: worker 0 must reserve the synced flow"
+    );
+    assert!(
+        reserve_synced_nat64_allocation_for_worker(&state, &synced_key, synced, false, 0, 1),
+        "precondition: worker 1 must join the SAME reservation — this is the \
+         early-return path that ORs its holder bit in, and without it there is \
+         only one holder and nothing below discriminates"
+    );
+
+    // Worker 0 rolls back. Worker 1 still holds it, so the port stays claimed:
+    // a fresh, unrelated local flow must NOT be handed 1024.
+    rollback_nat64_allocation_for_worker(&state, &synced_key, synced, false, 2, 0);
+    let after_first = state
+        .allocate_source_for_worker(
+            0,
+            crate::ip_proto::PROTO_TCP,
+            "2001:db8::77".parse().unwrap(),
+            dst_v4,
+            6000,
+            443,
+            3,
+            0,
+        )
+        .expect("a fresh flow still allocates");
+    assert_ne!(
+        after_first,
+        (snat, 1024),
+        "worker 0's rollback freed a reservation worker 1 still holds: {:?} was \
+         handed to a fresh flow while the synced one is live. The 1:N reverse \
+         index then mis-demuxes the server's replies — the collision #6211 F2 \
+         exists to prevent (#7094)",
+        after_first
+    );
+
+    // The LAST holder lets go. Now the port must come back to the pool.
+    rollback_nat64_allocation_for_worker(&state, &synced_key, synced, false, 4, 1);
+    assert!(
+        reserve_synced_nat64_allocation_for_worker(&state, &synced_key, synced, false, 5, 0),
+        "after the last holder rolled back, the same tuple must be reservable \
+         again; if this fails the rollback path never frees and the pool leaks a \
+         port per rolled-back synced flow"
+    );
+}
+
+#[test]
+fn nat64_7094_rollback_is_a_noop_on_the_reverse_entry() {
+    // Mirrors nat64_4381_reverse_entry_release_is_noop for the rollback path:
+    // only the FORWARD entry owns the allocation, so a reverse-entry rollback
+    // must not release it. Without this, the is_reverse guard could be deleted
+    // and the test above would still pass — it only ever passes is_reverse=false.
+    let state = Nat64State::from_snapshots(&[single_addr_prefix()]);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+    let c: Ipv6Addr = "2001:db8::2".parse().unwrap();
+    let (snat, pa) = state
+        .allocate_source_for_worker(0, crate::ip_proto::PROTO_TCP, c, dst_v4, 6000, 443, 1, 0)
+        .unwrap();
+    let key = crate::session::SessionKey {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: IpAddr::V6(c),
+        dst_ip: IpAddr::V6("64:ff9b::0808:0808".parse().unwrap()),
+        src_port: 6000,
+        dst_port: 443,
+    };
+    rollback_nat64_allocation_for_worker(
+        &state,
+        &key,
+        Nat64State::forward_decision(snat, dst_v4, pa),
+        true, // is_reverse
+        2,
+        0,
+    );
+    let again = state
+        .allocate_source_for_worker(0, crate::ip_proto::PROTO_TCP, c, dst_v4, 6000, 443, 3, 0)
+        .unwrap();
+    assert_eq!(
+        again,
+        (snat, pa),
+        "a REVERSE-entry rollback released the forward entry's allocation; only \
+         the forward entry owns it"
+    );
+}


### PR DESCRIPTION
Closes #7094

## Which is it — dead code, or a missing caller? **Both**, in that order

**Dead.** All four production sites call `rollback_nat64_allocation_for_worker`;
no test called the untracked twin either; `cargo check --tests --bins` warned.
Deleting does not weaken the #6211 F2 guard the twin belonged to — that guard
works by making an untracked call fail the non-test build, and an **undefined**
name fails *every* profile, which is strictly stronger than a name that exists
under `cfg(test)`.

**And a missing caller — the part the dead twin was hiding.**
`rollback_nat64_allocation_for_worker` (install-failure, admission-refusal, two
ICMP-error-bounce paths) had **no test caller at all**, while its siblings have
between 6 and 37. Deleting alone would have closed the warning and left the
production rollback path untested with the family still looking covered.

So the deliverable is the deletion **plus** the two cells that path never had.

## The first fixture was wrong, and the assertion was not the thing to fix

The holder cell first built its two holders with two `allocate_source_for_worker`
calls on one flow. It failed — worker 0's rollback freed the reservation — and
the tempting read was "found a defect".

It hadn't. The fixture never created a second holder: the live-hit path returns
the existing translation and gives back the port it just claimed **without**
OR-ing in the second worker's bit ("Idempotent re-entry for an already-allocated
flow"). With one holder, freeing on the first rollback is correct.

`reserve_flow` is where workers 2..N land — `slot.holders |= holder.bit()`,
commented as exactly that — so an **HA-synced** reservation is the only state in
which "release only THIS worker's hold" is observable at all. Rebuilt on
`reserve_synced_nat64_allocation_for_worker`, and cell R1 confirms it now reds
when the holder check is bypassed.

The second cell pins the `is_reverse` guard, which the first cannot see because
it only ever passes `is_reverse=false`.

## Validation

Rust change, so the gate is the Rust instrument — a Go run proves nothing about
it (`go test ./...` is included only to show nothing else moved).

- `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1` —
  **4896 passed, 0 failed**
- `cargo check --tests --bins` — the `never used` warning for the deleted
  function is gone
- `go test -count=1 ./...` — 68 packages ok, unchanged
- Mutation matrix, full Rust suite, private `CARGO_TARGET_DIR`, green control:

| cell | mutation | named failing tests | collected |
|---|---|---|---|
| CONTROL | none | 0 (green) | 4896 |
| R1 | `rollback_flow` ignores holders (frees unconditionally) | `nat64_7094_rollback_for_worker_frees_only_that_holder` | 4826 |
| R2 | drop the `is_reverse` guard | `nat64_7094_rollback_is_a_noop_on_the_reverse_entry`, `nat64_4381_reverse_entry_release_is_noop` | 4825 |

**A harness note worth passing on:** R1 first scored as a *build break*. Cargo
prints `error: test failed, to rerun ...` for **assertion** failures too, so a
bare `^error` grep calls every red a VOID — and a matrix gated that way reports
"no cells red". The harness now excludes that line and gates on tests-collected
first. Related: a `--name-filter` run reported "0 tests, 2 filtered out" in its
tail while the main binary's block, which ran both tests, was further up; read
the target's own result line, not the last one printed.

No cluster smoke: allocator-internal, no forwarding or HA behaviour change.
