### PR TITLE
zonecounters: name which cause makes per-zone counters unavailable

### DIFF
--- a/docs/log/7087.md
+++ b/docs/log/7087.md
@@ -1,0 +1,57 @@
+# docs/log/7087.md — #7087 (per-zone counter diagnostic fields had no reader)
+
+- **Timestamp**: 2026-08-29
+- **Action**: Read the layout version so the three "not available" causes are
+  named instead of collapsed.
+- **File(s)**: `pkg/zonecounters/zonecounters.go`,
+  `pkg/zonecounters/unavailable_cause_7087_test.go`,
+  `pkg/cli/cli_show_security_zones.go`,
+  `pkg/grpcapi/server_show_zones_text.go`
+
+## The issue's enumeration is partly stale
+
+It says four fields are declared, decoded and read by nothing. Re-measured at
+`origin/master`:
+
+| field | non-test readers |
+|---|---|
+| `ZoneCounterOverflowActive` | **3** — landed since filing |
+| `ZoneCounterLayoutVersion` | 0 |
+| `FloodCounterLayoutVersion` | 0 |
+| `FloodCounterOverflowActive` | 0 |
+
+Three of four still hold. This change takes the zone half.
+
+## The claim the fix disproves
+
+`pkg/zonecounters`' own doc: the three causes are *"genuinely indistinguishable
+at this layer and naming one would be a guess."* True only because the layout
+version had no reader. With it:
+
+- `layoutVersion == 0` — helper predates per-zone accounting. **Known**, and not
+  actionable on this box: it needs a helper upgrade.
+- `overflowActive` — slot table exhausted. **Known** and actionable here.
+- otherwise — a helper that publishes, with room, reporting nothing for this
+  zone: **idle**. Also known.
+
+None is a guess. The generic line survives only for callers that cannot supply a
+version.
+
+## Two decisions worth keeping
+
+**Order.** An old helper publishes no overflow bit either, so the version check
+runs FIRST. Reversed, an upgrade-needed box reports as slot-exhausted — a wrong
+AND actionable diagnosis, worse than an ambiguous one. That row is in the table
+because it is what a later readability-motivated reorder would break.
+
+**The sentinel is not 0.** `0` is meaningful on this wire (absent field =
+pre-#3651 helper), so `LayoutVersionUnknown` is `^uint32(0)`. Had it been 0, a
+caller that merely failed to read a status would render as one reporting an old
+helper — the same conflation this issue is about, reintroduced in the shim.
+`cmd/cli` validates the design: it is dependency-free of `pkg/dataplane` by
+design (#1451), genuinely cannot read a status, and correctly gets the ambiguous
+line.
+
+**Through `dpProbe()`, never the stored `dp` field** (#2114) on the gRPC
+accessor, mirroring its sibling — under the live indirection a field assertion
+answers "capability absent" for a healthy backend.

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -106,7 +106,8 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 				// because with no overflow they remain genuinely ambiguous and
 				// naming one would be a guess.
 				// #6895: one canonical spelling for all three surfaces.
-				fmt.Println(zonecounters.UnavailableLine(zoneCounterOverflowActive(c)))
+				fmt.Println(zonecounters.UnavailableLineFor(
+					zoneCounterLayoutVersion(c), zoneCounterOverflowActive(c)))
 			case errIn == nil && errOut == nil:
 				fmt.Println("  Traffic statistics:")
 				fmt.Printf("    Input:  %d packets, %d bytes\n",
@@ -242,6 +243,24 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 // The status read is per-invocation of `show security zones` and only on the
 // branch that has already decided the zone is unpopulated, so it costs nothing on
 // the healthy path.
+// zoneCounterLayoutVersion reports the helper's per-zone counter layout version,
+// or unknownToCaller when no status could be read.
+//
+// #7087: it returns the SENTINEL rather than 0 on a failed read, because 0 is a
+// meaningful value on this wire — absent field means a pre-#3651 helper. A read
+// failure and an old helper are different states and must not render the same
+// sentence; that conflation is the defect this accessor exists to avoid.
+func zoneCounterLayoutVersion(c *CLI) uint32 {
+	if c == nil {
+		return zonecounters.LayoutVersionUnknown
+	}
+	status, err := c.userspaceDataplaneStatus()
+	if err != nil {
+		return zonecounters.LayoutVersionUnknown
+	}
+	return status.ZoneCounterLayoutVersion
+}
+
 func zoneCounterOverflowActive(c *CLI) bool {
 	if c == nil {
 		return false

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -100,8 +100,8 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 				// this renderer previously had NO #6845 overflow
 				// specialisation, so the same cluster reported slot exhaustion
 				// on the local CLI and the generic three-cause line here.
-				buf.WriteString(zonecounters.UnavailableLine(
-					s.zoneCounterOverflowActive()) + "\n")
+				buf.WriteString(zonecounters.UnavailableLineFor(
+					s.zoneCounterLayoutVersion(), s.zoneCounterOverflowActive()) + "\n")
 			case errIn == nil && errOut == nil:
 				buf.WriteString("  Traffic statistics:\n")
 				fmt.Fprintf(buf, "    Input:  %d packets, %d bytes\n", ingress.Packets, ingress.Bytes)
@@ -351,4 +351,27 @@ func (s *Server) zoneCounterOverflowActive() bool {
 		return false
 	}
 	return status.ZoneCounterOverflowActive
+}
+
+// zoneCounterLayoutVersion mirrors zoneCounterOverflowActive for the layout
+// version, returning the SENTINEL rather than 0 when no status could be read
+// (#7087): 0 means a pre-#3651 helper on this wire, so a read failure must not
+// render as one.
+func (s *Server) zoneCounterLayoutVersion() uint32 {
+	// Through dpProbe(), never the stored dp field — same #2114 reason as the
+	// sibling above: under the live indirection an assertion on the field
+	// answers "capability absent" for a healthy backend, which here would
+	// report LayoutVersionUnknown and render the generic line on a box whose
+	// helper version is perfectly readable.
+	provider, ok := s.dpProbe().(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		return zonecounters.LayoutVersionUnknown
+	}
+	status, err := provider.Status()
+	if err != nil {
+		return zonecounters.LayoutVersionUnknown
+	}
+	return status.ZoneCounterLayoutVersion
 }

--- a/pkg/zonecounters/unavailable_cause_7087_test.go
+++ b/pkg/zonecounters/unavailable_cause_7087_test.go
@@ -1,0 +1,102 @@
+package zonecounters
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7087: the four per-zone counter wire fields had no Go reader, so every
+// "not available" rendering collapsed three distinct causes into one sentence.
+//
+// This file's own doc used to say those causes were "genuinely indistinguishable
+// at this layer and naming one would be a guess". That was true only because the
+// layout version was never read. It carries the answer, and with it all three
+// causes are KNOWN — none is a guess.
+//
+// The table is total over the (layoutVersion, overflowActive) product actually
+// reachable, and every row asserts a DISTINCT sentence. Asserting only that the
+// right cause appears would pass against a function that returned the same
+// string for everything and happened to contain every keyword.
+func TestUnavailableLineNamesTheCause_7087(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		layoutVersion uint32
+		overflow      bool
+		wantSubstr    string
+	}{
+		{"old helper, no overflow bit", 0, false, "predates per-zone accounting"},
+		// ORDER GUARD. An old helper publishes no overflow bit either, so if the
+		// overflow check ran first this row would render "slot capacity
+		// EXHAUSTED" — a WRONG and ACTIONABLE diagnosis, which is worse than an
+		// ambiguous one. It is the row most likely to be broken by a later edit
+		// that reorders the switch for readability.
+		{"old helper AND overflow set", 0, true, "predates per-zone accounting"},
+		{"current helper, slots exhausted", 2, true, "EXHAUSTED"},
+		{"current helper, room, nothing recorded", 2, false, "the zone is idle"},
+		// The caller that CANNOT read a status at all — cmd/cli, which is
+		// dependency-free of pkg/dataplane by design. It must get the ambiguous
+		// line, because for it the three causes really are indistinguishable.
+		{"no status readable", LayoutVersionUnknown, false, "helper predates"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UnavailableLineFor(tc.layoutVersion, tc.overflow)
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Errorf("layoutVersion=%d overflow=%v rendered the wrong cause.\n got: %s\nwant substring: %q",
+					tc.layoutVersion, tc.overflow, got, tc.wantSubstr)
+			}
+		})
+	}
+
+	// DISTINCTNESS. The point of the change is that an operator can tell the
+	// causes apart, so the four reachable renderings must be four different
+	// strings. Without this, a refactor that collapsed two arms would satisfy
+	// every row above that happens to share a keyword.
+	seen := map[string]string{}
+	for _, c := range []struct {
+		label string
+		line  string
+	}{
+		{"pre-dating helper", UnavailableLineFor(0, false)},
+		{"overflow", UnavailableLineFor(2, true)},
+		{"idle", UnavailableLineFor(2, false)},
+		{"unknown/no status", UnavailableLineFor(LayoutVersionUnknown, false)},
+	} {
+		if prev, dup := seen[c.line]; dup {
+			t.Errorf("%q and %q render the SAME sentence, so an operator cannot "+
+				"tell them apart — which is the whole of #7087:\n  %s", prev, c.label, c.line)
+		}
+		seen[c.line] = c.label
+	}
+}
+
+// The sentinel must NOT be a value the wire can carry. 0 means "pre-#3651
+// helper"; if LayoutVersionUnknown were 0, a caller that merely failed to read a
+// status would be reported as running an old helper — a confident wrong answer
+// manufactured by the shim, and the exact conflation this issue is about.
+func TestLayoutVersionUnknownIsNotAWireValue_7087(t *testing.T) {
+	if LayoutVersionUnknown == 0 {
+		t.Fatal("LayoutVersionUnknown is 0, which is a MEANINGFUL wire value " +
+			"(absent field = pre-#3651 helper). A caller that could not read a status " +
+			"would then be indistinguishable from one reporting an old helper")
+	}
+	if UnavailableLineFor(LayoutVersionUnknown, false) == UnavailableLineFor(0, false) {
+		t.Error("a caller with NO status renders the same sentence as one reporting a " +
+			"pre-#3651 helper; those are different states and the operator is told the " +
+			"same thing about both")
+	}
+}
+
+// The pre-#7087 entry point must keep compiling and must keep its old meaning
+// for callers that have only the overflow bit — otherwise this change is a
+// silent behaviour edit at every call site that was not updated.
+func TestUnavailableLineDelegatesUnchanged_7087(t *testing.T) {
+	if UnavailableLine(true) != UnavailableLineFor(LayoutVersionUnknown, true) {
+		t.Error("UnavailableLine(true) no longer matches its delegation target")
+	}
+	if !strings.Contains(UnavailableLine(true), "EXHAUSTED") {
+		t.Error("UnavailableLine(true) lost the #6845 overflow specialisation")
+	}
+	if !strings.Contains(UnavailableLine(false), "helper predates") {
+		t.Error("UnavailableLine(false) lost the generic three-cause line")
+	}
+}

--- a/pkg/zonecounters/zonecounters.go
+++ b/pkg/zonecounters/zonecounters.go
@@ -43,6 +43,14 @@ const (
 		"per-zone accounting, the zone exceeded the dataplane's " +
 		"hot-path slot capacity, or the zone is idle)"
 
+	unavailablePreDatingHelper = "  Traffic statistics: not available " +
+		"(the running dataplane helper predates per-zone accounting, so it " +
+		"publishes no per-zone volume at all; upgrade the helper)"
+
+	unavailableIdle = "  Traffic statistics: not available " +
+		"(the helper publishes per-zone volume and has slot capacity for this " +
+		"zone, but has recorded none: the zone is idle)"
+
 	unavailableOverflow = "  Traffic statistics: not available " +
 		"(the dataplane's per-zone hot-path slot capacity is " +
 		"EXHAUSTED, so this zone's traffic is not being counted " +
@@ -60,9 +68,57 @@ const (
 //
 // It carries NO trailing newline, so callers that print a line and callers that
 // assemble a buffer both use it unchanged.
+//
+// Deprecated for new callers: prefer UnavailableLineFor, which also consumes the
+// layout version and can therefore name the pre-#3651-helper cause instead of
+// folding it into the generic line (#7087). Kept so existing callers that have
+// only the overflow bit compile unchanged; it delegates.
 func UnavailableLine(overflowActive bool) string {
-	if overflowActive {
+	return UnavailableLineFor(unknownLayoutVersion, overflowActive)
+}
+
+// unknownLayoutVersion is the sentinel UnavailableLine passes when its caller
+// has no layout version to give. It is deliberately NOT 0: 0 is a MEANINGFUL
+// value on this wire (absent field = pre-#3651 helper), so reusing it would make
+// a caller that simply lacks the datum indistinguishable from one reporting an
+// old helper — the exact conflation #7087 is about, reintroduced in the shim.
+const unknownLayoutVersion = LayoutVersionUnknown
+
+// LayoutVersionUnknown is what a caller passes when it could not read a status
+// at all. Exported because the accessors that feed UnavailableLineFor need to
+// distinguish "no status" from "layout version 0" (a pre-#3651 helper), and
+// those are different sentences.
+const LayoutVersionUnknown = ^uint32(0)
+
+// UnavailableLineFor names WHICH of the three causes applies, when the wire says.
+//
+// #7087: the doc above this file's constants said the three causes are
+// "genuinely indistinguishable at this layer and naming one would be a guess."
+// That was true only because the layout-version field had no reader. It does
+// carry the answer:
+//
+//	layoutVersion == 0   the helper predates per-zone accounting — KNOWN, and
+//	                     not actionable on this box: it needs a helper upgrade.
+//	overflowActive       the slot table is exhausted — KNOWN and actionable.
+//	otherwise            a helper that publishes, with room, reporting nothing
+//	                     for this zone: the zone is IDLE. Also known.
+//
+// So with both fields all three are distinguishable and none is a guess. The
+// generic line survives only for callers that cannot supply a layout version.
+//
+// Order matters: an old helper publishes no overflow bit either, so the version
+// check must come first or an upgrade-needed box would be reported as
+// slot-exhausted — a wrong AND actionable diagnosis, which is worse than an
+// ambiguous one.
+func UnavailableLineFor(layoutVersion uint32, overflowActive bool) string {
+	switch {
+	case layoutVersion == 0:
+		return unavailablePreDatingHelper
+	case overflowActive:
 		return unavailableOverflow
+	case layoutVersion == unknownLayoutVersion:
+		return unavailableGeneric
+	default:
+		return unavailableIdle
 	}
-	return unavailableGeneric
 }


### PR DESCRIPTION
Closes #7087

## The claim this disproves

`pkg/zonecounters`' own doc says the three "not available" causes are

> genuinely indistinguishable at this layer and naming one would be a guess

**That was true only because `ZoneCounterLayoutVersion` had no Go reader.** It
carries the answer:

| state | cause | known? |
|---|---|---|
| `layoutVersion == 0` | helper predates per-zone accounting | yes — needs a helper upgrade |
| `overflowActive` | slot table exhausted | yes — actionable here |
| otherwise | publishes, has room, recorded nothing → **idle** | yes |

None is a guess. `UnavailableLineFor` renders them distinctly; `UnavailableLine`
delegates unchanged for callers holding only the overflow bit.

## Two decisions that carry the change

**The version check runs FIRST, and that ordering is load-bearing.** An old
helper publishes no overflow bit either, so reversing it reports an
upgrade-needed box as slot-exhausted — a **wrong and actionable** diagnosis,
which is worse than an ambiguous one.

**The sentinel is `^uint32(0)`, not `0`.** `0` is *meaningful* on this wire
(absent field = pre-#3651 helper). Had the sentinel been 0, a caller that merely
failed to read a status would render as one reporting an old helper — the same
conflation this issue is about, reintroduced in the shim. `cmd/cli` validates the
design: dependency-free of `pkg/dataplane` by design (#1451), it genuinely cannot
read a status and correctly gets the ambiguous line.

The gRPC accessor goes through `dpProbe()`, never the stored `dp` field,
mirroring its sibling for the #2114 reason — under the live indirection a field
assertion answers "capability absent" for a healthy backend.

## The issue's enumeration is partly stale

It says four fields have no reader. Re-measured at `origin/master`:
`ZoneCounterOverflowActive` now has **3** readers — that half landed since
filing. The other three hold. **This PR takes the zone half**; the flood half
(`FloodCounterLayoutVersion`, `FloodCounterOverflowActive`) and #7086's
alarm-without-drop gap remain open.

## Mutation matrix

`collected=8`, **0 build errors**, `git diff --stat` non-empty between edit and
run in every cell.

| cell | mutation | FAIL cells | named |
|---|---|---|---|
| M0 | control | 0 | — |
| M1 | reorder — overflow checked before the version | 2 | `.../old_helper_AND_overflow_set` **only** |
| M2 | sentinel becomes `0` | 3 | incl. `TestLayoutVersionUnknownIsNotAWireValue_7087` |
| M3 | collapse idle back into the generic line | 1 | `TestUnavailableLineNamesTheCause_7087` |

**M1 is the cell that matters.** It is a pure readability reorder — the kind of
edit that arrives in an unrelated cleanup — and it reds exactly the row written
for it and nothing else.

The distinctness assertion is separate from the per-row ones on purpose: a
refactor collapsing two arms would satisfy every row that happens to share a
keyword, so the four reachable renderings are asserted to be four different
strings.