### PR TITLE
session: record no ingress identity for a fabric-redirected session

### DIFF
--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2468,6 +2468,12 @@ pub(super) fn poll_binding_process_descriptor(
                                         .policy
                                         .hit_counter_by_idx(policy_result.policy_counter_idx)
                                         .cloned();
+                                    let (stamped_ifindex, stamped_vlan) =
+                                        crate::session::stamped_ingress_identity(
+                                            meta.ingress_ifindex,
+                                            meta.ingress_vlan_id,
+                                            fabric_ingress,
+                                        );
                                     let forward_metadata = SessionMetadata {
                                         ingress_zone: from_zone_id,
                                         egress_zone: to_zone_id,
@@ -2476,8 +2482,15 @@ pub(super) fn poll_binding_process_descriptor(
                                         // tag. Recorded ONCE here and never re-derived from the zone, which is
                                         // the approximation `show/clear security flow session interface <name>`
                                         // is being freed from.
-                                        ingress_ifindex: meta.ingress_ifindex,
-                                        ingress_vlan_id: meta.ingress_vlan_id,
+                                        // #7096: NOT meta.ingress_ifindex directly.
+                                        // A fabric-redirected packet carries the
+                                        // LOCAL fabric member's ifindex while its
+                                        // zone names the PEER's real ingress, and
+                                        // the peer's interface is not knowable here
+                                        // (the fabric stamp carries a zone id and
+                                        // nothing else). See stamped_ingress_identity.
+                                        ingress_ifindex: stamped_ifindex,
+                                        ingress_vlan_id: stamped_vlan,
                                         owner_rg_id,
                                         fabric_ingress,
                                         is_reverse: false,

--- a/userspace-dp/src/session/entry.rs
+++ b/userspace-dp/src/session/entry.rs
@@ -20,6 +20,51 @@ pub(crate) struct SessionDecision {
 /// existing `UserspaceDpMeta.ingress_zone` default at afxdp/types/mod.rs:64).
 /// Removing the `Arc<str>` saves 28 bytes per `SessionMetadata` and
 /// eliminates the `LOCK XADD` atomic on every `metadata.clone()`.
+/// #7096: the `{ingress_ifindex, ingress_vlan_id}` pair a session should be
+/// STAMPED with, given whether its first packet arrived over the HA fabric.
+///
+/// For a fabric-redirected packet the two halves of the ingress record come from
+/// different places and name different interfaces. The ZONE is overridden to the
+/// peer-encoded ORIGINAL ingress zone (`stage_classify_fabric_ingress` →
+/// `zone_pair_ids_for_flow_with_override`), which is correct: the flow logically
+/// arrived on the peer's WAN. But `meta.ingress_ifindex` is whatever the XDP shim
+/// stamped from `ctx->ingress_ifindex`, and NOTHING in production rewrites it —
+/// verified by sweep: every `meta.ingress_ifindex = ...` assignment in the tree
+/// is in a `#[cfg(test)]` fixture. So it is the LOCAL fabric member's netdev.
+///
+/// The peer's real ingress interface is NOT KNOWABLE here, and that is structural
+/// rather than an omission: the fabric stamp carries a u16 zone id and nothing
+/// else — two bytes big-endian in the synthetic fabric MAC
+/// (`parse_zone_encoded_fabric_ingress_from_frame`, #3075). There is no interface
+/// identity on the wire to recover.
+///
+/// So the honest stamp is NONE. Zero means "no ingress identity recorded" and the
+/// Go consumers fall back to the #4792 zone approximation — which is exactly what
+/// they already do for a peer-imported session, and what they do TODAY for this
+/// case by accident. Naming the local fabric member instead would be a
+/// confidently WRONG answer: `show security flow session interface ge-0-0-0`
+/// would select flows that arrived on the peer's WAN, and `interface reth0.50`
+/// would stop selecting them. Being a `clear` filter too, that is a wrong-session
+/// deletion (#6975 / #6987 family).
+///
+/// Why this was latent rather than live, and why that is not a reason to leave
+/// it: `buildSessionEgressIfaces` only keys an interface that has at least one
+/// UNIT, and the shipped wiring gives the fabric member none — it appears only
+/// inside `fab0 { fabric-options { member-interfaces { ge-0/0/0; } } }`. So the
+/// lookup misses and the CLI falls back. The trigger is one config line
+/// (`set interfaces ge-0/0/0 unit 0 ...`). The inertness rested on an operator
+/// not writing it, and nothing in the tree bound that.
+pub(crate) fn stamped_ingress_identity(
+    ingress_ifindex: u32,
+    ingress_vlan_id: u16,
+    fabric_ingress: bool,
+) -> (u32, u16) {
+    if fabric_ingress {
+        return (0, 0);
+    }
+    (ingress_ifindex, ingress_vlan_id)
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct SessionMetadata {
     pub(crate) ingress_zone: u16,

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -8021,3 +8021,76 @@ fn retransmitted_synack_does_not_resurrect_the_forward_half_6752() {
          a handshake that never completed (#6752)",
     );
 }
+
+// ---- #7096: the fabric-redirected ingress identity ----
+
+/// #7096: a fabric-redirected session must record NO ingress identity, not the
+/// LOCAL fabric member's.
+///
+/// The two halves of the ingress record come from different sources for such a
+/// packet: the zone is overridden to the peer's ORIGINAL ingress zone (correct —
+/// the flow logically arrived on the peer's WAN), while `meta.ingress_ifindex`
+/// is still the local fabric member's netdev because nothing in production
+/// rewrites it. Recording that would make
+/// `show security flow session interface ge-0-0-0` select flows that arrived on
+/// the PEER's WAN, and `interface reth0.50` stop selecting them — and the same
+/// filter drives `clear`, so it is a wrong-session deletion.
+#[test]
+fn a_fabric_redirected_session_records_no_ingress_identity_7096() {
+    const LOCAL_FABRIC_MEMBER: u32 = 7;
+    const TAG: u16 = 50;
+
+    let (ifindex, vlan) = stamped_ingress_identity(LOCAL_FABRIC_MEMBER, TAG, true);
+    assert_eq!(
+        (ifindex, vlan),
+        (0, 0),
+        "a fabric-redirected session must record NO ingress identity. The peer's \
+         real ingress interface is not knowable here — the fabric stamp carries a \
+         u16 zone id and nothing else — so naming the local fabric member is a \
+         confidently WRONG answer, which is strictly worse than the zone \
+         approximation the Go side falls back to on zero (#7096)"
+    );
+}
+
+/// THE PAIRED CELL. The suppression must not widen: an ordinary (non-fabric)
+/// session must still record its true ingress identity, which is the whole point
+/// of #4983 and the thing this fix must not undo.
+///
+/// Identical inputs to the cell above; only `fabric_ingress` differs. That is
+/// what makes the pair discriminating rather than two separate demonstrations —
+/// a fix that returned (0, 0) unconditionally would satisfy the first cell and
+/// silently revert #4983.
+#[test]
+fn an_ordinary_session_still_records_its_true_ingress_identity_7096() {
+    const LOCAL_FABRIC_MEMBER: u32 = 7;
+    const TAG: u16 = 50;
+
+    let (ifindex, vlan) = stamped_ingress_identity(LOCAL_FABRIC_MEMBER, TAG, false);
+    assert_eq!(
+        (ifindex, vlan),
+        (LOCAL_FABRIC_MEMBER, TAG),
+        "a session whose first packet did NOT arrive over the fabric must keep its \
+         true {{ifindex, vlan}} identity — zeroing it unconditionally would revert \
+         #4983 and put every session back on the #4792 zone approximation"
+    );
+}
+
+/// #7096: the VLAN half must be cleared with the ifindex, not left behind.
+///
+/// The pair is the logical ingress unit and is meaningful only together — the Go
+/// consumer keys `{parent ifindex, unit VLAN}`. A residual VLAN beside a zeroed
+/// ifindex would key `{0, 50}`, which is not "no identity recorded" but a
+/// DIFFERENT identity, and one that could collide with a real interface whose
+/// ifindex resolution failed.
+#[test]
+fn the_fabric_stamp_clears_both_halves_of_the_pair_7096() {
+    for vlan in [0u16, 1, 50, 4094] {
+        let (ifindex, got_vlan) = stamped_ingress_identity(9, vlan, true);
+        assert_eq!(
+            (ifindex, got_vlan),
+            (0, 0),
+            "both halves must clear together for vlan {vlan}; a residual VLAN \
+             beside a zeroed ifindex is a different identity, not an absent one"
+        );
+    }
+}


### PR DESCRIPTION
Closes #7096

Refs #7095 — the wire half is specified at the bottom, with sizing, rather than
folded in. See "Why this is not one PR".

## The defect

For a packet redirected from the HA peer across the fabric, the two halves of the
session's ingress record came from different sources and named different
interfaces:

- the **zone** is overridden to the peer-encoded ORIGINAL ingress zone. Correct —
  the flow logically arrived on the peer's WAN.
- the **#4983 ingress identity** is `meta.ingress_ifindex`, which the XDP shim
  sets from `ctx->ingress_ifindex` and which **nothing in production rewrites**.
  So it is the LOCAL fabric member's netdev.

Verified by predicate rather than spot-check: **every** `meta.ingress_ifindex = `
assignment in `userspace-dp/src/` lands in a `_tests.rs` fixture. Production only
ever makes local `let` bindings from `resolve_ingress_logical_ifindex`.

## Why "record the right interface" is not an available fix

**The fabric stamp carries a u16 zone id and nothing else** — two bytes,
big-endian, in the synthetic fabric MAC (`parse_zone_encoded_fabric_ingress_from_frame`,
#3075). The peer's real ingress interface never crosses the fabric, so it is not
knowable on the receiving node. That is structural, not an omission.

So the honest stamp is **none**. Zero means "no ingress identity recorded" and the
Go consumers fall back to the #4792 zone approximation — which is what they
already do for a peer-imported session, and what they do for this case today by
accident.

Naming the local fabric member is **confidently wrong** rather than approximate:
`show security flow session interface ge-0-0-0` would select flows that arrived on
the peer's WAN, and `interface reth0.50` would stop selecting them. The same
filter drives `clear`, so it is a wrong-session deletion (#6975/#6987 family).

## Latent, and why that is a reason to fix it rather than defer

`buildSessionEgressIfaces` only keys an interface carrying at least one **unit**,
and the shipped wiring gives the fabric member none — it appears only inside
`fab0 { fabric-options { member-interfaces { ge-0/0/0; } } }`. So the lookup
misses and the CLI falls back.

The trigger is **one config line**: `set interfaces ge-0/0/0 unit 0 ...`. The
inertness rested on an operator not writing it, and nothing in the tree bound
that.

## The change

`SessionMetadata` already carried `fabric_ingress`, so the discriminator existed.
The change is a named helper (`stamped_ingress_identity`) carrying the whole
argument in its doc block, plus one gated install site. The host-local install
site is untouched — it hard-codes `fabric_ingress: false`, so it is not reachable
by this class.

## The paired cell is what makes the tests discriminating

| cell | asserts |
|---|---|
| `a_fabric_redirected_session_records_no_ingress_identity_7096` | fabric → `(0, 0)` |
| `an_ordinary_session_still_records_its_true_ingress_identity_7096` | **identical inputs**, only `fabric_ingress` differing → identity preserved |
| `the_fabric_stamp_clears_both_halves_of_the_pair_7096` | ifindex and VLAN clear **together**, over four VLAN values |

The second is load-bearing: a fix returning `(0, 0)` unconditionally would satisfy
the first cell and **silently revert #4983**, putting every session back on the
zone approximation. The third exists because a residual VLAN beside a zeroed
ifindex is a *different* identity, not an absent one — it would key `{0, 50}`
against a consumer that keys `{parent ifindex, unit VLAN}`.

## Why this is not one PR with #7095

I was asked for one PR and am proposing two, having now measured the second half.

#7096 is a recording fix: one helper, one gated call site, three cells. #7095 is a
**cluster wire change** — a new field on the session-sync record, a
cluster-stable identity fold, the Rust import path, a Go consumer resolving the
fold back to a name, and a golden reclassified against the merge target.

Folding a wire change into a recording fix means the wire half gets reviewed as an
afterthought, which is the same argument used for shipping the #7890 disposition
change separately from #7891.

**The #7095 design, settled by this PR's measurement:**

- The identity must be **cluster-stable**, not node-local — an FNV fold of the
  reth-relative name in the manner of `config.StableZoneID` (#3075).
- It rides as a **trailing length-gated field**, mirroring `Generation` (#2170).
  `sync_protocol.go` names this pattern explicitly and warns that widening a
  fixed-offset field in place "would be a wire flag-day". **No
  `SessionSyncWireVersion` bump** — the same reasoning as #2239/#3931.
- **Zero is the unknown sentinel AND the legacy-peer sentinel**, and one encoding
  serves both: an old sender emits no field → absent → 0 → zone fallback, which is
  exactly what a fabric-redirected session must also report. That is why #7096 has
  to land first — it settles that "unknown" is a value the wire must be able to
  carry, not an error.

## Validation

- `cargo build` clean
- `cargo test --bin xpf-userspace-dp -- --test-threads=1 _7096` — **3 passed**,
  under a per-cell `CARGO_TARGET_DIR` in `/var/tmp`
- Merged `origin/master` before pushing (clean, no unmerged paths), per the #7897
  lesson
- Full suite: `cargo test --bin xpf-userspace-dp -- --test-threads=1` — **4772
  collected, 4770 passed, 0 failed, 2 ignored**, 0 ENOSPC
  ([comment](https://github.com/psaab/xpf/pull/7908#issuecomment-5460438963);
  the first launch of it silently never ran — see the correction there)
