### PR TITLE
Bind the poll loop's mirror sample counter wiring

### DIFF
--- a/docs/log/7091.md
+++ b/docs/log/7091.md
@@ -1,0 +1,70 @@
+# 7091 — bind the poll loop's mirror sample counter wiring
+
+- **Timestamp**: 2026-08-28
+- **Action**: added a source-shape wiring guard for the AF_XDP poll loop's
+  per-binding mirror sample counter
+- **File(s)**:
+  - `userspace-dp/src/afxdp/poll_descriptor/mirror_wiring_7091_tests.rs` (new)
+  - `userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs` (module registration)
+
+## Premise, measured before designing
+
+Replacing `&mut binding.mirror_sample_counter` with `&mut 0u64` at
+`poll_descriptor/mod.rs:337` left the whole suite green:
+
+    premise-fresh-counter: rc=0 collected=4827 named_failures=0 enospc=0
+
+Unbound, confirmed.
+
+## Why the counter matters
+
+`mirror_sample_allows` samples on `current % rate == 0`, reading the counter
+BEFORE incrementing. A counter that is 0 on every call selects EVERY call. Under
+`set forwarding-options port-mirroring ... rate N` that clones every flow-cache-
+served packet to the analyzer instead of one in N — the N-fold clone flood and
+the O(PPS) true-shared CAS on the target's `pending_tx_admitted` that #6114
+removed and #6304 bound one level down.
+
+## Instrument choice: a behavioural cell was tried first and discarded
+
+The counter is only read inside `stage_flow_cache_hit`'s in-place fast path,
+guarded by `is_self_target && owned_packet_frame.is_none()` — the packet must
+egress the binding it arrived on. Driving it needs a hairpin fixture whose route
+returns the flow to its ingress interface, with `binding_lookup` resolving that
+ifindex to the same binding index. `nat_snapshot()`'s LAN-to-WAN shape does not.
+
+The cell built on it drove `txn_run_descriptor` for one seed packet plus three
+flow-cache hits with mirroring configured, and reported the binding's counter at
+0 **on the unmutated tree** (`left: 0, right: 3`). Its own vacuity guard
+(`resolve_mirror_config(&forwarding, 24, 0).is_some()`) passed, so mirroring was
+configured — the miss was the `is_self_target` gate. That fixture cannot produce
+the state it asserts about, and had it been written to pass it would have
+certified the severed wiring as bound.
+
+The existing #6304 cells call `stage_flow_cache_hit` DIRECTLY with an explicit
+`initial_sample_counter`. They bind what the stage does with the counter it is
+handed and, by construction, cannot observe WHICH counter the poll loop hands
+it. That is the gap.
+
+## Mutation matrix — full suite, no `-run` filter, `--test-threads=1`
+
+Verdict discriminates three states: RED needs named `^test ... FAILED` lines
+AND tests-collected > 0; `rc != 0` alone is not a red.
+
+| cell | edit | rc | collected | named | verdict | which assertion fired |
+|------|------|----|-----------|-------|---------|-----------------------|
+| control | none | 0 | 4827 | 0 | GREEN | — (both guards ran, `... ok`) |
+| m1 | `&mut binding.mirror_sample_counter` -> `&mut 0u64` | 101 | 4825 | 2 | RED | "does not pass the BINDING's mirror sample counter" + count found 0 |
+| m2 | second threading site added (partial-revert shape) | 101 | 4826 | 1 | RED | count guard only — wiring guard correctly stayed green |
+| m3 | production renames `stage_flow_cache_hit`, guard not updated | 101 | 4826 | 1 | RED | the NON-VACUITY assertion, `mirror_wiring_7091_tests.rs:62` |
+
+m2 and m3 localise: each reds exactly one guard, and the other stays green for
+the right reason. m3 is the paired vacuity cell — without it, a rename would
+leave the scan looking for nothing and passing forever.
+
+## Docs
+
+No module documentation change. This is a test-only addition: no production
+behaviour, config surface, or operator-visible output changes, and
+`docs/userspace-dataplane-architecture.md` documents port-mirroring only as a
+live-artifact category, not at the sampling-counter level this guard binds.

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -584,3 +584,10 @@ pub(super) fn stage_flow_cache_hit(
 #[cfg(test)]
 #[path = "flow_cache_hit_tests.rs"]
 mod flow_cache_hit_tests;
+
+// #7091: the WIRING guard lives beside the #6304 stage tests it complements —
+// those bind what the stage does with the counter it is HANDED, this binds which
+// counter the poll loop hands it.
+#[cfg(test)]
+#[path = "mirror_wiring_7091_tests.rs"]
+mod mirror_wiring_7091_tests;

--- a/userspace-dp/src/afxdp/poll_descriptor/mirror_wiring_7091_tests.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mirror_wiring_7091_tests.rs
@@ -1,0 +1,114 @@
+// #7091: the poll loop must hand `stage_flow_cache_hit` the BINDING's persistent
+// mirror sample counter, not a fresh one.
+//
+// MEASURED FIRST. Replacing the argument with `&mut 0u64` leaves the entire
+// `userspace-dp` suite green — rc=0, 4827 tests collected, 0 named failures, on
+// an unfiltered `cargo test --release --bins -- --test-threads=1`. The seam is
+// genuinely unbound.
+//
+// WHY THIS IS A SOURCE-SHAPE ASSERTION, stated because a behavioural cell was
+// attempted first and is the better instrument when it is available.
+//
+// The counter is only USED inside `stage_flow_cache_hit`'s in-place fast path,
+// which is guarded by `is_self_target && owned_packet_frame.is_none()` — the
+// packet must egress the SAME binding it arrived on. A driven cell therefore
+// needs a hairpin fixture: a flow whose route sends it back out its ingress
+// interface, with `binding_lookup` resolving that ifindex to the same binding
+// index. `nat_snapshot()`'s LAN->WAN shape does not, and a cell built on it
+// measures nothing: I wrote one, and it reported the binding's counter at 0
+// after three flow-cache hits ON THE UNMUTATED TREE, because the mirror block
+// was never entered. That is a fixture that cannot produce the state it asserts
+// about — the same failure the existing #6304 coverage has one level down.
+//
+// The #6304 cells in `flow_cache_hit_tests.rs` call `stage_flow_cache_hit`
+// DIRECTLY with an explicit `initial_sample_counter`. They bind everything the
+// stage does with the counter it is handed and, by construction, cannot observe
+// WHICH counter the poll loop hands it. That is this file's subject.
+//
+// So this asserts the ARGUMENT at the call site, which is exactly the defect:
+// the identity of the expression passed, not the behaviour of the callee. The
+// repo binds this class the same way — `TestArmProofIsInvokedFromCompileUserspaceShim`
+// walks a function for a `CallExpr`, and the #5103 reth guard asserts a call
+// site's assignment shape.
+//
+// Comments are stripped before matching. A source-scanning guard that reads its
+// own explanatory prose is satisfied by the sentence describing what it should
+// find — and this file names the mutation verbatim, so without stripping it
+// would pass against a severed call site.
+
+use std::path::Path;
+
+/// #7091 fail-on-revert: the mirror sample counter passed into
+/// `stage_flow_cache_hit` must be the BINDING's field.
+#[test]
+fn poll_loop_passes_the_bindings_mirror_sample_counter_7091() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("afxdp")
+        .join("poll_descriptor")
+        .join("mod.rs");
+    let src = std::fs::read_to_string(&path).expect("poll_descriptor/mod.rs must be readable");
+
+    // Strip line comments so this file's own prose, and any doc comment at the
+    // call site, cannot satisfy the assertions below.
+    let code: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // NON-VACUITY, checked first: if the call is gone or renamed, every
+    // assertion below passes for free and this guard is decoration.
+    assert!(
+        code.contains("stage_flow_cache_hit("),
+        "poll_descriptor/mod.rs no longer calls stage_flow_cache_hit — either the \
+         established-flow fast path was restructured, in which case this guard is \
+         scanning for something that no longer exists, or it was removed. Either \
+         way it is not evidence that the counter is threaded (#7091)"
+    );
+
+    assert!(
+        code.contains("&mut binding.mirror_sample_counter"),
+        "the poll loop does not pass the BINDING's mirror sample counter into \
+         stage_flow_cache_hit.\n`mirror_sample_allows` samples on \
+         `current % rate == 0` using the value it is handed BEFORE incrementing, \
+         so a counter that is 0 on every call selects EVERY call. With \
+         `set forwarding-options port-mirroring ... rate N`, every packet served \
+         by the flow cache — most packets of every long-lived flow — is cloned to \
+         the analyzer instead of one in N: the N-fold clone flood and the O(PPS) \
+         true-shared CAS on the target's pending_tx_admitted that #6114 removed \
+         and #6304 bound one level down (#7091)"
+    );
+}
+
+/// #7091 over-reach guard: the counter must be a per-BINDING field, so exactly
+/// one binding's counter is threaded per call site.
+///
+/// Without this, the assertion above is satisfied by a build that ALSO passes a
+/// fresh counter somewhere else on the same path — the shape a partial revert
+/// would leave. It also fails if the argument is duplicated onto a second call
+/// site that a future fast path adds without its own binding state.
+#[test]
+fn the_mirror_sample_counter_has_exactly_one_poll_loop_call_site_7091() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("afxdp")
+        .join("poll_descriptor")
+        .join("mod.rs");
+    let src = std::fs::read_to_string(&path).expect("poll_descriptor/mod.rs must be readable");
+    let code: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let threaded = code.matches("&mut binding.mirror_sample_counter").count();
+    assert_eq!(
+        threaded, 1,
+        "expected exactly ONE site threading the binding's mirror sample counter \
+         through the poll loop, found {threaded}. Zero means the wiring is severed \
+         (see the sibling test); more than one means a second fast path takes it \
+         too, and each such path needs its own reachability argument before this \
+         guard can speak for it (#7091)"
+    );
+}


### PR DESCRIPTION
The AF_XDP poll loop's established-flow fast path passes the binding's
persistent mirror sample counter into `stage_flow_cache_hit`, so port-mirroring
samples one packet in N across the life of a flow. Nothing observed *which*
counter it passed.

## Premise, measured at master before designing

Replacing `&mut binding.mirror_sample_counter` with `&mut 0u64` at
`poll_descriptor/mod.rs:337` left the entire suite green:

```
premise-fresh-counter: rc=0 collected=4827 named_failures=0 enospc=0
```

That mutation is not cosmetic. `mirror_sample_allows` samples on
`current % rate == 0`, reading the counter **before** incrementing it, so a
counter that is 0 on every call selects *every* call. Under
`set forwarding-options port-mirroring ... rate N`, every packet served by the
flow cache — most packets of every long-lived flow — is cloned to the analyzer
instead of one in N: the N-fold clone flood and the O(PPS) true-shared CAS on
the target's `pending_tx_admitted` that #6114 removed and #6304 bound one level
down.

## Why a source-shape assertion

A behavioural cell was written first and discarded, which is the part worth
reviewing.

The counter is only *read* inside `stage_flow_cache_hit`'s in-place fast path,
guarded by `is_self_target && owned_packet_frame.is_none()`: the packet must
egress the binding it arrived on. Driving it needs a hairpin fixture whose route
returns the flow to its ingress interface with `binding_lookup` resolving that
ifindex to the same binding index. `nat_snapshot()`'s LAN→WAN shape does not.

The cell built on it drove `txn_run_descriptor` for a seed packet plus three
flow-cache hits with mirroring configured, and reported the binding's counter at
0 **on the unmutated tree** (`left: 0, right: 3`). Its own vacuity guard
(`resolve_mirror_config(&forwarding, 24, 0).is_some()`) passed, so mirroring
*was* configured — the miss was the `is_self_target` gate. A fixture that cannot
produce the state it asserts about would, had it been written to pass, have
certified the severed wiring as bound.

The existing #6304 cells call `stage_flow_cache_hit` directly with an explicit
`initial_sample_counter`. They bind what the stage does with the counter it is
handed and, by construction, cannot observe which counter the poll loop hands
it. That is this file's subject: the identity of the argument at the call site,
which is precisely the defect. The repo binds this class the same way in
`TestArmProofIsInvokedFromCompileUserspaceShim` and the #5103 reth guard.

Comments are stripped before matching — this file names the mutation verbatim,
so an unstripped scan would be satisfied by its own prose. Non-vacuity is
asserted first, and cell m3 below proves that assertion is load-bearing.

## Mutation matrix

Full suite, no `-run` filter, `--test-threads=1`. RED requires named
`^test ... FAILED` lines **and** tests-collected > 0 — `rc != 0` alone is not a
red.

| cell | edit | rc | collected | named | verdict | which assertion fired |
|------|------|----|-----------|-------|---------|-----------------------|
| control | none | 0 | 4827 | 0 | GREEN | — both guards ran (`... ok`) |
| m1 | `&mut binding.mirror_sample_counter` → `&mut 0u64` | 101 | 4825 | 2 | RED | "does not pass the BINDING's mirror sample counter" + count found 0 |
| m2 | second threading site added (partial-revert shape) | 101 | 4826 | 1 | RED | count guard only; wiring guard correctly stayed green |
| m3 | production renames `stage_flow_cache_hit`, guard not updated | 101 | 4826 | 1 | RED | the **non-vacuity** assertion, `mirror_wiring_7091_tests.rs:62` |

m2 and m3 localise — each reds exactly one guard and leaves the other green for
the right reason. m3 is the paired vacuity cell: without it a rename would leave
the scan looking for nothing and passing forever.

## Docs

No module documentation change. Test-only addition: no production behaviour,
config surface, or operator-visible output changes, and
`docs/userspace-dataplane-architecture.md` covers port-mirroring only as a
live-artifact category, not at the sampling-counter level this binds. Reasoning
recorded in `docs/log/7091.md`.

Closes #7091