### PR TITLE
session sync: carry a cluster-stable ingress-interface identity to the HA peer (#7095)

### DIFF
--- a/docs/log/7095.md
+++ b/docs/log/7095.md
@@ -1,0 +1,80 @@
+# #7095 — carry the #4983 ingress identity to the HA peer
+
+## Timestamp
+2026-08-28
+
+## Action
+Sync a CLUSTER-STABLE ingress-interface identity so the #4983 diagnostic
+survives a failover. Before this, every peer-synced session degraded to the
+#4792 zone approximation — half the sessions on a two-node cluster at all times,
+and all of them immediately after an RG transition.
+
+Design handed over settled by close-6949 (which did the #7096 upstream half);
+implemented as specified, not re-derived.
+
+## What crosses the wire, and what does not
+An ifindex is NODE-LOCAL: node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are the
+same logical RETH member with different numbers, so #6928 synced nothing rather
+than render a confidently wrong name on the peer.
+
+What rides instead is `config.StableIfaceID` over the RETH-RELATIVE name
+(`reth0.50`), which both chassis agree on by construction — zones bind to it and
+`RethToPhysical` resolves it to each node's own member. The RECEIVER turns the
+fold back into its OWN `{ifindex, vlan}` before the helper stores it, so nothing
+node-local ever crosses.
+
+## Files
+- `pkg/config/stable_iface_7095.go` + test — the fold, the name mapping, the
+  reverse lookup
+- `pkg/dataplane/types.go` — `IngressIfaceFold` on both SessionValue structs
+- `pkg/cluster/sync_protocol.go` — two encoders, two decoders
+- `pkg/cluster/sync.go`, `sync_conn_gen.go` — the injected sender resolver
+- `pkg/daemon/ingress_fold_7095.go` — both directions' resolvers
+- `pkg/dataplane/userspace/` — the import resolver, request fields
+- `userspace-dp/src/protocol/control.rs`, `server/helpers/session_sync.rs`
+- `userspace-dp/tests/fixtures/protocol_wire_v1.json` — golden
+- `docs/sync-protocol.md`, `docs/session-sync-architecture.md`
+
+## Zero carries three meanings, deliberately
+A legacy peer emits no field; an interface with no cluster-stable name folds to
+0; a fabric-redirected session records nothing at all, because the fabric stamp
+carries a u16 zone id and nothing else (#7096). All three want the same
+fallback, and one encoding serves them — which is why there is no separate
+"unknown" marker.
+
+An unknown or AMBIGUOUS fold resolves to nothing on the receiving side too. The
+reverse lookup ENUMERATES candidate names and folds them rather than inverting
+the hash, so a collision is visible and returns not-found instead of a coin
+flip.
+
+## Four things the suite caught that review would not
+
+1. **Spelling.** Config carries `ge-0/0/1`, anything derived from an ifindex
+   carries `ge-0-0-1`. Comparing them unnormalised does not fail loudly — an
+   unmatched member keeps its own name, so node 0 folds `ge-0-0-1` while node 1
+   folds `ge-7-0-1`, the folds disagree, and every session silently degrades.
+   My first cross-node fixture used one spelling on both sides and could not see
+   it; it now uses the real ones.
+2. **Struct placement.** `Generation` must be the FIRST field past the on-map
+   conntrack layout, asserted by offset. Inserting ahead of it moved that offset.
+3. **Seven truncation constants.** Mixed-version cells cut a payload by a
+   hard-coded width to simulate an old peer; a new trailing field shifts every
+   one. Stale, they do not fail as "short frame" — the cut lands inside the
+   #3301 block and `AppTimeout` decodes as a nonzero leftover.
+4. **The #6949 parity gate.** I added the request fields to `SessionDeltaInfo`
+   as well, which is the Rust→Go direction, where every Go-declared JSON key must
+   be one the Rust producer emits.
+
+## Golden classification (against the MERGE TARGET)
+Merged `origin/master` first, asserted `git ls-files -u` empty, regenerated, then
+diffed against `origin/master`'s copy — not this branch's HEAD, which would be
+additive by construction:
+
+    added=2  removed=0  changed=0
+      + /session_sync_request/ingress_ifindex = 0
+      + /session_sync_request/ingress_vlan_id = 0
+
+## Validation
+- `go test -count=1 ./...` — 69 packages ok, 0 failures
+- `cargo test -- --test-threads=1` — 4904 collected, 0 failed
+- 5-cell mutation matrix, instrument chosen per file type — see PR body

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -61,15 +61,36 @@ metadata carried as length-gated trailing wire fields; none is part of the on-ma
 BPF conntrack ABI (`bpfSessionValue`).
 
 `IngressIfindex` / `IngressVlanID` (#4983 — the interface a session's first
-packet arrived on) are the opposite case on both counts: they ARE part of the
-on-map C conntrack ABI, and they are deliberately NOT synced. An ifindex is
-node-local — node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are different numbers
-for the same logical RETH member — so carrying the originating node's value
-would make `show security flow session interface <name>` name the WRONG
-interface on the importing node, which is worse than approximating. A
-peer-synced session therefore lands in the "no ingress identity carried" (`0`)
-branch — alongside the reverse companion and the host-outbound GRE path — and
-the CLI answers it from the ingress zone, exactly as it did before #4983.
+packet arrived on) are part of the on-map C conntrack ABI, and the IFINDEX
+itself is still never synced. An ifindex is node-local — node 0's `ge-0-0-1` and
+node 1's `ge-7-0-1` are different numbers for the same logical RETH member — so
+carrying the originating node's value would make
+`show security flow session interface <name>` name the WRONG interface on the
+importing node, which is worse than approximating.
+
+**What IS synced, since #7095, is a cluster-stable FOLD of the interface's
+name.** The reth-relative name (`reth0.50`) is byte-identical on both chassis —
+zones bind to it, and `RethToPhysical` resolves it to each node's own member — so
+`config.StableIfaceID` over that name is agreed by construction.
+`IngressIfaceFold` rides as a length-gated trailing u32 (the #2170 pattern, no
+`SessionSyncWireVersion` bump), and the RECEIVER resolves it back to its OWN
+`{ifindex, vlan}` before the helper stores it. Nothing node-local crosses the
+wire; the importing node ends up with its own numbers for the interface the peer
+named. Before #7095 every peer-synced session degraded to the zone
+approximation, which meant half the sessions on a two-node cluster at all times
+and all of them immediately after an RG transition — the diagnostic stopped
+working exactly when it was most needed.
+
+`0` still means "no ingress identity carried", and it now arrives from four
+places that all want the same fallback: the reverse companion, the
+host-outbound GRE path, a legacy peer whose frame stops before the field, and a
+session whose interface has no cluster-stable name — including a
+fabric-redirected one, which records nothing at all because the fabric stamp
+carries a u16 zone id and nothing else (#7096). An UNKNOWN or AMBIGUOUS fold
+resolves to nothing rather than to a device: a fold this node cannot place, or
+one two stable names collide on, falls back to the zone, because naming no
+interface costs an approximation while naming the wrong one is the confidently
+wrong rendering #6928 refused to ship.
 
 That branch does NOT include "a pre-#4983 session" (#6928, corrected): a new
 daemon can never read one. `sessions` / `sessions_v6` are in the shim ABI

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -417,6 +417,34 @@ and therefore cannot host this guard, so no `config_epoch` field is added to
 `TestConfigEpochNoRejectAgainstZeroBaseline5274` in
 `pkg/cluster/sync_config_epoch_5274_test.go`.
 
+## Ingress Interface Identity (#7095)
+
+Every **session** message carries a length-gated trailing `IngressIfaceFold
+uint32` after `RTFlowSessionID`. An old decoder stops before it and reads
+`IngressIfaceFold == 0` (`if off+4 <= len(payload)`); there is no
+`SessionSyncWireVersion` bump, for the same reason #2239/#3931 did not need one.
+
+**It is not an ifindex.** An ifindex is node-local — node 0's `ge-0-0-1` and node
+1's `ge-7-0-1` are the same logical RETH member with different numbers — so
+#6928 synced nothing rather than name the wrong NIC on the peer. What rides the
+wire is `config.StableIfaceID` over the RETH-RELATIVE name (`reth0.50`), which is
+byte-identical on both chassis because zones bind to it and `RethToPhysical`
+resolves it per node. The receiver resolves the fold back to its OWN
+`{ifindex, vlan}` before the helper stores it.
+
+**Zero is the unknown sentinel, and one encoding serves every producer of it:** a
+legacy peer emits no field at all, an interface with no cluster-stable name folds
+to 0, and a fabric-redirected session records no identity because the fabric
+stamp carries a u16 zone id and nothing else (#7096). All three fall back to the
+#4792 zone approximation on display. An unknown or ambiguous fold on the
+receiving side resolves to nothing for the same reason — the zone is honest where
+a guess is not.
+
+Adding this field moved every mixed-version truncation constant in
+`pkg/cluster/*_test.go` by 4 bytes. That is the standing cost of the trailing-field
+pattern: those cells cut a payload back by a hard-coded width to simulate an old
+peer, so each new trailing field has to be added to each count.
+
 ## RT_FLOW Session Id (#5212)
 
 Every **session** message carries a length-gated trailing `RTFlowSessionID

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -777,10 +777,22 @@ type SessionSync struct {
 	peerSnapshotProtocol atomic.Uint32
 	zoneRGMu             sync.RWMutex
 	zoneRGMap            map[uint16]int
-	deleteJournalMu      sync.Mutex
-	deleteJournal        [][]byte
-	deleteJournalCap     int
-	lastPeerRxMono       atomic.Int64 // CLOCK_MONOTONIC nanos of last inbound sync msg (#1792)
+
+	// ingressFoldFn resolves a session's LOCAL ingress identity to the
+	// #7095 cluster-stable fold that rides the sync wire. Injected by the
+	// daemon, which owns the config; pkg/cluster deliberately holds no
+	// config of its own.
+	//
+	// NIL IS THE UNKNOWN CASE, not an error: an unset resolver stamps 0,
+	// which is the same value a legacy peer sends and a fabric-redirected
+	// session records, and the consumer falls back to the zone
+	// approximation for all three. So a node that has not wired it yet
+	// syncs exactly what it synced before #7095.
+	ingressFoldFn    func(ifindex uint32, vlan uint16) uint32
+	deleteJournalMu  sync.Mutex
+	deleteJournal    [][]byte
+	deleteJournalCap int
+	lastPeerRxMono   atomic.Int64 // CLOCK_MONOTONIC nanos of last inbound sync msg (#1792)
 	// peerHeartbeatAckEver latches when the CURRENTLY connected peer proves it
 	// understands syncMsgHeartbeat by replying syncMsgHeartbeatAck. It gates
 	// the two enforcement paths that would otherwise punish a legacy peer that
@@ -1288,6 +1300,35 @@ func (s *SessionSync) SetZoneRGMap(m map[uint16]int) {
 	s.zoneRGMu.Lock()
 	s.zoneRGMap = m
 	s.zoneRGMu.Unlock()
+}
+
+// SetIngressFoldFn wires the #7095 cluster-stable ingress-interface resolver.
+//
+// It is guarded by zoneRGMu because it is read on the send path exactly where
+// the zone map is, and passing nil restores the pre-#7095 behaviour of stamping
+// nothing — which the wire already treats as "unknown".
+func (s *SessionSync) SetIngressFoldFn(fn func(ifindex uint32, vlan uint16) uint32) {
+	s.zoneRGMu.Lock()
+	s.ingressFoldFn = fn
+	s.zoneRGMu.Unlock()
+}
+
+// stampIngressIfaceFold fills in the #7095 wire field from the session's
+// node-local ingress identity, just before it is encoded.
+//
+// It runs on the SEND path only. The fold is computed from THIS node's
+// {ifindex, vlan} against THIS node's config, so the name it folds is the one
+// this node would display — and the peer resolves that same fold to its own
+// device. A session with no local identity (ifindex 0, the #7096
+// fabric-redirected case among them) folds to 0 and stays unknown.
+func (s *SessionSync) stampIngressIfaceFold(ifindex uint32, vlan uint16) uint32 {
+	s.zoneRGMu.Lock()
+	fn := s.ingressFoldFn
+	s.zoneRGMu.Unlock()
+	if fn == nil || ifindex == 0 {
+		return 0
+	}
+	return fn(ifindex, vlan)
 }
 
 // SetRuntime wires the backend-neutral runtime used by SessionSync.

--- a/pkg/cluster/sync_config_epoch_5274_test.go
+++ b/pkg/cluster/sync_config_epoch_5274_test.go
@@ -192,10 +192,11 @@ func TestSessionWireRoundTripConfigEpoch5274V4(t *testing.T) {
 	}
 
 	// Mixed-version: truncate the trailing #5274 config epoch (8 bytes) AND the
-	// #5212 RTFlowSessionID (8 bytes) so the frame ends after PolicyCounterIdx
+	// #5212 RTFlowSessionID (8 bytes) AND the #7095 IngressIfaceFold (4
+	// bytes) so the frame ends after PolicyCounterIdx
 	// (an old peer that stops there). Decode must still succeed with epoch 0 and
 	// the #3301 fields + Generation preserved.
-	legacy := payload[:len(payload)-16]
+	legacy := payload[:len(payload)-20]
 	_, lVal, ok := decodeSessionV4Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -239,10 +240,11 @@ func TestSessionWireRoundTripConfigEpoch5274V6(t *testing.T) {
 	}
 
 	// Mixed-version: truncate the trailing epoch (8 bytes) AND the #5212
-	// RTFlowSessionID (8 bytes) so the frame ends after Nat64SnatV4 (an old peer
+	// RTFlowSessionID (8 bytes) AND the #7095 IngressIfaceFold (4 bytes) so
+	// the frame ends after Nat64SnatV4 (an old peer
 	// stops there). Decode still succeeds with epoch 0 and NAT64 source
 	// preserved.
-	legacy := payload[:len(payload)-16]
+	legacy := payload[:len(payload)-20]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) v6 decode failed")

--- a/pkg/cluster/sync_conn_gen.go
+++ b/pkg/cluster/sync_conn_gen.go
@@ -120,6 +120,11 @@ func (g *fullSetSeqGuard) reset() {
 func (s *SessionSync) stampInstallGenV4(key dataplane.SessionKey, val *dataplane.SessionValue) {
 	g := s.nextInstallGen()
 	val.Generation = g
+	// #7095: stamp the cluster-stable ingress fold on the same pass that
+	// stamps the generation — one place per family, covering both the
+	// incremental and the bulk send paths, which both call this immediately
+	// before encoding.
+	val.IngressIfaceFold = s.stampIngressIfaceFold(val.IngressIfindex, val.IngressVlanID)
 	// #5274: stamp the admitting config epoch = the config-sync generation
 	// (#3931) this node currently holds. A session still present in the local
 	// table when it is queued has survived this node's own config-apply
@@ -165,6 +170,11 @@ func (s *SessionSync) stampInstallGenV4(key dataplane.SessionKey, val *dataplane
 func (s *SessionSync) stampInstallGenV6(key dataplane.SessionKeyV6, val *dataplane.SessionValueV6) {
 	g := s.nextInstallGen()
 	val.Generation = g
+	// #7095: stamp the cluster-stable ingress fold on the same pass that
+	// stamps the generation — one place per family, covering both the
+	// incremental and the bulk send paths, which both call this immediately
+	// before encoding.
+	val.IngressIfaceFold = s.stampIngressIfaceFold(val.IngressIfindex, val.IngressVlanID)
 	// #5274: stamp the admitting config epoch (see stampInstallGenV4).
 	val.ConfigEpoch = s.configGenCounter.Load()
 	s.genSentMu.Lock()

--- a/pkg/cluster/sync_gen_guard_test.go
+++ b/pkg/cluster/sync_gen_guard_test.go
@@ -360,7 +360,7 @@ func TestSessionWireRoundTripPolicyFields3301V4(t *testing.T) {
 	// ConfigEpoch (8 bytes) AND the #5212 RTFlowSessionID (8 bytes) so the frame
 	// ends after Generation (an old peer that stops there). Decode must still
 	// succeed with the new fields at 0 and Generation preserved.
-	legacy := payload[:len(payload)-24]
+	legacy := payload[:len(payload)-28]
 	_, lVal, ok := decodeSessionV4Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -404,9 +404,10 @@ func TestSessionWireRoundTripPolicyFields3301V6(t *testing.T) {
 
 	// Drop the #3301 AppTimeout+PolicyCounterIdx (8 bytes), the #4565 trailing
 	// Nat64SnatV4 (4 bytes), the #5274 ConfigEpoch (8 bytes) AND the #5212
-	// RTFlowSessionID (8 bytes) to simulate a pre-#3301 peer that omits all of
+	// RTFlowSessionID (8 bytes) AND the #7095 IngressIfaceFold (4 bytes) to
+	// simulate a pre-#3301 peer that omits all of
 	// the additive trailing fields.
-	legacy := payload[:len(payload)-28]
+	legacy := payload[:len(payload)-32]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -439,10 +440,10 @@ func TestSessionWireRoundTripNat64SnatV4_4565(t *testing.T) {
 	}
 
 	// Legacy (pre-#4565) peer omits the trailing Nat64SnatV4 (4 bytes) — and,
-	// being older, the #5274 ConfigEpoch (8 bytes) and the #5212 RTFlowSessionID
-	// (8 bytes) too — so truncate all three to reach an after-#3301 frame ->
+	// being older, the #5274 ConfigEpoch (8 bytes), the #5212 RTFlowSessionID
+	// (8 bytes) and the #7095 IngressIfaceFold (4 bytes) too — so truncate all three to reach an after-#3301 frame ->
 	// Nat64SnatV4 all-zero (not NAT64).
-	legacy := payload[:len(payload)-20]
+	legacy := payload[:len(payload)-24]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -486,9 +487,10 @@ func TestCrossVersionShortPayloadDecode(t *testing.T) {
 	full := encodeSessionV4Payload(key, val)
 	// Simulate a pre-#2170 OLD encoder: drop the trailing 32 bytes (the
 	// #2170 generation u64 + the #3301 AppTimeout/PolicyCounterIdx block + the
-	// #5274 ConfigEpoch u64 + the #5212 RTFlowSessionID u64) so the payload ends
+	// #5274 ConfigEpoch u64 + the #5212 RTFlowSessionID u64 + the #7095
+	// IngressIfaceFold u32) so the payload ends
 	// at FibGen.
-	short := full[:len(full)-32]
+	short := full[:len(full)-36]
 	_, dVal, ok := decodeSessionV4Payload(short)
 	if !ok {
 		t.Fatal("short (legacy) payload should still decode")

--- a/pkg/cluster/sync_ingress_fold_7095_test.go
+++ b/pkg/cluster/sync_ingress_fold_7095_test.go
@@ -1,0 +1,129 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// sync_ingress_fold_7095_test.go — #7095.
+//
+// The ingress-identity fold rides the session-sync wire as a TRAILING
+// LENGTH-GATED field — the #2170 Generation pattern that sync_protocol.go names
+// as its own and warns is the alternative to a wire flag-day. These cells bind
+// the two halves of that contract: a new peer round-trips it, and an old peer's
+// shorter payload decodes to 0 with every earlier field intact.
+
+func sessionValue7095(fold uint32) dataplane.SessionValue {
+	return dataplane.SessionValue{
+		State:            2,
+		SessionID:        0x1122334455667788,
+		Created:          11,
+		LastSeen:         22,
+		Timeout:          33,
+		Generation:       44,
+		AppTimeout:       55,
+		PolicyCounterIdx: 66,
+		ConfigEpoch:      77,
+		RTFlowSessionID:  88,
+		IngressZone:      9,
+		IngressIfaceFold: fold,
+	}
+}
+
+func sessionKey7095() dataplane.SessionKey {
+	var k dataplane.SessionKey
+	copy(k.SrcIP[:], []byte{10, 0, 0, 1})
+	copy(k.DstIP[:], []byte{10, 0, 0, 2})
+	k.SrcPort = 1234
+	k.DstPort = 443
+	k.Protocol = 6
+	return k
+}
+
+func TestIngressFoldRoundTripsOnTheWire_7095(t *testing.T) {
+	key := sessionKey7095()
+	const fold = 0xDEADBEEF
+	payload := encodeSessionV4Payload(key, sessionValue7095(fold))
+	_, got, ok := decodeSessionV4Payload(payload)
+	if !ok {
+		t.Fatal("decode failed")
+	}
+	if got.IngressIfaceFold != fold {
+		t.Fatalf("IngressIfaceFold round-tripped as %#x, want %#x", got.IngressIfaceFold, uint32(fold))
+	}
+	// The field is APPENDED, so everything ahead of it must be untouched — a
+	// mis-sized buffer or a slipped offset shows up in these, not in the fold.
+	if got.RTFlowSessionID != 88 || got.ConfigEpoch != 77 || got.Generation != 44 {
+		t.Fatalf("appending the fold disturbed an earlier trailing field: "+
+			"Generation=%d ConfigEpoch=%d RTFlowSessionID=%d",
+			got.Generation, got.ConfigEpoch, got.RTFlowSessionID)
+	}
+}
+
+// TestLegacyPeerPayloadDecodesFoldAsUnknown_7095 is the length-gating half, and
+// the one that matters for a mixed-version cluster.
+//
+// An old sender's payload simply STOPS before this field; truncating a current
+// payload by exactly the field width reproduces that byte-for-byte. The decode
+// must yield 0 — the unknown sentinel — while every field the old sender DID
+// send survives. A decoder that read past the end, or that treated the shorter
+// payload as invalid, would corrupt or drop every session arriving from a peer
+// on the previous release.
+func TestLegacyPeerPayloadDecodesFoldAsUnknown_7095(t *testing.T) {
+	key := sessionKey7095()
+	full := encodeSessionV4Payload(key, sessionValue7095(0xABCD1234))
+	legacy := full[:len(full)-4]
+
+	gotKey, got, ok := decodeSessionV4Payload(legacy)
+	if !ok {
+		t.Fatal("a legacy peer's shorter payload was REJECTED — every session from a " +
+			"peer on the previous release would be dropped (#7095)")
+	}
+	if got.IngressIfaceFold != 0 {
+		t.Fatalf("the absent field decoded as %#x, want 0 (unknown). A non-zero value "+
+			"here names a device the peer never claimed", got.IngressIfaceFold)
+	}
+	if gotKey != key || got.RTFlowSessionID != 88 || got.ConfigEpoch != 77 ||
+		got.Generation != 44 || got.SessionID != 0x1122334455667788 {
+		t.Fatalf("truncation disturbed fields the legacy peer DID send: keyOK=%v "+
+			"Generation=%d ConfigEpoch=%d RTFlowSessionID=%d SessionID=%#x",
+			gotKey == key, got.Generation, got.ConfigEpoch, got.RTFlowSessionID, got.SessionID)
+	}
+}
+
+// TestIngressFoldRoundTripsV6_7095 covers the SEPARATE v6 encoder/decoder pair.
+// Wiring only v4 leaves every IPv6 session degraded after a failover while the
+// v4 cells above stay green.
+func TestIngressFoldRoundTripsV6_7095(t *testing.T) {
+	var key dataplane.SessionKeyV6
+	copy(key.SrcIP[:], []byte{0x20, 0x01, 0x0d, 0xb8})
+	copy(key.DstIP[:], []byte{0x20, 0x01, 0x0d, 0xb9})
+	key.SrcPort = 5000
+	key.DstPort = 443
+	key.Protocol = 6
+	val := dataplane.SessionValueV6{
+		State:            2,
+		SessionID:        7,
+		RTFlowSessionID:  88,
+		ConfigEpoch:      77,
+		IngressIfaceFold: 0x0BADF00D,
+	}
+	payload := encodeSessionV6Payload(key, val)
+	_, got, ok := decodeSessionV6Payload(payload)
+	if !ok {
+		t.Fatal("v6 decode failed")
+	}
+	if got.IngressIfaceFold != 0x0BADF00D {
+		t.Fatalf("v6 fold round-tripped as %#x, want %#x", got.IngressIfaceFold, uint32(0x0BADF00D))
+	}
+	_, shortGot, ok := decodeSessionV6Payload(payload[:len(payload)-4])
+	if !ok || shortGot.IngressIfaceFold != 0 {
+		t.Fatalf("v6 legacy truncation: ok=%v fold=%#x, want ok=true fold=0",
+			ok, shortGot.IngressIfaceFold)
+	}
+	if shortGot.RTFlowSessionID != 88 || shortGot.ConfigEpoch != 77 {
+		t.Fatalf("v6 truncation disturbed earlier fields: ConfigEpoch=%d RTFlowSessionID=%d",
+			shortGot.ConfigEpoch, shortGot.RTFlowSessionID)
+	}
+}

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -97,9 +97,10 @@ func encodeSessionV4Payload(key dataplane.SessionKey, val dataplane.SessionValue
 	valSize := 160
 	// +8 for the #2170 install Generation, +8 for the #3301 trailing
 	// AppTimeout(u32)+PolicyCounterIdx(u32), +8 for the #5274 ConfigEpoch, +8 for
-	// the #5212 RTFlowSessionID. All length-gated: an old decoder stops after the
-	// field it knows and ignores the rest.
-	buf := make([]byte, keySize+valSize+8+8+8+8)
+	// the #5212 RTFlowSessionID, +4 for the #7095 IngressIfaceFold. All
+	// length-gated: an old decoder stops after the field it knows and ignores
+	// the rest.
+	buf := make([]byte, keySize+valSize+8+8+8+8+4)
 	off := 0
 	copy(buf[off:], key.SrcIP[:])
 	off += 4
@@ -203,6 +204,16 @@ func encodeSessionV4Payload(key dataplane.SessionKey, val dataplane.SessionValue
 	// it; absent => 0 (legacy peer / fresh-local-id fallback).
 	binary.LittleEndian.PutUint64(buf[off:], val.RTFlowSessionID)
 	off += 8
+	// #7095: the CLUSTER-STABLE fold of the session's ingress interface name
+	// (length-gated trailing field). The #4983 ingress identity is an
+	// IFINDEX, which is node-local and would name a different NIC on the
+	// importing node, so what rides the wire is a fold of the RETH-RELATIVE
+	// name both chassis agree on. Old decoders stop after RTFlowSessionID and
+	// ignore it; absent => 0, which is also what a session with no
+	// cluster-stable ingress name and a fabric-redirected session (#7096)
+	// send. All three fall back to the #4792 zone approximation.
+	binary.LittleEndian.PutUint32(buf[off:], val.IngressIfaceFold)
+	off += 4
 	return buf[:off]
 }
 func encodeSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) []byte {
@@ -320,6 +331,16 @@ func encodeSessionV6Payload(key dataplane.SessionKeyV6, val dataplane.SessionVal
 	// absent => 0 (legacy peer / fresh-local-id fallback on import).
 	binary.LittleEndian.PutUint64(buf[off:], val.RTFlowSessionID)
 	off += 8
+	// #7095: the CLUSTER-STABLE fold of the session's ingress interface name
+	// (length-gated trailing field). The #4983 ingress identity is an
+	// IFINDEX, which is node-local and would name a different NIC on the
+	// importing node, so what rides the wire is a fold of the RETH-RELATIVE
+	// name both chassis agree on. Old decoders stop after RTFlowSessionID and
+	// ignore it; absent => 0, which is also what a session with no
+	// cluster-stable ingress name and a fabric-redirected session (#7096)
+	// send. All three fall back to the #4792 zone approximation.
+	binary.LittleEndian.PutUint32(buf[off:], val.IngressIfaceFold)
+	off += 4
 	return buf[:off]
 }
 
@@ -494,6 +515,13 @@ func decodeSessionV4Payload(payload []byte) (dataplane.SessionKey, dataplane.Ses
 		val.RTFlowSessionID = binary.LittleEndian.Uint64(payload[off:])
 		off += 8
 	}
+	// #7095: cluster-stable ingress-interface fold (length-gated; absent → 0 =
+	// legacy peer / no stable name / fabric-redirected, all of which fall back
+	// to the zone approximation).
+	if off+4 <= len(payload) {
+		val.IngressIfaceFold = binary.LittleEndian.Uint32(payload[off:])
+		off += 4
+	}
 	return key, val, true
 }
 
@@ -630,6 +658,13 @@ func decodeSessionV6Payload(payload []byte) (dataplane.SessionKeyV6, dataplane.S
 	if off+8 <= len(payload) {
 		val.RTFlowSessionID = binary.LittleEndian.Uint64(payload[off:])
 		off += 8
+	}
+	// #7095: cluster-stable ingress-interface fold (length-gated; absent → 0 =
+	// legacy peer / no stable name / fabric-redirected, all of which fall back
+	// to the zone approximation).
+	if off+4 <= len(payload) {
+		val.IngressIfaceFold = binary.LittleEndian.Uint32(payload[off:])
+		off += 4
 	}
 	return key, val, true
 }

--- a/pkg/cluster/sync_rtflow_session_id_5212_test.go
+++ b/pkg/cluster/sync_rtflow_session_id_5212_test.go
@@ -61,10 +61,11 @@ func TestSessionWireRoundTripRTFlowSessionID5212V4(t *testing.T) {
 			dVal.ConfigEpoch, dVal.Generation, dVal.PolicyCounterIdx)
 	}
 
-	// Mixed-version: truncate the trailing 8-byte #5212 id (an old peer stops
+	// Mixed-version: truncate the trailing 8-byte #5212 id AND the 4-byte
+	// #7095 IngressIfaceFold behind it (an old peer stops
 	// after ConfigEpoch). Decode must still succeed with id 0 and the epoch +
 	// prior fields preserved.
-	legacy := payload[:len(payload)-8]
+	legacy := payload[:len(payload)-12]
 	_, lVal, ok := decodeSessionV4Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -106,9 +107,10 @@ func TestSessionWireRoundTripRTFlowSessionID5212V6(t *testing.T) {
 			dVal.ConfigEpoch, dVal.Nat64SnatV4)
 	}
 
-	// Mixed-version: truncate the trailing 8-byte id (an old peer stops after
+	// Mixed-version: truncate the trailing 8-byte id AND the 4-byte #7095
+	// IngressIfaceFold behind it (an old peer stops after
 	// ConfigEpoch). Decode still succeeds with id 0 and the epoch preserved.
-	legacy := payload[:len(payload)-8]
+	legacy := payload[:len(payload)-12]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) v6 decode failed")

--- a/pkg/config/stable_iface_7095.go
+++ b/pkg/config/stable_iface_7095.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// stable_iface_7095.go — #7095: a CLUSTER-STABLE name for a session's ingress
+// interface, so the #4983 identity can ride the HA session-sync wire.
+//
+// WHY NOT THE IFINDEX. An ifindex is NODE-LOCAL. Node 0's `ge-0-0-1` and node
+// 1's `ge-7-0-1` are the same logical RETH member with different numbers, so
+// shipping the originating node's value renders a confidently WRONG interface
+// name on the importing node — worse than the zone approximation it would
+// replace. #6928 therefore syncs nothing and the peer falls back to the zone.
+//
+// WHAT IS STABLE. The RETH-RELATIVE name is: `docs/ha-cluster-userspace.conf`
+// binds its zones to `reth0.50` / `reth0.80` / `reth1` — byte-identical strings
+// on both nodes — while only the members differ, and RethToPhysical resolves
+// reth to the LOCAL member by node id. So both nodes agree on the name by
+// construction, and each resolves it to its own device. That is what rides the
+// wire, folded to a u32 in the manner of StableZoneID (#3075).
+//
+// ZERO IS "UNKNOWN", AND IT IS ALSO WHAT A LEGACY PEER SENDS. The wire field is
+// length-gated (the #2170 Generation pattern), so an old sender emits nothing,
+// the decoder reads absent, and the value is 0 — the same 0 a fabric-redirected
+// session records deliberately (#7096: the fabric stamp carries a u16 zone id
+// and nothing else, so the peer's real ingress interface is not knowable on the
+// receiving node). One encoding serves both, and the consumer's fallback for
+// both is the #4792 zone approximation. Do NOT add a separate unknown marker.
+
+// StableIfaceID folds a cluster-stable interface name to a non-zero u32.
+//
+// Zero is reserved as the unknown/legacy sentinel, so the fold never returns
+// it: a name that hashes to 0 is mapped to 1. That collision is one extra name
+// sharing bucket 1, which the reverse lookup resolves the same way it resolves
+// any other collision — by comparing candidate names, not by trusting the id.
+func StableIfaceID(name string) uint32 {
+	if name == "" {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	s := h.Sum64()
+	folded := uint32(s) ^ uint32(s>>32)
+	if folded == 0 {
+		return 1
+	}
+	return folded
+}
+
+// ClusterStableIfaceName maps a LOCAL interface name and VLAN id to the name
+// both nodes agree on, or "" when there is none.
+//
+// A member of a RETH becomes its reth-relative form (`ge-0-0-1` -> `reth1`); a
+// non-member keeps its own name, which is stable only if both nodes happen to
+// name it identically. That second case is deliberately included: a
+// single-homed interface with the same name on both nodes (a management or
+// fabric-parent link) is as agreed as a reth is, and excluding it would report
+// "unknown" for a session whose interface both nodes can name.
+//
+// The VLAN suffix is appended when vlan > 0, matching how zones bind units
+// (`reth0.50`). A VID of 0 is not distinguishable from an untagged frame at
+// this layer (see SessionValue.IngressVlanID), so it contributes no suffix.
+func (c *Config) ClusterStableIfaceName(local string, vlan uint16) string {
+	if c == nil || local == "" {
+		return ""
+	}
+	base := local
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	stable := base
+	for reth, member := range c.RethToPhysical() {
+		if member == base {
+			stable = reth
+			break
+		}
+	}
+	if vlan > 0 {
+		return stable + "." + strconv.FormatUint(uint64(vlan), 10)
+	}
+	return stable
+}
+
+// ClusterStableIfaceNames enumerates every cluster-stable name this config can
+// produce, in a deterministic order.
+//
+// It is the candidate set the reverse lookup folds over. Enumerating rather
+// than inverting the hash is what makes a collision harmless: two names folding
+// alike are both candidates, and the caller sees the ambiguity instead of
+// silently getting the wrong one.
+func (c *Config) ClusterStableIfaceNames() []string {
+	if c == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	add := func(n string) {
+		if n != "" {
+			seen[n] = struct{}{}
+		}
+	}
+	rethOf := make(map[string]string)
+	for reth, member := range c.RethToPhysical() {
+		rethOf[member] = reth
+		add(reth)
+	}
+	for name, ifc := range c.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
+		base := name
+		if reth, ok := rethOf[name]; ok {
+			base = reth
+		}
+		add(base)
+		for _, unit := range ifc.Units {
+			if unit != nil && unit.VlanID > 0 {
+				add(base + "." + strconv.FormatUint(uint64(unit.VlanID), 10))
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LocalIfaceForStableID resolves a wire fold back to a LOCAL interface name.
+//
+// It returns ok=false for 0 (unknown / legacy peer) and for an id no local name
+// folds to — a session whose ingress interface this node does not have, which
+// happens when the peer's config is ahead of ours. Both are the same answer to
+// the consumer: fall back to the zone approximation rather than name a device.
+//
+// On a collision it returns ok=false as well, rather than the first match: two
+// names folding alike means this node cannot tell WHICH interface the peer
+// meant, and the zone approximation is honest where a coin flip is not.
+func (c *Config) LocalIfaceForStableID(id uint32) (string, bool) {
+	if c == nil || id == 0 {
+		return "", false
+	}
+	var hit string
+	for _, name := range c.ClusterStableIfaceNames() {
+		if StableIfaceID(name) != id {
+			continue
+		}
+		if hit != "" {
+			return "", false
+		}
+		hit = name
+	}
+	if hit == "" {
+		return "", false
+	}
+	return c.ResolveReth(hit), true
+}

--- a/pkg/config/stable_iface_7095.go
+++ b/pkg/config/stable_iface_7095.go
@@ -72,9 +72,20 @@ func (c *Config) ClusterStableIfaceName(local string, vlan uint16) string {
 	if i := strings.IndexByte(base, '.'); i >= 0 {
 		base = base[:i]
 	}
+	// The caller's name may be either spelling: config carries the Junos form
+	// (`ge-0/0/1`) while the kernel — and therefore anything derived from an
+	// ifindex — carries the Linux one (`ge-0-0-1`). Compare in the Linux form so
+	// both land on the same member.
+	//
+	// Getting this wrong does not fail loudly: an unmatched member keeps its own
+	// name, so node 0 would fold `ge-0-0-1` while node 1 folds `ge-7-0-1`, the
+	// folds would disagree, the peer would resolve nothing, and every session
+	// would silently degrade to the zone approximation — the exact outcome this
+	// change exists to remove, with no error anywhere.
+	baseLinux := LinuxIfName(base)
 	stable := base
 	for reth, member := range c.RethToPhysical() {
-		if member == base {
+		if LinuxIfName(member) == baseLinux {
 			stable = reth
 			break
 		}

--- a/pkg/config/stable_iface_7095_test.go
+++ b/pkg/config/stable_iface_7095_test.go
@@ -1,0 +1,160 @@
+package config
+
+import "testing"
+
+// stable_iface_7095_test.go — #7095.
+//
+// The whole premise of putting an ingress identity on the HA wire is that BOTH
+// NODES AGREE on it. So the cells assert the agreement between two configs that
+// differ exactly as the two chassis do — node id and member slot — rather than
+// pinning either side to a literal. A literal would encode which node I trusted,
+// and the failure this design exists to prevent is precisely one node naming a
+// device the other does not have.
+
+// clusterCfg7095 builds one node's view: the same reth topology, with the member
+// slot and node id that node actually has.
+func clusterCfg7095(nodeID, slot int) *Config {
+	c := &Config{}
+	c.Chassis.Cluster = &ClusterConfig{NodeID: nodeID}
+	c.Interfaces.Interfaces = map[string]*InterfaceConfig{}
+	member := func(name, reth string) {
+		c.Interfaces.Interfaces[name] = &InterfaceConfig{
+			Name:            name,
+			RedundantParent: reth,
+		}
+	}
+	// node 0 uses FPC 0, node 1 uses FPC 7 — the loss-cluster shape.
+	wan := "ge-" + itoa7095(slot) + "-0-2"
+	lan := "ge-" + itoa7095(slot) + "-0-1"
+	member(wan, "reth0")
+	member(lan, "reth1")
+	c.Interfaces.Interfaces["reth0"] = &InterfaceConfig{
+		Name:  "reth0",
+		Units: map[int]*InterfaceUnit{50: {Number: 50, VlanID: 50}, 80: {Number: 80, VlanID: 80}},
+	}
+	c.Interfaces.Interfaces["reth1"] = &InterfaceConfig{
+		Name:  "reth1",
+		Units: map[int]*InterfaceUnit{0: {Number: 0}},
+	}
+	return c
+}
+
+func itoa7095(i int) string { return string(rune('0' + i)) }
+
+// TestStableIfaceNameAgreesAcrossNodes_7095 is the property the wire field
+// depends on: the same logical interface folds to the same id on both chassis,
+// while each node resolves that id to its OWN device.
+func TestStableIfaceNameAgreesAcrossNodes_7095(t *testing.T) {
+	n0 := clusterCfg7095(0, 0)
+	n1 := clusterCfg7095(1, 7)
+
+	for _, tc := range []struct {
+		name       string
+		localOn0   string
+		vlan       uint16
+		wantLocal1 string
+	}{
+		{"reth0_vlan50", "ge-0-0-2", 50, "ge-7-0-2.50"},
+		{"reth0_vlan80", "ge-0-0-2", 80, "ge-7-0-2.80"},
+		{"reth1_untagged", "ge-0-0-1", 0, "ge-7-0-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stable0 := n0.ClusterStableIfaceName(tc.localOn0, tc.vlan)
+			if stable0 == "" {
+				t.Fatal("node 0 produced no cluster-stable name for its own member")
+			}
+			// The same logical interface, named locally on node 1.
+			local1 := "ge-7" + tc.localOn0[len("ge-0"):]
+			stable1 := n1.ClusterStableIfaceName(local1, tc.vlan)
+
+			if stable0 != stable1 {
+				t.Fatalf("the two nodes disagree on the stable name: node0(%q)=%q, "+
+					"node1(%q)=%q. The wire field is only meaningful if this holds — a "+
+					"disagreement means the importing node resolves the id to a different "+
+					"device, which is the confidently-wrong rendering #6928 refused to ship",
+					tc.localOn0, stable0, local1, stable1)
+			}
+			if StableIfaceID(stable0) != StableIfaceID(stable1) {
+				t.Fatalf("names agree (%q) but folds differ: %d vs %d",
+					stable0, StableIfaceID(stable0), StableIfaceID(stable1))
+			}
+
+			// And each node resolves the shared id back to its OWN member.
+			id := StableIfaceID(stable0)
+			got1, ok := n1.LocalIfaceForStableID(id)
+			if !ok {
+				t.Fatalf("node 1 could not resolve the shared id %d back to a local "+
+					"interface; a peer session would fall back to the zone approximation "+
+					"even though node 1 has the device", id)
+			}
+			if got1 != tc.wantLocal1 {
+				t.Fatalf("node 1 resolved the shared id to %q, want %q — resolving to the "+
+					"PEER's device name is the failure mode this design exists to avoid",
+					got1, tc.wantLocal1)
+			}
+			got0, ok := n0.LocalIfaceForStableID(id)
+			if !ok || got0 == got1 {
+				t.Fatalf("node 0 resolved the shared id to %q (ok=%v); it must resolve to "+
+					"its OWN member, which differs from node 1's %q", got0, ok, got1)
+			}
+		})
+	}
+}
+
+// TestStableIfaceZeroIsUnknownAndLegacy_7095 pins the sentinel that carries two
+// meanings on purpose: an absent field (legacy peer) and a session with no
+// knowable ingress interface (#7096's fabric-redirected case) are the same 0,
+// and both resolve to "no name" rather than to a device.
+func TestStableIfaceZeroIsUnknownAndLegacy_7095(t *testing.T) {
+	n0 := clusterCfg7095(0, 0)
+	if got := StableIfaceID(""); got != 0 {
+		t.Fatalf("StableIfaceID(\"\") = %d, want 0 — the empty name is how a caller "+
+			"says 'no identity', and it must land on the same sentinel a legacy peer's "+
+			"absent field does", got)
+	}
+	if name, ok := n0.LocalIfaceForStableID(0); ok || name != "" {
+		t.Fatalf("id 0 resolved to %q (ok=%v); 0 means unknown and must never name a "+
+			"device", name, ok)
+	}
+	// A fold for an interface this node does not have is also "no name", not a
+	// wrong one — the peer's config being ahead of ours is not an error.
+	if name, ok := n0.LocalIfaceForStableID(StableIfaceID("reth9.4000")); ok {
+		t.Fatalf("an unknown-to-this-node interface resolved to %q; it must fall back "+
+			"to the zone approximation instead", name)
+	}
+}
+
+// TestStableIfaceIDNeverReturnsTheSentinel_7095 guards the reservation itself.
+func TestStableIfaceIDNeverReturnsTheSentinel_7095(t *testing.T) {
+	// A broad sweep of plausible names: if any folded to 0 the sentinel would be
+	// ambiguous with a real interface, and that session would silently degrade.
+	var checked int
+	for _, base := range []string{"reth0", "reth1", "reth2", "ge-0-0-0", "ge-7-0-9",
+		"fab0", "fxp0", "em0", "st0", "lo0", "xe-1-2-3"} {
+		for vlan := 0; vlan <= 4095; vlan += 7 {
+			name := base
+			if vlan > 0 {
+				name = base + "." + itoaSlow7095(vlan)
+			}
+			checked++
+			if StableIfaceID(name) == 0 {
+				t.Fatalf("StableIfaceID(%q) == 0, colliding with the unknown sentinel", name)
+			}
+		}
+	}
+	if checked < 1000 {
+		t.Fatalf("only %d names checked; the sweep is too small to say much", checked)
+	}
+}
+
+func itoaSlow7095(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/pkg/config/stable_iface_7095_test.go
+++ b/pkg/config/stable_iface_7095_test.go
@@ -24,8 +24,12 @@ func clusterCfg7095(nodeID, slot int) *Config {
 		}
 	}
 	// node 0 uses FPC 0, node 1 uses FPC 7 — the loss-cluster shape.
-	wan := "ge-" + itoa7095(slot) + "-0-2"
-	lan := "ge-" + itoa7095(slot) + "-0-1"
+	// Config carries the JUNOS spelling; the lookups below use the LINUX one,
+	// which is what an ifindex resolves to. If the two are not normalised the
+	// members never match a reth and both nodes fold their own local name —
+	// silently, since an unmatched name is still a name.
+	wan := "ge-" + itoa7095(slot) + "/0/2"
+	lan := "ge-" + itoa7095(slot) + "/0/1"
 	member(wan, "reth0")
 	member(lan, "reth1")
 	c.Interfaces.Interfaces["reth0"] = &InterfaceConfig{
@@ -54,9 +58,9 @@ func TestStableIfaceNameAgreesAcrossNodes_7095(t *testing.T) {
 		vlan       uint16
 		wantLocal1 string
 	}{
-		{"reth0_vlan50", "ge-0-0-2", 50, "ge-7-0-2.50"},
-		{"reth0_vlan80", "ge-0-0-2", 80, "ge-7-0-2.80"},
-		{"reth1_untagged", "ge-0-0-1", 0, "ge-7-0-1"},
+		{"reth0_vlan50", "ge-0-0-2", 50, "ge-7/0/2.50"},
+		{"reth0_vlan80", "ge-0-0-2", 80, "ge-7/0/2.80"},
+		{"reth1_untagged", "ge-0-0-1", 0, "ge-7/0/1"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stable0 := n0.ClusterStableIfaceName(tc.localOn0, tc.vlan)

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -228,6 +228,14 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 		ss.SetZoneRGMap(buildZoneRGMap(cfg, applyResult.ZoneIDs))
 	}
 
+	// 2.21. #7095: rebuild the cluster-stable ingress-interface resolver the
+	// session-sync sender stamps outgoing sessions with. Rebuilt here rather
+	// than held, because it closes over BOTH the config (reth → local member)
+	// and an ifindex snapshot, and a commit can change either.
+	if ss := d.getSessionSync(); ss != nil {
+		ss.SetIngressFoldFn(buildIngressFoldFn(cfg))
+	}
+
 	// 2.45. #1956 V-4: managed->unmapped teardown MUST run BEFORE
 	// networkd.Apply so its stale-file sweep has nothing to half-clean.
 	// No-op idempotent when nothing transitioned (zero churn on an

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -15,6 +15,7 @@ import (
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 // applyDataplaneAndHACore runs the ordering-entangled dataplane-apply and
@@ -234,6 +235,18 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 	// and an ifindex snapshot, and a commit can change either.
 	if ss := d.getSessionSync(); ss != nil {
 		ss.SetIngressFoldFn(buildIngressFoldFn(cfg))
+	}
+	// And the reverse direction, used when a peer's session is imported: the
+	// fold the peer sent becomes THIS node's ifindex. Both closures share the
+	// same apply-time ifindex snapshot rationale.
+	if rt := d.dataplane(); rt != nil {
+		if adapter, ok := rt.(interface {
+			Manager() *dpuserspace.Manager
+		}); ok {
+			if mgr := adapter.Manager(); mgr != nil {
+				mgr.SetIngressFoldResolver(buildIngressFoldResolver(cfg))
+			}
+		}
 	}
 
 	// 2.45. #1956 V-4: managed->unmapped teardown MUST run BEFORE

--- a/pkg/daemon/ingress_fold_7095.go
+++ b/pkg/daemon/ingress_fold_7095.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"net"
+	"strconv"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -28,6 +30,69 @@ import (
 // the next commit — it degrades, it does not lie. (A RECYCLED ifindex is the
 // one case that could name the wrong device; that is #6987, which predates this
 // change and is tracked separately for the local display path as well.)
+func buildIngressFoldResolver(cfg *config.Config) func(uint32) (uint32, uint16, bool) {
+	if cfg == nil {
+		return nil
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	indexByLinuxName := make(map[string]uint32, len(ifaces))
+	for _, ifc := range ifaces {
+		if ifc.Index > 0 {
+			indexByLinuxName[ifc.Name] = uint32(ifc.Index)
+		}
+	}
+	// Pre-fold this node's own stable names once. The reverse direction runs per
+	// imported session, and a bulk sync imports the peer's whole table.
+	type local struct {
+		ifindex uint32
+		vlan    uint16
+	}
+	byFold := make(map[uint32]local)
+	ambiguous := make(map[uint32]struct{})
+	for _, stable := range cfg.ClusterStableIfaceNames() {
+		fold := config.StableIfaceID(stable)
+		if fold == 0 {
+			continue
+		}
+		localName, ok := cfg.LocalIfaceForStableID(fold)
+		if !ok {
+			// LocalIfaceForStableID already refuses a collision; record it so a
+			// later lookup does not silently take the other name's device.
+			ambiguous[fold] = struct{}{}
+			continue
+		}
+		base, vlan := localName, uint16(0)
+		if i := strings.LastIndexByte(localName, '.'); i >= 0 {
+			if v, err := strconv.ParseUint(localName[i+1:], 10, 16); err == nil {
+				base, vlan = localName[:i], uint16(v)
+			}
+		}
+		idx, ok := indexByLinuxName[config.LinuxIfName(base)]
+		if !ok || idx == 0 {
+			// This node does not currently have the device. Not an error: the
+			// peer may be ahead of us, and the session degrades to the zone.
+			continue
+		}
+		byFold[fold] = local{ifindex: idx, vlan: vlan}
+	}
+	return func(fold uint32) (uint32, uint16, bool) {
+		if fold == 0 {
+			return 0, 0, false
+		}
+		if _, bad := ambiguous[fold]; bad {
+			return 0, 0, false
+		}
+		l, ok := byFold[fold]
+		if !ok {
+			return 0, 0, false
+		}
+		return l.ifindex, l.vlan, true
+	}
+}
+
 func buildIngressFoldFn(cfg *config.Config) func(ifindex uint32, vlan uint16) uint32 {
 	if cfg == nil {
 		return nil

--- a/pkg/daemon/ingress_fold_7095.go
+++ b/pkg/daemon/ingress_fold_7095.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"net"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// ingress_fold_7095.go — #7095: the daemon side of the cluster-stable ingress
+// identity that rides the HA session-sync wire.
+//
+// pkg/cluster deliberately holds no config, so the resolver is built here and
+// injected. It is rebuilt on every config apply, which is also when the ifindex
+// snapshot is taken.
+
+// buildIngressFoldFn returns the resolver SessionSync stamps outgoing sessions
+// with: a session's node-local {ifindex, vlan} to the fold of the interface's
+// CLUSTER-STABLE name.
+//
+// Returns nil when there is nothing to resolve with, and nil is a supported
+// value — SessionSync stamps 0, the unknown sentinel, which is what a legacy
+// peer sends anyway. The failure mode of this whole path is degradation to the
+// #4792 zone approximation, never a wrong interface name.
+//
+// THE IFINDEX SNAPSHOT IS TAKEN ONCE PER APPLY, not per session: the send path
+// walks every session in a bulk sync, and a netlink round trip each would put a
+// syscall on that loop. A NIC that appears after this snapshot folds to 0 until
+// the next commit — it degrades, it does not lie. (A RECYCLED ifindex is the
+// one case that could name the wrong device; that is #6987, which predates this
+// change and is tracked separately for the local display path as well.)
+func buildIngressFoldFn(cfg *config.Config) func(ifindex uint32, vlan uint16) uint32 {
+	if cfg == nil {
+		return nil
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	nameByIndex := make(map[uint32]string, len(ifaces))
+	for _, ifc := range ifaces {
+		if ifc.Index > 0 {
+			nameByIndex[uint32(ifc.Index)] = ifc.Name
+		}
+	}
+	// Pre-fold the names this config can produce so the send path does no
+	// hashing per session — a bulk sync walks the whole table.
+	return func(ifindex uint32, vlan uint16) uint32 {
+		if ifindex == 0 {
+			return 0
+		}
+		name := nameByIndex[ifindex]
+		if name == "" {
+			return 0
+		}
+		return config.StableIfaceID(cfg.ClusterStableIfaceName(name, vlan))
+	}
+}

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -235,6 +235,28 @@ type SessionValue struct {
 	// Also part of the on-map C conntrack ABI.
 	IngressVlanID uint16
 
+	// IngressIfaceFold is the #7095 CLUSTER-STABLE fold of the session's
+	// ingress interface name, carried on the HA session-sync wire so the
+	// #4983 identity survives a failover.
+	//
+	// It exists because IngressIfindex cannot cross the wire: an ifindex is
+	// NODE-LOCAL, so the originating node's value names a different NIC on the
+	// importing node. This is instead a fold of the RETH-RELATIVE name
+	// (config.StableIfaceID over config.ClusterStableIfaceName), which both
+	// chassis agree on by construction and each resolves to its own member.
+	//
+	// ZERO MEANS UNKNOWN, and three different things produce it on purpose:
+	// a legacy peer that sends no field at all (the wire slot is length-gated,
+	// the #2170 Generation pattern), a session whose ingress interface has no
+	// cluster-stable name, and a fabric-redirected session, which records no
+	// ingress identity at all because the fabric stamp carries a u16 zone id
+	// and nothing else (#7096). The consumer's answer to all three is the same:
+	// fall back to the #4792 zone approximation rather than name a device.
+	//
+	// It is HA-wire metadata only and is not part of the on-map C conntrack
+	// ABI.
+	IngressIfaceFold uint32
+
 	// Generation is a per-(sender,key) monotonic install generation used
 	// by the HA session-sync deferred-delete guard (#2170). It is
 	// userspace-sync-only metadata — like the LogFlagUserspace* bits — and
@@ -599,6 +621,18 @@ type SessionValueV6 struct {
 	// (rolling-upgrade safe). A real id is never 0 (the allocator counter starts
 	// at 1), so the sentinel is unambiguous.
 	RTFlowSessionID uint64
+
+	// IngressIfaceFold is the #7095 cluster-stable ingress-interface fold, the
+	// v6 twin of the field on SessionValue. Same contract: a fold of the
+	// RETH-RELATIVE name (node-local ifindexes cannot cross the wire), carried
+	// as a length-gated trailing wire field, and 0 means unknown — legacy peer,
+	// no cluster-stable name, or a fabric-redirected session (#7096) — with the
+	// #4792 zone approximation as the consumer fallback for all three.
+	//
+	// It is a SEPARATE field on a SEPARATE type because v6 sessions travel
+	// through their own encoder and decoder; wiring only the v4 pair leaves
+	// every IPv6 session degraded after a failover.
+	IngressIfaceFold uint32
 }
 
 // ZoneConfig mirrors the C struct zone_config.

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -235,28 +235,6 @@ type SessionValue struct {
 	// Also part of the on-map C conntrack ABI.
 	IngressVlanID uint16
 
-	// IngressIfaceFold is the #7095 CLUSTER-STABLE fold of the session's
-	// ingress interface name, carried on the HA session-sync wire so the
-	// #4983 identity survives a failover.
-	//
-	// It exists because IngressIfindex cannot cross the wire: an ifindex is
-	// NODE-LOCAL, so the originating node's value names a different NIC on the
-	// importing node. This is instead a fold of the RETH-RELATIVE name
-	// (config.StableIfaceID over config.ClusterStableIfaceName), which both
-	// chassis agree on by construction and each resolves to its own member.
-	//
-	// ZERO MEANS UNKNOWN, and three different things produce it on purpose:
-	// a legacy peer that sends no field at all (the wire slot is length-gated,
-	// the #2170 Generation pattern), a session whose ingress interface has no
-	// cluster-stable name, and a fabric-redirected session, which records no
-	// ingress identity at all because the fabric stamp carries a u16 zone id
-	// and nothing else (#7096). The consumer's answer to all three is the same:
-	// fall back to the #4792 zone approximation rather than name a device.
-	//
-	// It is HA-wire metadata only and is not part of the on-map C conntrack
-	// ABI.
-	IngressIfaceFold uint32
-
 	// Generation is a per-(sender,key) monotonic install generation used
 	// by the HA session-sync deferred-delete guard (#2170). It is
 	// userspace-sync-only metadata — like the LogFlagUserspace* bits — and
@@ -332,6 +310,32 @@ type SessionValue struct {
 	// (rolling-upgrade safe). A real id is never 0 (the allocator counter starts
 	// at 1), so the sentinel is unambiguous.
 	RTFlowSessionID uint64
+
+	// IngressIfaceFold is the #7095 CLUSTER-STABLE fold of the session's
+	// ingress interface name, carried on the HA session-sync wire so the
+	// #4983 identity survives a failover.
+	//
+	// It exists because IngressIfindex cannot cross the wire: an ifindex is
+	// NODE-LOCAL, so the originating node's value names a different NIC on the
+	// importing node. This is instead a fold of the RETH-RELATIVE name
+	// (config.StableIfaceID over config.ClusterStableIfaceName), which both
+	// chassis agree on by construction and each resolves to its own member.
+	//
+	// ZERO MEANS UNKNOWN, and three different things produce it on purpose:
+	// a legacy peer that sends no field at all (the wire slot is length-gated,
+	// the #2170 Generation pattern), a session whose ingress interface has no
+	// cluster-stable name, and a fabric-redirected session, which records no
+	// ingress identity at all because the fabric stamp carries a u16 zone id
+	// and nothing else (#7096). The consumer's answer to all three is the same:
+	// fall back to the #4792 zone approximation rather than name a device.
+	//
+	// It is HA-wire metadata only and is not part of the on-map C conntrack
+	// ABI.
+	IngressIfaceFold uint32
+	// PLACEMENT: this sits after RTFlowSessionID, not before Generation.
+	// Generation must be the FIRST field past the on-map conntrack layout —
+	// TestSessionValueCarriesSyncOnlyGeneration asserts that offset exactly —
+	// so every sync-only field added later belongs behind it, not between.
 }
 
 // SessionKeyV6 mirrors the C struct session_key_v6 (5-tuple with 128-bit IPs).
@@ -633,6 +637,11 @@ type SessionValueV6 struct {
 	// through their own encoder and decoder; wiring only the v4 pair leaves
 	// every IPv6 session degraded after a failover.
 	IngressIfaceFold uint32
+	// PLACEMENT: this sits after RTFlowSessionID, not before Generation.
+	// Generation must be the FIRST field past the on-map conntrack layout —
+	// TestSessionValueCarriesSyncOnlyGeneration asserts that offset exactly —
+	// so every sync-only field added later belongs behind it, not between.
+
 }
 
 // ZoneConfig mirrors the C struct zone_config.

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -193,7 +193,13 @@ type Manager struct {
 	// haWatchdogMapWrite. nil-safe at the call site: it defaults to
 	// buildFabricSnapshots when unset (so bare &Manager{} literals still work).
 	fabricSnapshotBuilder func(*config.Config) []FabricSnapshot
-	lastIngressIfaces     []uint32
+
+	// ingressFoldResolver maps a peer's #7095 cluster-stable ingress fold to
+	// this node's own {ifindex, vlan}. Injected by the daemon, which owns both
+	// the config (reth -> local member) and the ifindex snapshot. Nil resolves
+	// nothing, which is the pre-#7095 import behaviour.
+	ingressFoldResolver func(uint32) (uint32, uint16, bool)
+	lastIngressIfaces   []uint32
 	// ingressInventoryAdopted records whether this Manager has reconciled
 	// lastIngressIfaces against the rows actually present in the PINNED
 	// userspace_ingress_ifaces map (#6784). It is false on a freshly

--- a/pkg/dataplane/userspace/manager_sessionsync_request.go
+++ b/pkg/dataplane/userspace/manager_sessionsync_request.go
@@ -29,6 +29,16 @@ func (m *Manager) buildSessionSyncRequestV4(op string, key dataplane.SessionKey,
 		// #919/#922: forward the raw u16 IDs alongside the legacy
 		// strings; the Rust daemon prefers IDs when nonzero.
 		req.IngressZoneID = val.IngressZone
+		// #7095: resolve the peer's cluster-stable ingress fold to THIS node's
+		// ifindex. The sender could not ship its own ifindex — it is node-local
+		// — so it shipped a fold of the reth-relative name both nodes agree on,
+		// and this is where it becomes a local number again. Unresolvable (0, an
+		// unknown fold, or a collision) leaves both fields 0 and the consumer
+		// falls back to the #4792 zone approximation, exactly as before #7095.
+		if ifindex, vlan, ok := m.resolveIngressFold(val.IngressIfaceFold); ok {
+			req.IngressIfindex = int(ifindex)
+			req.IngressVLANID = vlan
+		}
 		req.EgressZoneID = val.EgressZone
 		req.EgressIfindex, req.TXIfindex, req.OwnerRGID = m.sessionSyncEgressLocked(int(val.FibIfindex), val.FibVlanID, req.EgressZone)
 		req.TunnelEndpointID = m.sessionSyncTunnelEndpointIDLocked(req.EgressIfindex)
@@ -105,6 +115,16 @@ func (m *Manager) buildSessionSyncRequestV6(op string, key dataplane.SessionKeyV
 		// #919/#922: forward the raw u16 IDs alongside the legacy
 		// strings; the Rust daemon prefers IDs when nonzero.
 		req.IngressZoneID = val.IngressZone
+		// #7095: resolve the peer's cluster-stable ingress fold to THIS node's
+		// ifindex. The sender could not ship its own ifindex — it is node-local
+		// — so it shipped a fold of the reth-relative name both nodes agree on,
+		// and this is where it becomes a local number again. Unresolvable (0, an
+		// unknown fold, or a collision) leaves both fields 0 and the consumer
+		// falls back to the #4792 zone approximation, exactly as before #7095.
+		if ifindex, vlan, ok := m.resolveIngressFold(val.IngressIfaceFold); ok {
+			req.IngressIfindex = int(ifindex)
+			req.IngressVLANID = vlan
+		}
 		req.EgressZoneID = val.EgressZone
 		req.EgressIfindex, req.TXIfindex, req.OwnerRGID = m.sessionSyncEgressLocked(int(val.FibIfindex), val.FibVlanID, req.EgressZone)
 		req.TunnelEndpointID = m.sessionSyncTunnelEndpointIDLocked(req.EgressIfindex)
@@ -324,4 +344,36 @@ func findUserspaceEgressInterfaceSnapshot(snapshot *ConfigSnapshot, fibIfindex i
 		}
 	}
 	return InterfaceSnapshot{}, false
+}
+
+// resolveIngressFold maps a peer's #7095 cluster-stable ingress fold to this
+// node's own {ifindex, vlan}.
+//
+// The resolver is injected (the daemon owns the config and the ifindex
+// snapshot); an unset one resolves nothing, which is the pre-#7095 behaviour and
+// not an error. Returning ok=false for an unknown or ambiguous fold is
+// deliberate: naming no interface costs the zone approximation, while naming the
+// wrong one is the confidently-wrong rendering #6928 refused to ship.
+func (m *Manager) resolveIngressFold(fold uint32) (uint32, uint16, bool) {
+	if m == nil || fold == 0 {
+		return 0, 0, false
+	}
+	m.mu.Lock()
+	fn := m.ingressFoldResolver
+	m.mu.Unlock()
+	if fn == nil {
+		return 0, 0, false
+	}
+	return fn(fold)
+}
+
+// SetIngressFoldResolver wires the #7095 fold -> local {ifindex, vlan} lookup.
+// Passing nil restores the pre-#7095 behaviour of importing no ingress identity.
+func (m *Manager) SetIngressFoldResolver(fn func(uint32) (uint32, uint16, bool)) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.ingressFoldResolver = fn
+	m.mu.Unlock()
 }

--- a/pkg/dataplane/userspace/protocol_ha.go
+++ b/pkg/dataplane/userspace/protocol_ha.go
@@ -44,8 +44,19 @@ type SessionSyncRequest struct {
 	// prefers the IDs when nonzero and falls back to the legacy
 	// name strings otherwise. Old peers without these fields
 	// continue to work (Rust serde sets the IDs to 0).
-	IngressZoneID    uint16 `json:"ingress_zone_id,omitempty"`
-	EgressZoneID     uint16 `json:"egress_zone_id,omitempty"`
+	IngressZoneID uint16 `json:"ingress_zone_id,omitempty"`
+	EgressZoneID  uint16 `json:"egress_zone_id,omitempty"`
+	// #7095: the LOCAL ingress identity a peer-imported session should carry,
+	// resolved on THIS node from the cluster-stable fold the sender put on the
+	// wire. #6928 deliberately imported 0 because the sender's IFINDEX is
+	// node-local and would name a different NIC here; these are this node's own
+	// numbers for the interface the peer named, so they are safe to store.
+	//
+	// Additive and omitempty, like the zone-id mirrors above: an older helper
+	// decodes them via serde(default) to 0 and keeps the pre-#7095 behaviour of
+	// recording no ingress identity.
+	IngressIfindex   int    `json:"ingress_ifindex,omitempty"`
+	IngressVLANID    uint16 `json:"ingress_vlan_id,omitempty"`
 	OwnerRGID        int    `json:"owner_rg_id,omitempty"`
 	EgressIfindex    int    `json:"egress_ifindex,omitempty"`
 	TXIfindex        int    `json:"tx_ifindex,omitempty"`
@@ -135,8 +146,19 @@ type SessionDeltaInfo struct {
 	// event-stream payload (bytes [21],[22] u8 → u16 here for symmetry
 	// with SessionSyncRequest). The HA delta path prefers these IDs;
 	// the legacy strings stay populated when JSON callers fill them.
-	IngressZoneID    uint16 `json:"ingress_zone_id,omitempty"`
-	EgressZoneID     uint16 `json:"egress_zone_id,omitempty"`
+	IngressZoneID uint16 `json:"ingress_zone_id,omitempty"`
+	EgressZoneID  uint16 `json:"egress_zone_id,omitempty"`
+	// #7095: the LOCAL ingress identity a peer-imported session should carry,
+	// resolved on THIS node from the cluster-stable fold the sender put on the
+	// wire. #6928 deliberately imported 0 because the sender's IFINDEX is
+	// node-local and would name a different NIC here; these are this node's own
+	// numbers for the interface the peer named, so they are safe to store.
+	//
+	// Additive and omitempty, like the zone-id mirrors above: an older helper
+	// decodes them via serde(default) to 0 and keeps the pre-#7095 behaviour of
+	// recording no ingress identity.
+	IngressIfindex   int    `json:"ingress_ifindex,omitempty"`
+	IngressVLANID    uint16 `json:"ingress_vlan_id,omitempty"`
 	OwnerRGID        int    `json:"owner_rg_id,omitempty"`
 	Disposition      string `json:"disposition,omitempty"`
 	Origin           string `json:"origin,omitempty"`

--- a/pkg/dataplane/userspace/protocol_ha.go
+++ b/pkg/dataplane/userspace/protocol_ha.go
@@ -146,19 +146,8 @@ type SessionDeltaInfo struct {
 	// event-stream payload (bytes [21],[22] u8 → u16 here for symmetry
 	// with SessionSyncRequest). The HA delta path prefers these IDs;
 	// the legacy strings stay populated when JSON callers fill them.
-	IngressZoneID uint16 `json:"ingress_zone_id,omitempty"`
-	EgressZoneID  uint16 `json:"egress_zone_id,omitempty"`
-	// #7095: the LOCAL ingress identity a peer-imported session should carry,
-	// resolved on THIS node from the cluster-stable fold the sender put on the
-	// wire. #6928 deliberately imported 0 because the sender's IFINDEX is
-	// node-local and would name a different NIC here; these are this node's own
-	// numbers for the interface the peer named, so they are safe to store.
-	//
-	// Additive and omitempty, like the zone-id mirrors above: an older helper
-	// decodes them via serde(default) to 0 and keeps the pre-#7095 behaviour of
-	// recording no ingress identity.
-	IngressIfindex   int    `json:"ingress_ifindex,omitempty"`
-	IngressVLANID    uint16 `json:"ingress_vlan_id,omitempty"`
+	IngressZoneID    uint16 `json:"ingress_zone_id,omitempty"`
+	EgressZoneID     uint16 `json:"egress_zone_id,omitempty"`
 	OwnerRGID        int    `json:"owner_rg_id,omitempty"`
 	Disposition      string `json:"disposition,omitempty"`
 	Origin           string `json:"origin,omitempty"`

--- a/pkg/dataplane/userspace/session_ingress_fold_import_7095_test.go
+++ b/pkg/dataplane/userspace/session_ingress_fold_import_7095_test.go
@@ -1,0 +1,99 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// session_ingress_fold_import_7095_test.go — #7095, the RECEIVING half.
+//
+// The sender ships a fold of a name both chassis agree on; this side turns it
+// back into a LOCAL {ifindex, vlan} before the helper stores it. The cells below
+// bind that translation and, more importantly, the three ways it must decline.
+//
+// Declining matters more than resolving here. #6928 imported 0 on purpose,
+// because naming the wrong NIC is worse than naming none — so every path that
+// cannot be sure must reach 0, not a guess.
+
+func managerWithFoldResolver7095(fn func(uint32) (uint32, uint16, bool)) *Manager {
+	m := &Manager{}
+	m.SetIngressFoldResolver(fn)
+	return m
+}
+
+func TestImportResolvesFoldToLocalIfindex_7095(t *testing.T) {
+	const fold = 0x51DE51DE
+	m := managerWithFoldResolver7095(func(got uint32) (uint32, uint16, bool) {
+		if got != fold {
+			t.Errorf("resolver called with fold %#x, want %#x", got, fold)
+		}
+		return 42, 50, true
+	})
+	val := &dataplane.SessionValue{IngressIfaceFold: fold}
+	req := m.buildSessionSyncRequestV4("upsert", dataplane.SessionKey{}, val)
+	if req.IngressIfindex != 42 || req.IngressVLANID != 50 {
+		t.Fatalf("import resolved to {ifindex:%d vlan:%d}, want {42 50} — the peer's "+
+			"fold must become THIS node's numbers, which is the whole reason an "+
+			"ifindex is not what crosses the wire (#7095)",
+			req.IngressIfindex, req.IngressVLANID)
+	}
+}
+
+// TestImportDeclinesRatherThanGuesses_7095 covers every path to "no identity".
+// Each is a case where naming a device would be a confident lie.
+func TestImportDeclinesRatherThanGuesses_7095(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		fold     uint32
+		resolver func(uint32) (uint32, uint16, bool)
+	}{
+		{
+			// A legacy peer sends no wire field; it decodes to 0.
+			name: "legacy_peer_absent_field", fold: 0,
+			resolver: func(uint32) (uint32, uint16, bool) { return 9, 9, true },
+		},
+		{
+			// #7096: a fabric-redirected session records no ingress identity,
+			// because the fabric stamp carries a u16 zone id and nothing else —
+			// the peer's real ingress interface is not knowable here at all.
+			name: "fabric_redirected_records_nothing", fold: 0,
+			resolver: func(uint32) (uint32, uint16, bool) { return 9, 9, true },
+		},
+		{
+			// This node does not have the interface the peer named (its config
+			// is ahead of ours), or two stable names collided on one fold.
+			name: "unknown_or_ambiguous_fold", fold: 0x1234,
+			resolver: func(uint32) (uint32, uint16, bool) { return 0, 0, false },
+		},
+		{
+			// No resolver wired yet: the pre-#7095 behaviour, not an error.
+			name: "resolver_unset", fold: 0x1234, resolver: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := managerWithFoldResolver7095(tc.resolver)
+			val := &dataplane.SessionValue{IngressIfaceFold: tc.fold}
+			req := m.buildSessionSyncRequestV4("upsert", dataplane.SessionKey{}, val)
+			if req.IngressIfindex != 0 || req.IngressVLANID != 0 {
+				t.Fatalf("import produced {ifindex:%d vlan:%d} for %s; it must be {0 0}. "+
+					"A non-zero value here names a device on evidence this node does not "+
+					"have, which is the confidently-wrong rendering #6928 refused to ship",
+					req.IngressIfindex, req.IngressVLANID, tc.name)
+			}
+		})
+	}
+}
+
+// TestImportResolvesFoldV6_7095: v6 sessions travel through a SEPARATE request
+// builder. Wiring only v4 leaves every IPv6 session degraded after a failover
+// with the v4 cells still green.
+func TestImportResolvesFoldV6_7095(t *testing.T) {
+	m := managerWithFoldResolver7095(func(uint32) (uint32, uint16, bool) { return 7, 80, true })
+	val := &dataplane.SessionValueV6{IngressIfaceFold: 0xFEED}
+	req := m.buildSessionSyncRequestV6("upsert", dataplane.SessionKeyV6{}, val)
+	if req.IngressIfindex != 7 || req.IngressVLANID != 80 {
+		t.Fatalf("v6 import resolved to {ifindex:%d vlan:%d}, want {7 80}",
+			req.IngressIfindex, req.IngressVLANID)
+	}
+}

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -1272,6 +1272,20 @@ pub(crate) struct SessionSyncRequest {
     pub ingress_zone_id: u16,
     #[serde(rename = "egress_zone_id", default)]
     pub egress_zone_id: u16,
+    /// #7095: the LOCAL ingress identity a peer-imported session should carry.
+    ///
+    /// The originating node could not send its own `ingress_ifindex` — an
+    /// ifindex is node-local and would name a different NIC here, which is why
+    /// #6928 imported 0 — so it sent a fold of the RETH-RELATIVE name both
+    /// chassis agree on, and the Go side resolved that fold to THIS node's own
+    /// numbers before building this request. They are therefore safe to store.
+    ///
+    /// `default` keeps an older daemon's request decoding to 0, which is the
+    /// pre-#7095 behaviour: no ingress identity, zone approximation on display.
+    #[serde(rename = "ingress_ifindex", default)]
+    pub ingress_ifindex: i32,
+    #[serde(rename = "ingress_vlan_id", default)]
+    pub ingress_vlan_id: u16,
     #[serde(rename = "owner_rg_id", default)]
     pub owner_rg_id: i32,
     #[serde(rename = "egress_ifindex", default)]

--- a/userspace-dp/src/server/helpers/session_sync.rs
+++ b/userspace-dp/src/server/helpers/session_sync.rs
@@ -234,19 +234,39 @@ pub(crate) fn build_synced_session_entry(
             },
         },
         metadata: crate::session::SessionMetadata {
-            // #4983: a peer-imported session carries NO ingress identity, and
-            // this is deliberate rather than unfinished. An ifindex is
-            // NODE-LOCAL -- node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are
-            // different numbers for the same logical RETH member -- so the
-            // originating node's value would name a different NIC here. It is
-            // therefore not put on the cluster wire at all, and 0 is the
-            // honest answer: the Go consumer falls back to the zone
-            // approximation, which is approximate but never confidently wrong.
+            // #4983/#7095: a peer-imported session now carries an ingress
+            // identity again -- but a LOCALLY RESOLVED one.
+            //
+            // #6928 imported 0 here on purpose: an ifindex is NODE-LOCAL, so
+            // node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are different numbers
+            // for one logical RETH member, and shipping the originating node's
+            // value would name a different NIC here -- confidently wrong, which
+            // is worse than the zone approximation.
+            //
+            // #7095 does not ship the ifindex. The sender ships a FOLD of the
+            // reth-relative name (`reth0.50`), which both chassis agree on by
+            // construction, and the Go side resolves that fold against THIS
+            // node's config and ifindex table before building this request. So
+            // these are this node's own numbers for the interface the peer
+            // named, and storing them is safe.
+            //
+            // Zero still arrives and still means unknown: a legacy peer sends
+            // no wire field, a session whose interface has no cluster-stable
+            // name folds to 0, and a fabric-redirected session records no
+            // identity at all (#7096, because the fabric stamp carries a u16
+            // zone id and nothing else). All three keep the pre-#7095
+            // behaviour -- the Go consumer falls back to the zone
+            // approximation.
+            //
             // Note this install is `is_reverse: req.is_reverse`, so a FORWARD
-            // peer session lands here with 0 too -- see the scope note in
+            // peer session lands here too -- see the scope note in
             // pkg/dataplane/types.go.
-            ingress_ifindex: 0,
-            ingress_vlan_id: 0,
+            ingress_ifindex: if req.ingress_ifindex > 0 {
+                req.ingress_ifindex as u32
+            } else {
+                0
+            },
+            ingress_vlan_id: req.ingress_vlan_id,
             // #919: prefer the wire u16 IDs when populated; fall back
             // to name lookup for older peers that only sent strings.
             ingress_zone: if req.ingress_zone_id != 0 {

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -4298,3 +4298,75 @@ fn refresh_status_projects_interface_snat_registry_counters_6751() {
         "the sync-import conflict counter must reach its own status field"
     );
 }
+
+// --- #7095: a peer-imported session carries a LOCALLY RESOLVED ingress identity
+
+/// #6928 imported `ingress_ifindex: 0` on purpose: the originating node's
+/// ifindex is node-local and would name a different NIC here. #7095 does not
+/// ship an ifindex — it ships a fold of the reth-relative name both chassis
+/// agree on, and the Go side resolves it against THIS node's config and ifindex
+/// table before building the request. So what arrives here is already local, and
+/// storing it is what makes the identity survive a failover.
+#[test]
+fn session_sync_import_stores_locally_resolved_ingress_7095() {
+    let zones = rustc_hash::FxHashMap::default();
+    let req = SessionSyncRequest {
+        operation: "upsert".to_string(),
+        addr_family: libc::AF_INET as u8,
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: "10.0.0.1".to_string(),
+        dst_ip: "10.0.0.2".to_string(),
+        src_port: 5001,
+        dst_port: 80,
+        ingress_zone_id: 2,
+        egress_zone_id: 3,
+        ingress_ifindex: 42,
+        ingress_vlan_id: 50,
+        ..SessionSyncRequest::default()
+    };
+    let entry = build_synced_session_entry(&req, &zones).expect("build entry");
+    assert_eq!(
+        entry.metadata.ingress_ifindex, 42,
+        "a peer-imported session must carry the ingress ifindex the Go side \
+         resolved LOCALLY from the peer's cluster-stable fold; dropping it here \
+         is what made every synced session fall back to the zone approximation \
+         after a failover (#7095)"
+    );
+    assert_eq!(
+        entry.metadata.ingress_vlan_id, 50,
+        "the VLAN is half the identity: {{ifindex, vlan}} is the key the CLI \
+         resolves an interface name by, so two units of one trunk NIC alias \
+         onto each other without it"
+    );
+}
+
+/// The unknown case still imports nothing, and it arrives from three places
+/// that all want the same answer: a legacy peer that sent no wire field, an
+/// interface with no cluster-stable name, and a fabric-redirected session, whose
+/// ingress interface is not knowable on this node at all (#7096 — the fabric
+/// stamp carries a u16 zone id and nothing else).
+#[test]
+fn session_sync_import_keeps_zero_ingress_when_unknown_7095() {
+    let zones = rustc_hash::FxHashMap::default();
+    let req = SessionSyncRequest {
+        operation: "upsert".to_string(),
+        addr_family: libc::AF_INET as u8,
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: "10.0.0.1".to_string(),
+        dst_ip: "10.0.0.2".to_string(),
+        src_port: 5001,
+        dst_port: 80,
+        ingress_zone_id: 2,
+        egress_zone_id: 3,
+        // No ingress_ifindex / ingress_vlan_id: exactly what an older daemon
+        // sends, since serde defaults them.
+        ..SessionSyncRequest::default()
+    };
+    let entry = build_synced_session_entry(&req, &zones).expect("build entry");
+    assert_eq!(
+        entry.metadata.ingress_ifindex, 0,
+        "an absent ingress identity must stay 0 — the consumer falls back to the \
+         zone approximation, which is approximate but never confidently wrong"
+    );
+    assert_eq!(entry.metadata.ingress_vlan_id, 0);
+}

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -1089,6 +1089,8 @@
     "fabric_ingress": false,
     "generation": 0,
     "inactivity_timeout": 0,
+    "ingress_ifindex": 0,
+    "ingress_vlan_id": 0,
     "ingress_zone": "",
     "ingress_zone_id": 0,
     "is_reverse": false,


### PR DESCRIPTION
Closes #7095

Design handed over settled by close-6949 (which landed the #7096 upstream half in
#7908); implemented as specified rather than re-derived.

## The problem

`#4983` records the true ingress interface per session, but it never reached the
peer — so **after a failover every session degraded to the #4792 zone
approximation**. On a two-node cluster that is half the sessions at all times and
all of them immediately after an RG transition: the diagnostic stops working
exactly when it matters most.

## What crosses the wire, and what does not

An ifindex is **node-local** — node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are one
logical RETH member with different numbers — so #6928 synced nothing rather than
render a confidently wrong name on the peer. That decision stands: **the ifindex
still never crosses.**

What rides instead is `config.StableIfaceID` over the **reth-relative name**
(`reth0.50`), which both chassis agree on by construction — zones bind to it, and
`RethToPhysical` resolves it to each node's own member. The **receiver** turns the
fold back into its OWN `{ifindex, vlan}` before the helper stores it, so the
importing node ends up with its own numbers for the interface the peer named.

Wire shape, as specified: a **trailing length-gated u32** (the #2170 `Generation`
pattern), **no `SessionSyncWireVersion` bump**, decode `if off+4 <= len(payload)`,
absent → 0.

**Zero carries three meanings and one encoding serves all of them:** a legacy peer
emits no field, an interface with no cluster-stable name folds to 0, and a
fabric-redirected session records nothing at all because the fabric stamp carries
a u16 zone id and nothing else (#7096). All three want the same fallback. An
unknown or **ambiguous** fold declines on the receiving side too — the reverse
lookup enumerates candidates and folds them rather than inverting the hash, so a
collision returns not-found instead of a coin flip.

## Four things the suite caught that review would not have

1. **Interface spelling.** Config carries `ge-0/0/1`; anything derived from an
   ifindex carries `ge-0-0-1`. Comparing them unnormalised **does not fail
   loudly** — an unmatched member simply keeps its own name, so node 0 folds
   `ge-0-0-1` while node 1 folds `ge-7-0-1`, the folds disagree, the peer resolves
   nothing, and every session degrades silently with no error anywhere. My first
   cross-node fixture used one spelling on both sides and could not see it; it now
   uses the real ones.
2. **Struct placement.** `Generation` must be the FIRST field past the on-map
   conntrack layout, and `TestSessionValueCarriesSyncOnlyGeneration` asserts that
   offset exactly. Inserting ahead of it moved the offset; sync-only fields belong
   behind it.
3. **Seven truncation constants.** Mixed-version cells cut a payload by a
   hard-coded width to simulate an old peer, so a new trailing field shifts every
   one. Left stale they do not fail as "short frame" — the cut lands inside the
   #3301 block and `AppTimeout` decodes as a nonzero leftover.
4. **The #6949 parity gate.** I had added the request fields to `SessionDeltaInfo`
   too, which is the Rust→Go direction, where every Go-declared JSON key must be
   one the Rust producer actually emits.

## Golden, classified against the MERGE TARGET

Merged `origin/master` first, asserted `git ls-files -u` empty, regenerated, then
diffed against **`origin/master`'s** copy — not this branch's HEAD, which would be
additive by construction since the regen rewrites the file from that tree:

```
added=2  removed=0  changed=0
  + /session_sync_request/ingress_ifindex = 0
  + /session_sync_request/ingress_vlan_id = 0
```

Both new keys, both the zero default, nothing removed and no value changed — the
benign shape.

## Validation

Instrument chosen per file type, per cell:

- `go test -count=1 ./...` — **69 packages ok, 0 failures**, 0 `no space left`
- `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1` —
  **4904 collected, 0 failed**
- Mutation matrix, green control, `git diff --stat` non-empty between each edit
  and its run:

| cell | mutation | instrument | named failing tests |
|---|---|---|---|
| CONTROL | none | Go | 0 (green) |
| S1 | v4 encoder drops the fold | Go | `TestIngressFoldRoundTripsOnTheWire_7095`, `TestLegacyPeerPayloadDecodesFoldAsUnknown_7095` + 3 neighbouring wire cells |
| S2 | decoder reads the fold without the length gate | Go | `TestIngressFoldRoundTripsOnTheWire_7095` |
| S3 | drop the Junos/Linux spelling normalisation | Go | `TestStableIfaceNameAgreesAcrossNodes_7095` |
| S4 | import ignores the resolver (back to #6928's always-0) | Go | `TestImportResolvesFoldToLocalIfindex_7095`, `TestImportResolvesFoldV6_7095` |
| S5 | Rust import hard-codes 0 again | **cargo** | `session_sync_import_stores_locally_resolved_ingress_7095` (4836 collected) |

v4 and v6 are separate types, encoders, decoders and request builders throughout,
so each has its own cell — wiring only v4 would leave every IPv6 session degraded
after a failover with the v4 cells green.

No cluster smoke: this changes what a session carries, not how a packet is
forwarded. The HA-visible behaviour change is that a peer-synced session now
resolves its own ingress interface name instead of falling back to the zone.
