### PR TITLE
Single-source the peer-install node-local session scrub (#7097)

### DIFF
--- a/docs/log/7097.md
+++ b/docs/log/7097.md
@@ -1,0 +1,87 @@
+# #7097 — peer-install node-local scrub misses the #4983 ingress identity
+
+- **Timestamp**: 2026-08-28
+- **Action**: single-sourced the peer-install node-local strip; wired all four
+  install sites; added census / wiring / delegation guards; updated the
+  session-sync architecture doc.
+- **File(s)**: `pkg/dataplane/session_node_local.go` (new),
+  `pkg/dataplane/session_store.go`,
+  `pkg/dataplane/userspace/manager_sessions.go`,
+  `pkg/dataplane/peer_install_scrub_7097_test.go` (new),
+  `docs/session-sync-architecture.md`
+
+## Premise check at `origin/master` (`0d9f4de03`)
+
+The issue names the two `session_store.go` scrubs. Verified — and the
+enumeration is a FLOOR, not a census: the same incomplete list exists at
+**four** sites, and the two the issue does not name are the ones production
+actually reaches.
+
+| site | node-local list before | reached in production |
+|---|---|---|
+| `session_store.go` `putClusterSyncedV4Raw` | 5 FIB fields | only when the dataplane does NOT implement `clusterSyncedSessionInstaller` |
+| `session_store.go` `putClusterSyncedV6Raw` | 5 FIB fields | same |
+| `userspace/manager_sessions.go` `SetClusterSyncedSessionV4` | 5 FIB fields | **yes** — the userspace manager implements the installer |
+| `userspace/manager_sessions.go` `SetClusterSyncedSessionV6` | 5 FIB fields | **yes** |
+
+Fixing only the two named sites would have fixed the branch production never
+takes.
+
+## Reachability
+
+Latent at every site, on both paths. `pkg/cluster` never mentions
+`IngressIfindex` / `IngressVlanID` — neither `encodeSession*` nor
+`decodeSessionV4Payload` / `decodeSessionV6Payload` touches them — so a decoded
+peer row carries `0` and there is nothing for the scrub to strip today. This is
+defence in depth. It is fixed anyway because a defence-in-depth list that
+silently stops covering the field class it was written to cover is the failure
+mode the list exists to prevent, and because the obvious future caller (a
+reverse-sync that re-offers LOCAL rows) would put a local ifindex on a peer row,
+the one outcome #4983/#6928's design note says must never happen.
+
+## Why one list rather than two more lines
+
+Divergence between the four sites is ALWAYS a bug — they are four spellings of
+one rule — so this is a single-source case, not a bind-the-agreement case. The
+lists are now `dataplane.SessionValue.ScrubNodeLocal()` /
+`SessionValueV6.ScrubNodeLocal()`.
+
+## Out of scope, filed as a finding
+
+`mirrorSessionPairV4` / `mirrorSessionPairV6` (`manager_sessions.go:85`, `:243`)
+clear the same five FIB fields on the synthesized reverse companion and also do
+not clear the ingress pair — so the companion inherits the FORWARD direction's
+ingress ifindex. `pkg/dataplane/types.go` documents the reverse companion as a
+legitimate-`0` population ("its own ingress has not been OBSERVED yet"), so this
+contradicts the stated contract. Reachable via the #5305 rollback path:
+`rollbackV4` restores a map-read pre-image (a locally-owned row with a genuine
+stamped ingress) through `SetSessionV4`, which synthesizes the companion.
+
+NOT folded into `ScrubNodeLocal`: the companion resets fields because the
+reverse direction has not been observed, not because they belong to another
+node. A future node-local field should not automatically become a
+reverse-companion reset. Reported to the board as a separate candidate.
+
+## Guards
+
+- `TestScrubNodeLocalCoversExactlyTheNodeLocalFields7097` — reflection census.
+  Fills EVERY field with a non-zero sentinel, calls the helper, and compares the
+  zeroed set against the declared set in BOTH directions plus an anti-vacuity
+  floor (`len(scrubbed) == 0` fails). Reads no marker comment.
+- `TestPeerInstallStoreScrubsNodeLocalFields7097` — the wiring bind for the two
+  store sites: the census proves the helper is right, this proves the store
+  CALLS it.
+- `TestSessionValueFieldCountIsPinned7097` — 35 / 36. Forces a human to classify
+  any new field, the step #6928 skipped.
+- `TestClusterSyncedInstallSitesDelegateTheScrub7097` — AST pin: every
+  peer-install site calls `ScrubNodeLocal` and none assigns a node-local field
+  directly. Uses `go/parser`, so it cannot be satisfied by its own doc comment
+  (comments are not in the AST). Structural rather than behavioural for the
+  manager pair because every manager test in that package `t.Skipf`s without
+  memlock — measured: `ebpf.NewMap` returns `operation not permitted` here, so a
+  behavioural cell there would be VOID, not green.
+
+## Validation
+
+`TMPDIR=/var/tmp go test -count=1 ./...` — rc=0, 0 `--- FAIL`.
+No Rust source touched, so the cargo leg is unaffected.

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -88,8 +88,33 @@ installed into both places:
 - the Rust helper session table via the userspace manager RPC path
 
 `SetClusterSyncedSessionV4()` / `SetClusterSyncedSessionV6()` do both. Before
-install, they clear the cached FIB result so the receiving node recomputes
-node-local forwarding.
+install they strip every NODE-LOCAL field from the peer's row — the cached FIB
+result, so the receiving node recomputes forwarding, and the #4983 ingress
+identity, so the row lands in the documented `0` branch rather than naming a
+NIC by the peer's number.
+
+That strip is single-sourced in `dataplane.SessionValue.ScrubNodeLocal()` /
+`SessionValueV6.ScrubNodeLocal()` (`pkg/dataplane/session_node_local.go`,
+#7097). It has four callers: these two userspace-manager installers — the pair
+production reaches — and the `putClusterSyncedV4Raw` / `putClusterSyncedV6Raw`
+fallbacks in `pkg/dataplane/session_store.go`, which run only when the dataplane
+does not implement `clusterSyncedSessionInstaller`. Before #7097 each of the
+four kept its own hand-written list, and all four listed the five FIB fields and
+not the ingress pair that #6928 had added to the ABI: the lists went incomplete
+together, in one change, with nothing to notice. Nothing reached any site with a
+non-zero value — the session wire below never encodes `IngressIfindex` /
+`IngressVlanID`, so a decoded peer row carries `0` — so the gap was latent, not
+live. `TestScrubNodeLocalCoversExactlyTheNodeLocalFields7097` (a reflection
+census, both directions, plus a struct field-count pin) and
+`TestClusterSyncedInstallSitesDelegateTheScrub7097` (an AST pin that every
+peer-install site delegates and none has re-grown a private list) are what keep
+the one list complete.
+
+The reverse COMPANION that `mirrorSessionPairV4` / `...V6` synthesize is a
+different case and deliberately does not use this helper: it resets fields
+because the reverse direction has not been OBSERVED yet, not because they belong
+to another node. Folding the two would make a future node-local field
+automatically a reverse-companion reset, which does not follow.
 
 **#7581 — a synced import with no pool to reserve from is not a collision.**
 Before publishing a peer-synced session the helper reserves its translated NAT

--- a/pkg/dataplane/peer_install_scrub_7097_test.go
+++ b/pkg/dataplane/peer_install_scrub_7097_test.go
@@ -1,0 +1,317 @@
+package dataplane
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #7097: the peer-install node-local scrub must not fall behind the struct.
+//
+// A peer-owned session must not inherit fields that only mean something on the
+// node that produced them. Before this change FOUR install sites each carried
+// their own hand-written list of those fields, and every one of them listed the
+// five FIB fields and not the #4983 ingress pair that #6928 added to the ABI.
+// Nothing reached any of them with a non-zero value — pkg/cluster's session wire
+// never encodes the pair — so the incompleteness was latent, which is exactly
+// why nothing noticed it.
+//
+// The fix is one list (`ScrubNodeLocal`, session_node_local.go). These tests are
+// the two halves that keep it one list:
+//
+//   - the CENSUS below asserts the helper zeroes the declared node-local set and
+//     NOTHING else, by filling every field with a non-zero sentinel through
+//     reflection and comparing both directions. It reads no marker comment and
+//     no hand-maintained name list against the struct, so a field added to the
+//     helper without being declared fails as loudly as one declared without
+//     being zeroed. The field COUNT is pinned separately, so a new field on the
+//     struct forces a human to classify it.
+//   - the DELEGATION pin asserts every peer-install site calls the helper and
+//     none has re-grown a private list.
+
+// nodeLocalSessionFields are the fields a peer-owned row must NOT inherit.
+// FIB* are the resolved EGRESS of a lookup the ORIGINATING node performed;
+// Ingress* are the #4983 ingress-binding identity, node-local for the same
+// reason (node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are different numbers for
+// one logical RETH member).
+var nodeLocalSessionFields = map[string]bool{
+	"FibIfindex":     true,
+	"FibVlanID":      true,
+	"FibDmac":        true,
+	"FibSmac":        true,
+	"FibGen":         true,
+	"IngressIfindex": true,
+	"IngressVlanID":  true,
+}
+
+// fillNonZero sets every settable field of a struct to a non-zero sentinel, so
+// "this field came back zero" means the scrub zeroed it rather than the fixture
+// never having set it. A fixture that left a field at its zero value would make
+// the scrub look complete for a field it never touches.
+func fillNonZero(t *testing.T, v reflect.Value) {
+	t.Helper()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if !f.CanSet() {
+			continue
+		}
+		switch f.Kind() {
+		case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			f.SetUint(0x5A)
+		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f.SetInt(0x5A)
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.Array:
+			for j := 0; j < f.Len(); j++ {
+				if f.Index(j).Kind() == reflect.Uint8 {
+					f.Index(j).SetUint(0x5A)
+				}
+			}
+		case reflect.Struct:
+			fillNonZero(t, f)
+		default:
+			// A field kind this helper cannot seed would read as "scrubbed" for
+			// free. Fail rather than quietly under-cover it.
+			t.Fatalf("field %s has kind %s, which fillNonZero does not seed — "+
+				"the zero/non-zero comparison below would be vacuous for it (#7097)",
+				v.Type().Field(i).Name, f.Kind())
+		}
+	}
+}
+
+// zeroedFields reports which top-level fields of `after` are zero while the
+// same field of `before` was not.
+func zeroedFields(before, after reflect.Value) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < before.NumField(); i++ {
+		name := before.Type().Field(i).Name
+		b, a := before.Field(i), after.Field(i)
+		if !b.IsZero() && a.IsZero() {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func assertScrubCensus(t *testing.T, before, after reflect.Value) {
+	t.Helper()
+	scrubbed := zeroedFields(before, after)
+	if len(scrubbed) == 0 {
+		t.Fatal("the scrub zeroed NOTHING — the fixture or the call did not run, " +
+			"and the two directional checks below would both pass vacuously (#7097)")
+	}
+	for name := range nodeLocalSessionFields {
+		if !scrubbed[name] {
+			t.Errorf("%s is NODE-LOCAL but survived the peer-install scrub. A "+
+				"peer-owned row can then inherit this node's number and render a "+
+				"confidently wrong answer — worse than the zero the consumer falls "+
+				"back on (#7097)", name)
+		}
+	}
+	for name := range scrubbed {
+		if !nodeLocalSessionFields[name] {
+			t.Errorf("the scrub zeroes %s, which is NOT declared node-local. Either "+
+				"it is node-local and this list is stale, or the scrub is destroying "+
+				"a field the peer legitimately owns (#7097)", name)
+		}
+	}
+}
+
+// The census on the single-sourced helper itself.
+func TestScrubNodeLocalCoversExactlyTheNodeLocalFields7097(t *testing.T) {
+	t.Run("v4", func(t *testing.T) {
+		var val SessionValue
+		fillNonZero(t, reflect.ValueOf(&val).Elem())
+		before := reflect.ValueOf(val)
+		val.ScrubNodeLocal()
+		assertScrubCensus(t, before, reflect.ValueOf(val))
+	})
+	t.Run("v6", func(t *testing.T) {
+		var val SessionValueV6
+		fillNonZero(t, reflect.ValueOf(&val).Elem())
+		before := reflect.ValueOf(val)
+		val.ScrubNodeLocal()
+		assertScrubCensus(t, before, reflect.ValueOf(val))
+	})
+}
+
+// The wiring bind for the two session-store install sites: the census above
+// proves the HELPER is right, this proves the store actually CALLS it. A
+// sessionStoreTestDP does not implement clusterSyncedSessionInstaller, so the
+// early return is not taken and the scrub branch runs.
+func TestPeerInstallStoreScrubsNodeLocalFields7097(t *testing.T) {
+	t.Run("v4", func(t *testing.T) {
+		var val SessionValue
+		fillNonZero(t, reflect.ValueOf(&val).Elem())
+		before := reflect.ValueOf(val)
+
+		dp := &sessionStoreTestDP{}
+		key := SessionKey{Protocol: 6}
+		if err := (dataPlaneSessionStore{dp: dp}).putClusterSyncedV4Raw(key, val); err != nil {
+			t.Fatalf("putClusterSyncedV4Raw: %v", err)
+		}
+		got, ok := dp.v4[key]
+		if !ok {
+			t.Fatal("the store did not install the row — the scrub branch was not " +
+				"reached and this cell measures nothing")
+		}
+		assertScrubCensus(t, before, reflect.ValueOf(got))
+	})
+	t.Run("v6", func(t *testing.T) {
+		var val SessionValueV6
+		fillNonZero(t, reflect.ValueOf(&val).Elem())
+		before := reflect.ValueOf(val)
+
+		dp := &sessionStoreTestDP{}
+		key := SessionKeyV6{Protocol: 6}
+		if err := (dataPlaneSessionStore{dp: dp}).putClusterSyncedV6Raw(key, val); err != nil {
+			t.Fatalf("putClusterSyncedV6Raw: %v", err)
+		}
+		got, ok := dp.v6[key]
+		if !ok {
+			t.Fatal("the store did not install the row — the scrub branch was not " +
+				"reached and this cell measures nothing")
+		}
+		assertScrubCensus(t, before, reflect.ValueOf(got))
+	})
+}
+
+// The population pin. The census compares the helper against a DECLARED set;
+// this is what stops that set going stale silently. A field added to
+// SessionValue is either node-local (add it to ScrubNodeLocal AND to
+// nodeLocalSessionFields) or it is not (update this number) — either way a human
+// classifies it, which is the step #6928 skipped.
+func TestSessionValueFieldCountIsPinned7097(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		typ  reflect.Type
+		want int
+	}{
+		{"SessionValue", reflect.TypeOf(SessionValue{}), 35},
+		{"SessionValueV6", reflect.TypeOf(SessionValueV6{}), 36},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.typ.NumField(); got != tc.want {
+				t.Fatalf("%s has %d fields, pinned at %d. A new field must be "+
+					"classified: node-local fields go in BOTH ScrubNodeLocal and "+
+					"nodeLocalSessionFields; everything else just updates this number "+
+					"(#7097)", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// clusterSyncedInstallSites are every function that installs a session the
+// CLUSTER PEER owns. Each must delegate the node-local strip to ScrubNodeLocal
+// rather than keep its own list.
+//
+// The manager pair is the branch PRODUCTION takes: putClusterSyncedV4Raw's
+// scrub runs only when the dataplane does not implement
+// clusterSyncedSessionInstaller, and the userspace manager does implement it. A
+// behavioural test for the manager pair would need a real BPF map (its whole
+// package's manager tests t.Skipf without CAP_SYS_ADMIN/memlock), so it would
+// SKIP on developer machines — which is why this pin is structural. It is not a
+// substitute for the census: the census proves the helper is complete, this
+// proves nobody bypasses it.
+var clusterSyncedInstallSites = map[string][]string{
+	"session_store.go": {
+		"putClusterSyncedV4Raw",
+		"putClusterSyncedV6Raw",
+	},
+	"userspace/manager_sessions.go": {
+		"SetClusterSyncedSessionV4",
+		"SetClusterSyncedSessionV6",
+	},
+}
+
+func TestClusterSyncedInstallSitesDelegateTheScrub7097(t *testing.T) {
+
+	for file, fns := range clusterSyncedInstallSites {
+		t.Run(file, func(t *testing.T) {
+			path := filepath.Join(".", filepath.FromSlash(file))
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			fset := token.NewFileSet()
+			// Parsing with the Go parser, not a text scan, is what makes this
+			// immune to being satisfied by its own doc comment: comments are not
+			// expressions and never appear in the AST walked below.
+			f, err := parser.ParseFile(fset, path, src, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+
+			found := map[string]bool{}
+			for _, decl := range f.Decls {
+				fd, ok := decl.(*ast.FuncDecl)
+				if !ok || fd.Body == nil {
+					continue
+				}
+				var want bool
+				for _, name := range fns {
+					if fd.Name.Name == name {
+						want = true
+					}
+				}
+				if !want {
+					continue
+				}
+				found[fd.Name.Name] = true
+
+				var callsScrub bool
+				var ownList []string
+				ast.Inspect(fd.Body, func(n ast.Node) bool {
+					switch x := n.(type) {
+					case *ast.CallExpr:
+						if sel, ok := x.Fun.(*ast.SelectorExpr); ok &&
+							sel.Sel.Name == "ScrubNodeLocal" {
+							callsScrub = true
+						}
+					case *ast.AssignStmt:
+						for _, lhs := range x.Lhs {
+							sel, ok := lhs.(*ast.SelectorExpr)
+							if !ok {
+								continue
+							}
+							if nodeLocalSessionFields[sel.Sel.Name] {
+								ownList = append(ownList, sel.Sel.Name)
+							}
+						}
+					}
+					return true
+				})
+
+				if !callsScrub {
+					t.Errorf("%s does not call ScrubNodeLocal. A peer-install site "+
+						"that strips node-local fields by hand is how #7097 happened: "+
+						"#6928 added IngressIfindex/IngressVlanID to the ABI and every "+
+						"private list silently stopped covering the field class it "+
+						"existed to cover", fd.Name.Name)
+				}
+				if len(ownList) > 0 {
+					t.Errorf("%s assigns node-local fields directly (%s). Delete the "+
+						"private list and let ScrubNodeLocal own it, or this site will "+
+						"drift from the others again (#7097)",
+						fd.Name.Name, strings.Join(ownList, ", "))
+				}
+			}
+
+			// Anti-vacuity: a renamed or moved function must fail here, not
+			// silently reduce this cell to zero checks.
+			for _, name := range fns {
+				if !found[name] {
+					t.Errorf("%s not found in %s — this pin checked nothing for it. "+
+						"If the function moved, move this entry with it (#7097)",
+						name, file)
+				}
+			}
+		})
+	}
+}

--- a/pkg/dataplane/session_node_local.go
+++ b/pkg/dataplane/session_node_local.go
@@ -1,0 +1,63 @@
+package dataplane
+
+// Node-local session fields, and the single place they are stripped (#7097).
+//
+// A chassis-cluster session installed from a PEER carries the peer's view of
+// values that only mean something on the node that produced them. Two classes
+// exist on SessionValue / SessionValueV6:
+//
+//   - the cached FIB result (FibIfindex, FibVlanID, FibDmac, FibSmac, FibGen) —
+//     the resolved EGRESS of a lookup the ORIGINATING node performed against
+//     ITS routing and neighbour state;
+//   - the #4983 ingress identity (IngressIfindex, IngressVlanID) — the binding
+//     the session's first packet arrived on, on the originating node.
+//
+// Both are ifindex-shaped, and an ifindex is node-local: node 0's `ge-0-0-1`
+// and node 1's `ge-7-0-1` are different numbers for the same logical RETH
+// member. Adopting a peer's number does not degrade the answer, it INVERTS it —
+// `show security flow session interface <name>` would name a confidently WRONG
+// interface, which is strictly worse than the zero the consumer falls back on
+// (it approximates from the ingress zone instead, exactly as it did before
+// #4983). docs/session-sync-architecture.md states this contract.
+//
+// #7097 is what happens when that contract is enforced by a hand-maintained
+// list at each install site instead of one function. #6928 added the ingress
+// pair to the ABI; the FIB list at all FOUR peer-install sites — the v4 and v6
+// store fallbacks in session_store.go and the v4 and v6 userspace-manager
+// installers in pkg/dataplane/userspace/manager_sessions.go — silently stopped
+// covering the node-local field class it was written to cover, in the same
+// change, at every site, because there was nothing to notice. Nothing reached
+// those sites with a non-zero value (pkg/cluster's session wire never encodes
+// the pair, so a decoded peer row has it at 0), so it was latent rather than
+// live; a defence-in-depth list going quietly incomplete is the failure mode
+// the list exists to prevent, not a reason to leave it incomplete.
+//
+// So there is now ONE list. A future node-local field is added here and every
+// install site gets it; a site that grows its own list again is what
+// TestClusterSyncedInstallSitesDelegateTheScrub7097 fails on.
+
+// ScrubNodeLocal zeroes every field of the value that is meaningful only on the
+// node that produced it. Call it on a COPY destined for the local session maps
+// when the row is owned by the cluster peer.
+func (v *SessionValue) ScrubNodeLocal() {
+	v.FibIfindex = 0
+	v.FibVlanID = 0
+	v.FibDmac = [6]byte{}
+	v.FibSmac = [6]byte{}
+	v.FibGen = 0
+	v.IngressIfindex = 0
+	v.IngressVlanID = 0
+}
+
+// ScrubNodeLocal is the IPv6 twin. The two structs are separate declarations
+// with separate field sets, so this is a separate list — but both are reached
+// by the same census test, which is the point.
+func (v *SessionValueV6) ScrubNodeLocal() {
+	v.FibIfindex = 0
+	v.FibVlanID = 0
+	v.FibDmac = [6]byte{}
+	v.FibSmac = [6]byte{}
+	v.FibGen = 0
+	v.IngressIfindex = 0
+	v.IngressVlanID = 0
+}

--- a/pkg/dataplane/session_store.go
+++ b/pkg/dataplane/session_store.go
@@ -301,11 +301,12 @@ func (s dataPlaneSessionStore) putClusterSyncedV4Raw(key SessionKey, val Session
 	if installer, ok := s.dp.(clusterSyncedSessionInstaller); ok {
 		return installer.SetClusterSyncedSessionV4(key, val)
 	}
-	val.FibIfindex = 0
-	val.FibVlanID = 0
-	val.FibDmac = [6]byte{}
-	val.FibSmac = [6]byte{}
-	val.FibGen = 0
+	// The row belongs to the PEER: strip every field that is meaningful only on
+	// the node that produced it before it lands in this node's maps. The list
+	// is single-sourced (#7097) — see ScrubNodeLocal in session_node_local.go
+	// for which fields and why, and for what went wrong when each install site
+	// kept its own copy.
+	val.ScrubNodeLocal()
 	return s.dp.SetSessionV4(key, val)
 }
 
@@ -356,11 +357,8 @@ func (s dataPlaneSessionStore) putClusterSyncedV6Raw(key SessionKeyV6, val Sessi
 	if installer, ok := s.dp.(clusterSyncedSessionInstaller); ok {
 		return installer.SetClusterSyncedSessionV6(key, val)
 	}
-	val.FibIfindex = 0
-	val.FibVlanID = 0
-	val.FibDmac = [6]byte{}
-	val.FibSmac = [6]byte{}
-	val.FibGen = 0
+	// IPv6 twin of the peer-owned scrub in putClusterSyncedV4Raw (#7097).
+	val.ScrubNodeLocal()
 	return s.dp.SetSessionV6(key, val)
 }
 

--- a/pkg/dataplane/userspace/manager_sessions.go
+++ b/pkg/dataplane/userspace/manager_sessions.go
@@ -98,11 +98,15 @@ func (m *Manager) mirrorSessionPairV4(key dataplane.SessionKey, val dataplane.Se
 
 func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {
 	installVal := val
-	installVal.FibIfindex = 0
-	installVal.FibVlanID = 0
-	installVal.FibDmac = [6]byte{}
-	installVal.FibSmac = [6]byte{}
-	installVal.FibGen = 0
+	// The peer owns this row: strip every node-local field before it reaches
+	// this node's maps or the helper. Single-sourced in
+	// dataplane.SessionValue.ScrubNodeLocal (#7097) — this site kept its own
+	// copy of the list and it silently stopped covering the #4983 ingress
+	// identity when #6928 added it to the ABI. THIS is the site production
+	// reaches: the session_store.go fallback runs only when the dataplane does
+	// not implement clusterSyncedSessionInstaller, which the userspace manager
+	// does.
+	installVal.ScrubNodeLocal()
 	// The helper already synthesizes the correct reverse companion from the
 	// forward cluster-synced entry using local forwarding and HA state. An
 	// explicit reverse cluster update can overwrite that locally-derived
@@ -252,11 +256,15 @@ func (m *Manager) mirrorSessionPairV6(key dataplane.SessionKeyV6, val dataplane.
 
 func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) error {
 	installVal := val
-	installVal.FibIfindex = 0
-	installVal.FibVlanID = 0
-	installVal.FibDmac = [6]byte{}
-	installVal.FibSmac = [6]byte{}
-	installVal.FibGen = 0
+	// The peer owns this row: strip every node-local field before it reaches
+	// this node's maps or the helper. Single-sourced in
+	// dataplane.SessionValue.ScrubNodeLocal (#7097) — this site kept its own
+	// copy of the list and it silently stopped covering the #4983 ingress
+	// identity when #6928 added it to the ABI. THIS is the site production
+	// reaches: the session_store.go fallback runs only when the dataplane does
+	// not implement clusterSyncedSessionInstaller, which the userspace manager
+	// does.
+	installVal.ScrubNodeLocal()
 	// Reverse entries are never mirrored (see SetClusterSyncedSessionV4): write
 	// the BPF mirror and return — no mirror failure to compensate.
 	if !shouldMirrorUserspaceSession(val.IsReverse) {


### PR DESCRIPTION
Closes #7097

## The issue's premise held — and its enumeration was a floor

The issue names the two scrubs in `pkg/dataplane/session_store.go`: they zero the
five cached-FIB fields and not the #4983 ingress identity (`IngressIfindex`,
`IngressVlanID`) that #6928 added to the on-map conntrack ABI. Verified at
`0d9f4de03`.

Re-derived at master, the same incomplete list exists at **four** sites — and the
two the issue does not name are the ones production actually reaches:

| site | list before | reached in production |
|---|---|---|
| `session_store.go` `putClusterSyncedV4Raw` | 5 FIB fields | only when the dataplane does NOT implement `clusterSyncedSessionInstaller` |
| `session_store.go` `putClusterSyncedV6Raw` | 5 FIB fields | same |
| `userspace/manager_sessions.go` `SetClusterSyncedSessionV4` | 5 FIB fields | **yes** |
| `userspace/manager_sessions.go` `SetClusterSyncedSessionV6` | 5 FIB fields | **yes** |

`putClusterSynced*Raw`'s scrub runs only on the `!ok` branch of
`s.dp.(clusterSyncedSessionInstaller)`, and the userspace manager implements that
interface. Fixing only the named pair would have fixed the branch production never
takes.

## Reachability: latent everywhere, on both paths

`pkg/cluster` never mentions `IngressIfindex` / `IngressVlanID` — not in the
encoders, not in `decodeSessionV4Payload` / `decodeSessionV6Payload` — so a
decoded peer row carries `0` and there is nothing for any of the four to strip
today. This is defence in depth, and the PR says so in the code.

It is fixed anyway for two reasons. A defence-in-depth list that silently stops
covering the field class it was written to cover is the failure mode the list
exists to prevent. And the obvious future caller — a reverse-sync-on-reconnect
that reads LOCAL rows and re-offers them — would put a local ifindex on a peer's
row, which is the one outcome the #4983/#6928 design note says must never happen:
adopting a peer's ifindex does not degrade the answer, it **inverts** it.
`show security flow session interface <name>` would name a confidently wrong NIC,
strictly worse than the `0` the consumer approximates from the ingress zone.

## Why one list instead of two more lines

Divergence between the four sites is *always* a bug — they are four spellings of
one rule — so this is a single-source case, not a bind-the-agreement case. The
list is now `dataplane.SessionValue.ScrubNodeLocal()` /
`SessionValueV6.ScrubNodeLocal()` in the new `pkg/dataplane/session_node_local.go`,
which also carries the reasoning. A site that re-grows a private list fails the
AST pin below.

## Guards, and what each one can see

| test | binds |
|---|---|
| `TestScrubNodeLocalCoversExactlyTheNodeLocalFields7097` | reflection census: fills EVERY field with a non-zero sentinel, calls the helper, compares the zeroed set against the declared node-local set in **both directions**, with a `len(scrubbed) == 0` anti-vacuity floor. Reads no marker comment and no name list against the struct, so an under-scrub and an over-scrub fail alike |
| `TestPeerInstallStoreScrubsNodeLocalFields7097` | the wiring bind for the store pair — the census proves the helper is complete, this proves the store *calls* it |
| `TestSessionValueFieldCountIsPinned7097` | 35 / 36. A new field forces a human to classify it as node-local or not — the step #6928 skipped |
| `TestClusterSyncedInstallSitesDelegateTheScrub7097` | AST pin: every peer-install site calls `ScrubNodeLocal` and none assigns a node-local field directly, plus a not-found branch so a renamed site cannot silently reduce the cell to zero checks |

**Why the manager pair is pinned structurally rather than behaviourally, stated
plainly.** Every `Manager` test in `pkg/dataplane/userspace` needs a real BPF map.
Measured here: `ebpf.NewMap` returns `operation not permitted (MEMLOCK may be too
low)`, and `TestSetClusterSyncedSessionV4SkipsReverseHelperMirror` `t.Skipf`s. A
behavioural cell at that site would be **void**, not green, on a developer machine
— so the pin is an AST walk instead. It uses `go/parser`, not a text scan, so it
cannot be satisfied by its own doc comment: comments are not expressions and never
reach the walked AST. It is not a substitute for the census; the census proves the
helper is complete, the pin proves nobody bypasses it.

## Mutation matrix

Every cell full-suite over `./pkg/dataplane/ ./pkg/dataplane/userspace/`, gated on
a **named** failing test, `git diff --stat` recorded per cell, restored via
`git checkout -- .` between cells.

| cell | mutation | diff | verdict | named failing test |
|---|---|---|---|---|
| C0 | none (control) | — | GREEN | — |
| M1 | drop `v.IngressIfindex = 0` from the v4 helper | 1 del | **RED** | census/v4, store-wiring/v4 |
| M2 | drop `v.IngressVlanID = 0` from the v6 helper | 1 del | **RED** | census/v6, store-wiring/v6 |
| M3 | remove the `ScrubNodeLocal()` call from `putClusterSyncedV4Raw` | 1 del | **RED** | store-wiring/v4, AST pin/`session_store.go` |
| M4 | restore the **shipped** 5-field list at `SetClusterSyncedSessionV4` | +5/-1 | **RED** | AST pin/`manager_sessions.go` **only** |
| M5 | over-scrub: add `v.PolicyID = 0` to the v4 helper | +1 | **RED** | census/v4 (the over-scrub direction) |
| M6 | add a field to `SessionValue` | +2/-1 | **RED** | count pin/`SessionValue` |
| M7c | rename `putClusterSyncedV4Raw` without moving the pin's entry | +5/-5 | **RED** | AST pin anti-vacuity, verbatim: "putClusterSyncedV4Raw not found in session_store.go" |
| M8 | reorder the assignments inside `ScrubNodeLocal` (benign) | +6/-6 | GREEN | over-reach control |

M1/M2 localise: the v4 mutation fires only the `/v4` subtests, the v6 mutation only
`/v6`.

**M4 is the cell that justifies the structural pin.** It restores what actually
shipped at the site production reaches, and the AST pin is the *only* guard that
sees it — the census stays green because the helper is untouched.

**Void cells, disclosed.** Two earlier attempts at M7 measured nothing and are
superseded by M7c: the first renamed the production function only, dangling the
test's call site (BUILD-BREAK, correctly classified, not scored); the second
renamed the string inside `clusterSyncedInstallSites` too, so its GREEN was
*correct* and said nothing about the anti-vacuity branch. Separately, my first
harness classified C0 and M8 as BUILD-BREAK because its tests-collected probe
counted `--- PASS`, which only prints under `-v`; both were re-run on `_r2` log
paths with a corrected verdict function and came back GREEN.

## Out of scope — a separate finding, not folded in

`mirrorSessionPairV4` / `mirrorSessionPairV6` (`manager_sessions.go:85`, `:243`)
clear the same five FIB fields on the synthesized reverse companion and likewise
do not clear the ingress pair, so the companion inherits the **forward**
direction's ingress ifindex. `pkg/dataplane/types.go` documents the reverse
companion as a legitimate-`0` population ("its own ingress has not been OBSERVED
yet"), so this contradicts the stated contract. It is reachable via the #5305
rollback path: `rollbackV4` restores a map-read pre-image — a locally-owned row
with a genuinely stamped ingress — through `SetSessionV4`, which synthesizes the
companion.

It is deliberately **not** folded into `ScrubNodeLocal`. The companion resets
fields because the reverse direction has not been *observed*, not because they
belong to *another node*. Folding them would make every future node-local field
automatically a reverse-companion reset, which does not follow. Raised separately.

## Docs

`docs/session-sync-architecture.md` said the installers "clear the cached FIB
result". It now describes the full node-local strip, names the single source and
its four callers, records why the gap was latent, and states why the reverse
companion does not share the helper. `docs/log/7097.md` carries the working log.

## Validation

- `TMPDIR=/var/tmp go test -count=1 ./...` — rc=0, **0** `--- FAIL`, 69 packages
  `ok`, 0 build failures (`/var/tmp/g7097_full_r2.log`).
- No Rust source touched, so the cargo leg is unaffected.
- Merged current `origin/master` (`731fd9a09`); the merge touched only
  `userspace-dp/src/nat/*` and no Go file, so the gate above still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y