### PR TITLE
config: gate the routing-policy from-protocol value domain at commit

### DIFF
--- a/pkg/config/compiler_earlystrict.go
+++ b/pkg/config/compiler_earlystrict.go
@@ -158,6 +158,12 @@ func runEarlyStrictAndFolds(cfg *Config, opts compileOpts) error {
 	if err := validateIPMonitoringStrict(cfg); err != nil {
 		strictErrs = append(strictErrs, err)
 	}
+	// #7121: a routing-policy `from protocol` token is rendered verbatim as
+	// ` match source-protocol` and ONE FRR-rejected line degrades the whole
+	// managed reload, so an unknown token cannot be left to the render side.
+	if err := validateRoutingPolicyProtocolsStrict(cfg); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
 	// #1830 (e): the #1733 equal-flow worker-cap validator
 	// (validateEqualFlowWorkerCapStrict / MaxEqualFlowWorkers) is retired.
 	// The v8 lease rotation now sizes its per-worker scratch from the true

--- a/pkg/config/compiler_validate_strict_routing_protocol_7121.go
+++ b/pkg/config/compiler_validate_strict_routing_protocol_7121.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// validateRoutingPolicyProtocolsStrict rejects a `policy-options
+// policy-statement <p> term <t> from protocol <tok>` naming a protocol the FRR
+// renderer cannot emit (#7121).
+//
+// Why a hard reject rather than a warning: the token is rendered verbatim as
+// ` match source-protocol <tok>`, FRR rejects an unknown one, and a single
+// rejected line degrades the WHOLE managed reload (#1880/#2223). The blast
+// radius of one typo is the managed FRR section, not the one policy — the same
+// reasoning that makes the identically-spelled firewall-filter leaf a strict
+// reject via filterProtocolResolvable.
+//
+// It reports the FIRST offending token with its full path. The leaf is
+// multi-valued and a term can carry several protocols, so naming the term alone
+// would leave the operator grepping.
+func validateRoutingPolicyProtocolsStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.PolicyOptions.PolicyStatements))
+	for name := range cfg.PolicyOptions.PolicyStatements {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, stmtName := range names {
+		stmt := cfg.PolicyOptions.PolicyStatements[stmtName]
+		if stmt == nil {
+			continue
+		}
+		for _, term := range stmt.Terms {
+			if term == nil {
+				continue
+			}
+			for _, proto := range term.FromProtocols {
+				if RoutingProtocolResolvable(proto) {
+					continue
+				}
+				return fmt.Errorf(
+					"policy-options policy-statement %q term %q: `from protocol %s` is not a "+
+						"routing protocol this dataplane can match; FRR rejects an unknown "+
+						"source-protocol and ONE rejected line degrades the whole managed FRR "+
+						"reload (#1880/#2223), so this would not fail alone. Valid: direct "+
+						"(connected), static, ospf, ospf6, bgp, rip, ripng, isis, kernel",
+					stmtName, term.Name, proto)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/config/routing_policy_protocol_domain_7121_test.go
+++ b/pkg/config/routing_policy_protocol_domain_7121_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7121: `policy-options policy-statement <p> term <t> from protocol <tok>` had
+// no value-domain check in ANY spelling. The token is rendered verbatim as
+// ` match source-protocol <tok>`, FRR rejects an unknown one, and ONE rejected
+// line degrades the whole managed reload (#1880/#2223) — so a single typo was a
+// green commit that could take down the managed FRR section.
+func TestRoutingPolicyProtocolDomainIsGated_7121(t *testing.T) {
+	cfgWith := func(proto string) *Config {
+		return &Config{PolicyOptions: PolicyOptionsConfig{
+			PolicyStatements: map[string]*PolicyStatement{
+				"p1": {Name: "p1", Terms: []*PolicyTerm{
+					{Name: "t1", FromProtocols: []string{proto}},
+				}},
+			},
+		}}
+	}
+
+	for _, tc := range []struct {
+		proto  string
+		accept bool
+	}{
+		// Every FRR keyword the renderers can emit.
+		{"bgp", true}, {"ospf", true}, {"ospf6", true}, {"static", true},
+		{"rip", true}, {"ripng", true}, {"isis", true}, {"kernel", true},
+		{"connected", true},
+		// Junos spells directly-connected routes "direct"; BOTH renderers
+		// rewrite it to "connected". Rejecting it would break a working config.
+		{"direct", true},
+		// The issue's own example.
+		{"ospv", false},
+		// NOT the sibling leaf's domain. `firewall filter ... from protocol` is
+		// IP protocols and is gated by filterProtocolResolvable; the two leaves
+		// share a spelling and nothing else. Resolving one through the other
+		// would accept these here.
+		{"tcp", false}, {"udp", false}, {"icmp", false}, {"gre", false},
+	} {
+		t.Run(tc.proto, func(t *testing.T) {
+			err := validateRoutingPolicyProtocolsStrict(cfgWith(tc.proto))
+			if tc.accept && err != nil {
+				t.Errorf("%q is a protocol the renderer emits, but commit rejected it: %v",
+					tc.proto, err)
+			}
+			if !tc.accept && err == nil {
+				t.Errorf("%q was ACCEPTED at commit. It renders as `match source-protocol %s`, "+
+					"which FRR rejects — and one rejected line degrades the whole managed "+
+					"reload, so this does not fail alone", tc.proto, tc.proto)
+			}
+			if !tc.accept && err != nil {
+				// The operator has to be able to find it: a multi-valued leaf on
+				// a term that may carry several protocols.
+				for _, want := range []string{"p1", "t1", tc.proto} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("the rejection does not name %q, so the operator cannot "+
+							"locate the offending token: %v", want, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The two identically-spelled leaves must NOT resolve through one another.
+// Asserting the domains are disjoint where it matters is what stops a later
+// "consolidation" merging the two lists.
+func TestRoutingAndFilterProtocolDomainsAreDistinct_7121(t *testing.T) {
+	// IP protocols the filter leaf accepts and the routing leaf must not.
+	for _, ipProto := range []string{"tcp", "udp", "gre", "icmpv6"} {
+		if !filterProtocolResolvable(ipProto) {
+			t.Fatalf("premise broken: %q is no longer accepted by the FILTER domain, so this "+
+				"test is not comparing the two domains any more", ipProto)
+		}
+		if RoutingProtocolResolvable(ipProto) {
+			t.Errorf("%q resolves in the ROUTING domain; it is an IP protocol, and accepting "+
+				"it renders `match source-protocol %s` which FRR rejects", ipProto, ipProto)
+		}
+	}
+	// And a routing protocol the filter leaf must not silently accept as an
+	// IP protocol number. `ospf` is deliberately in BOTH (IP protocol 89 and an
+	// FRR keyword), so it is excluded — the overlap is real and not a bug.
+	for _, routingOnly := range []string{"bgp", "static", "kernel", "isis"} {
+		if !RoutingProtocolResolvable(routingOnly) {
+			t.Fatalf("premise broken: %q left the routing domain", routingOnly)
+		}
+		if filterProtocolResolvable(routingOnly) {
+			t.Errorf("%q resolves in the FILTER domain, which is IP protocols — if that is "+
+				"intended, this test needs updating; if not, the filter gate is too wide",
+				routingOnly)
+		}
+	}
+}
+
+// The `direct` -> `connected` rewrite lived in TWO renderers with a copy each.
+// Single-sourcing it means the mapping itself must be asserted, or a future
+// edit could make the domain accept `direct` while the keyword lookup returns
+// something else.
+func TestDirectMapsToConnected_7121(t *testing.T) {
+	got, ok := FRRRoutingProtocolKeyword("direct")
+	if !ok || got != "connected" {
+		t.Fatalf(`FRRRoutingProtocolKeyword("direct") = (%q, %v), want ("connected", true) — `+
+			`Junos spells directly-connected routes "direct" and FRR's keyword is "connected"`, got, ok)
+	}
+	if got, _ := FRRRoutingProtocolKeyword("connected"); got != "connected" {
+		t.Errorf(`the FRR spelling must resolve to itself, got %q`, got)
+	}
+}

--- a/pkg/config/routing_protocol_domain.go
+++ b/pkg/config/routing_protocol_domain.go
@@ -1,0 +1,65 @@
+package config
+
+import "strings"
+
+// FRRRoutingProtocolKeyword maps a Junos routing-protocol token to the FRR
+// keyword that renders it, and reports whether the token is in the domain at
+// all.
+//
+// #7121: this is the SSOT for the value domain of every place a routing-protocol
+// NAME crosses into FRR — `policy-options policy-statement <p> term <t> from
+// protocol <tok>` (rendered as ` match source-protocol`), and the
+// `export`/redistribute path. Before this it existed only inside pkg/frr, so the
+// commit-time gate could not consult it and an unknown token committed clean.
+//
+// That matters more than an ordinary typo: FRR rejects an unknown
+// `source-protocol`, and one rejected line degrades the WHOLE managed reload
+// (#1880/#2223). A single `from protocol ospv;` was a green commit that could
+// take down the managed FRR section.
+//
+// NOT the same domain as the identically-spelled `firewall filter ... from
+// protocol`, which is IP protocols (tcp/udp/gre/icmp) and is gated separately by
+// filterProtocolResolvable. The two leaves share a spelling and nothing else;
+// resolving one through the other's list would accept `tcp` for a routing policy
+// and `bgp` for a firewall filter.
+//
+// The `direct` alias is carried here because BOTH renderers rewrite it and each
+// had its own copy — `redistribute.go` and `policy_render.go`. Junos spells
+// directly-connected routes `direct`; FRR's keyword is `connected`. A divergence
+// between those two copies is always a bug, so they are single-sourced rather
+// than bound by an agreement test.
+func FRRRoutingProtocolKeyword(token string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	// Junos spelling for directly-connected routes; FRR calls it "connected".
+	case "direct", "connected":
+		return "connected", true
+	case "static":
+		return "static", true
+	// ospf6 / ripng are the FRR keywords for OSPFv3 / RIPng. Without them a
+	// bare `export ospf6` / `export ripng` falls through to the skip-and-warn
+	// path and IPv6 IGP redistribution cannot be expressed (#2943).
+	case "ospf":
+		return "ospf", true
+	case "ospf6":
+		return "ospf6", true
+	case "bgp":
+		return "bgp", true
+	case "rip":
+		return "rip", true
+	case "ripng":
+		return "ripng", true
+	case "isis":
+		return "isis", true
+	case "kernel":
+		return "kernel", true
+	default:
+		return "", false
+	}
+}
+
+// RoutingProtocolResolvable reports whether a routing-policy `from protocol`
+// token names a protocol the FRR renderer can emit.
+func RoutingProtocolResolvable(token string) bool {
+	_, ok := FRRRoutingProtocolKeyword(token)
+	return ok
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -186,7 +186,14 @@ var schemaPolicyOptions = &schemaNode{desc: "Policy options", children: map[stri
 				// leaf instead of replacing the previous one (#2008 H18 /
 				// Copilot #2011). A single-value leaf collapses separate set
 				// commands down to only the last protocol.
-				"protocol": {desc: "Protocol", args: 1, multi: true, placeholder: "<protocol>", children: nil},
+				// #7121: valueExamples is the operator-facing completion list AND what the
+				// #2419 compact/block equivalence probe synthesizes from. Without it the
+				// probe used a placeholder the new strict gate rejects, so every spelling
+				// failed identically and the cell went blind — it would have reported
+				// "compiles equivalently" for a leaf it could no longer observe at all.
+				// The domain itself is config.FRRRoutingProtocolKeyword; these are two
+				// members of it, not a second copy.
+				"protocol": {desc: "Protocol (direct, static, ospf, ospf6, bgp, rip, ripng, isis, kernel)", args: 1, multi: true, placeholder: "<protocol>", valueExamples: []string{"bgp", "ospf"}, children: nil},
 				// prefix-list / route-filter / community / as-path may all be
 				// repeated within one term (Junos OR's repeated same-type `from`
 				// matches). Mark them multi so SetPath keeps every flat-set

--- a/pkg/frr/redistribute.go
+++ b/pkg/frr/redistribute.go
@@ -25,9 +25,12 @@ import (
 // ospf6 / ripng are the FRR keywords for OSPFv3 / RIPng redistribution;
 // without them a bare `export ospf6` / `export ripng` falls through to the
 // skip-and-warn path and IPv6 IGP redistribution cannot be expressed (#2943).
-var knownRedistProtocols = map[string]bool{
-	"connected": true, "static": true, "ospf": true, "ospf6": true,
-	"bgp": true, "rip": true, "ripng": true, "isis": true, "kernel": true,
+// #7121: the domain moved to config.FRRRoutingProtocolKeyword so the COMMIT
+// gate can consult it. It lived here, where a commit-time validator could not
+// reach it (pkg/frr imports pkg/config, not the reverse), which is why an
+// unknown `from protocol` token committed clean and degraded the reload.
+func knownRedistProtocol(name string) bool {
+	return config.RoutingProtocolResolvable(name)
 }
 
 // resolveRedistribute converts a Junos export value into FRR redistribute commands.
@@ -73,7 +76,7 @@ func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsCon
 	if export == "direct" {
 		export = "connected"
 	}
-	if knownRedistProtocols[export] {
+	if knownRedistProtocol(export) {
 		// A protocol can never redistribute itself: FRR rejects
 		// `redistribute ospf` under `router ospf` (etc.), and ONE
 		// rejected line degrades the WHOLE managed reload (#1880/#2223).


### PR DESCRIPTION
Closes #7121

`policy-options policy-statement <p> term <t> from protocol <tok>` had **no
value-domain check in any spelling**. The token is rendered verbatim as
` match source-protocol <tok>`; FRR rejects an unknown one, and **one rejected
line degrades the whole managed reload** (#1880/#2223). So `from protocol ospv;`
was a green commit that could take down the managed FRR section — not just that
policy.

## The sibling shares a spelling and nothing else

`firewall filter ... from protocol` **is** gated, via `filterProtocolResolvable`.
But its domain is **IP protocols** (`tcp`, `udp`, `gre`, `icmp`); the routing
one is **routing protocols** (`bgp`, `static`, `kernel`, `isis`). Resolving
either through the other would accept `tcp` for a routing policy and `bgp` for a
firewall filter, so they stay separate and
`TestRoutingAndFilterProtocolDomainsAreDistinct_7121` asserts they stay that way.

(`ospf` is deliberately in **both** — IP protocol 89 *and* an FRR keyword — so
it is excluded from that test. The overlap is real, not a bug.)

## Why the domain had to move

It lived in `pkg/frr`, where a commit-time validator **cannot reach it** —
`pkg/frr` imports `pkg/config`, not the reverse. That is precisely why the gate
was absent. It is now `config.FRRRoutingProtocolKeyword`, and `pkg/frr` resolves
through it.

That also **single-sources the `direct` → `connected` rewrite**, which had a copy
in *each* renderer (`redistribute.go` and `policy_render.go`). Junos spells
directly-connected routes `direct`; FRR's keyword is `connected`. A divergence
between those copies is always a bug, so they are single-sourced rather than
bound by an agreement test, and the mapping itself is asserted.

## The schema `valueExamples` are load-bearing, not cosmetic

Adding the gate **broke `TestCompactBlockEquivalenceInventory2419`**, and the
failure is worth reading rather than silencing.

The #2419 compact/block equivalence probe synthesizes its values from
`valueExamples`. With none, it used a placeholder the new gate rejects — so every
spelling failed **identically**, the cell went blind, and the inventory reported
the site as *"now compiles equivalently"* for a leaf it could no longer observe
at all. The test helpfully suggests removing the inventory line; **that would
have masked a divergence rather than fixing one.**

Giving the leaf real examples restores the probe's ability to see the read, and
doubles as the operator's `?` completion list.

Verified the direction: the inventory test **passes on master** and **failed on
this branch** before the examples were added — so the interaction was mine, not
pre-existing.

## Validation

`pkg/config` and `pkg/frr` both green, including the #2419 inventory. The table
covers every FRR keyword, the `direct` alias, the issue's own `ospv` typo, and
the four IP protocols the sibling domain accepts. Repo-wide gate below.