### PR TITLE
Tally per-zone flood alarms on the alarm-without-drop arm

### DIFF
--- a/docs/log/7086.md
+++ b/docs/log/7086.md
@@ -1,0 +1,70 @@
+# 7086 — per-zone flood ALARM tally on the alarm-without-drop arm
+
+- **Timestamp**: 2026-08-28
+- **Action**: added a separate per-zone flood alarm triple, recorded at the
+  three `alarm-without-drop` arms of `stage_screen_check`
+- **File(s)**:
+  - `userspace-dp/src/afxdp/flood_counters.rs`
+  - `userspace-dp/src/afxdp/poll_stages.rs`
+  - `userspace-dp/src/afxdp/poll_stages_tests.rs`
+  - `docs/userspace-dataplane-gaps.md`
+
+## Premise, confirmed at master
+
+`alarm_without_drop` is checked per ZONE (`ScreenProfile.alarm_without_drop`,
+`screen/mod.rs:484`), not per check. The three alarm arms call
+`emit_screen_alarm_event` + `screen.record_alarm_without_drop()` and return
+`Continue(Pass)`; only the else-arms call `counters.record_screen_drop(...)`,
+which is the sole feeder of `record_zone_flood_drop`. So an alarming zone
+records nothing per-zone, confirmed by construction and by the m1 cell below.
+
+## The finding that fixed the scope boundary
+
+`alarm_without_drop` being per-ZONE means an alarming zone has zero flood drops
+**by construction**. It is therefore exactly the row `FloodCounterStore::
+snapshot` omits, and `Manager.ReadFloodCounters` (`pkg/dataplane/maps_screen.go:106`)
+returns `ErrCounterNotPopulated` only on a MISSING offset-map row.
+
+So widening the snapshot predicate to publish alarm-only zones, without also
+teaching the Go render about alarms, would render "SYN flood events: 0" on a
+zone under a live flood alarm — a confident wrong answer replacing an honest
+"not available", and strictly worse than the reported bug.
+
+Predicate and render are therefore inseparable, and both are deferred to the
+surface follow-up. This change stops at the counter, which is where the
+orchestrator's design put it; the measurement above is why that boundary is
+correct rather than merely convenient.
+
+## Mutation matrix — full suite, no `-run` filter, `--test-threads=1`
+
+RED requires named `^test ... FAILED` lines AND tests-collected > 0.
+
+| cell | edit | rc | collected | verdict | reds |
+|------|------|----|-----------|---------|------|
+| control | none | 0 | 4836 | GREEN | — |
+| m1 | delete all three tally calls (the #7086 defect) | 101 | 4834 | RED | behavioural + drift guard |
+| m2 | rejected fix: alarm arms call `record_zone_flood_drop` INSTEAD | 101 | 4834 | RED | behavioural (alarm-tally) + drift guard |
+| m3 | rejected fix: record BOTH — isolates the separation assert | 101 | 4835 | RED | behavioural, `snapshot().is_empty()` only |
+| m4 | `FloodPending::reset` stops clearing alarm deltas | 101 | 4835 | RED | refold cell only |
+| m5 | operator clear stops zeroing the alarm triple | 101 | 4835 | RED | clear cell only |
+| m6 | alarm recorder loses its reason filter | 101 | 4835 | RED | non-flood-reason cell only |
+
+m3 exists because m2 stopped at an earlier assertion, leaving the separation
+contract — the one the issue's rejected fix violates — unproven. m4/m5/m6 each
+red exactly one cell.
+
+## Instrument note
+
+The subject is driven through the LIVE `stage_screen_check`, not through
+`record_zone_flood_alarm`. The defect was that the arms never reached the
+recorder, so a test calling the recorder directly passes against the broken
+tree — it would bind the library, not the wiring.
+
+`run_stage_screen_capture` built a fresh `ForwardingState`, and so a fresh
+`FloodCounterStore`, per call. That is invisible to a verdict assertion but
+fatal to an accumulated tally: the thread-local accumulator survives across
+calls while the store does not. A caller-owned-forwarding variant was added.
+
+The drop leg is a positive control, not decoration: it proves the fixture
+crosses the UDP-flood threshold, so the alarm leg's empty drop snapshot is the
+suppression under test and not a flood that never happened.

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -811,6 +811,45 @@ zone with no traffic / no flood events alike.
   helper store (the Go `ClearAllCounters` override sends it) so an operator clear
   does not snap back on the next 1 s poll.
 
+  **Alarm arm (#7086).** The drop-path funnel above is what makes the tally
+  drift-proof for DROPS, and is exactly why it missed alarms: a zone configured
+  `alarm-without-drop` suppresses the drop and forwards the packet, so
+  `stage_screen_check`'s three alarm arms never reach `record_screen_drop`. A
+  zone under a sustained flood alarm therefore published NOTHING — `snapshot`
+  omits all-zero rows, the Go side replaces its offset map from that sparse
+  snapshot, and all four render sites printed "the zone has recorded no flood
+  events" during a live flood. Junos `alarm-without-drop` suppresses the drop,
+  not the statistic.
+
+  The fix is a SEPARATE per-zone alarm triple, never folded into the drop
+  counts: a counter whose name, module doc and call-site contract all say DROP
+  must not report packets that were permitted and forwarded, which would turn an
+  honest "not available" into a confident wrong answer. `record_zone_flood_alarm`
+  is called at each of the three alarm arms and shares the drop half's LUT,
+  per-zone atomic block and single per-RX-batch fold (`FloodPending` gains a
+  parallel `alarms` array under the same `touched_slots` bitmask). Batching is
+  MORE load-bearing here, not less: `alarm_without_drop` is a per-ZONE profile
+  flag, so an alarming zone suppresses every flood drop it would take and a
+  volumetric flood runs this path per packet on every worker with no drop
+  thinning it.
+
+  Unlike the drop side there is no funnel to make drift impossible — the
+  suppression is decided inline in three arms and `record_alarm_without_drop`
+  lives in the `screen` module, which cannot see the afxdp slot map — so a test
+  derives the expected tally-call count from the arms themselves and fails if a
+  fourth arm is added without one.
+
+  **The wire is still drops-only, deliberately.** `snapshot`'s row predicate and
+  the Go render are unchanged. Emitting a row for an alarm-only zone without
+  teaching the render about alarms would make the surface WORSE:
+  `Manager.ReadFloodCounters` returns `ErrCounterNotPopulated` only when the
+  offset map has no row, so a row of zeroed drop counts renders "SYN flood
+  events: 0" on a zone that is actively alarming. Because `alarm_without_drop`
+  is per-zone, an alarming zone has zero drops BY CONSTRUCTION and is precisely
+  the row the predicate omits, so predicate and render cannot be separated. They
+  change together with the flood surface's cause-naming work (the #7907
+  treatment of the zone half).
+
   **Rejected-build safety, flood half.** The flood store is the exact sibling
   of the traffic store above — `Arc`-backed, carried forward by the same
   `previous` handle — so the #5716/#6832 split applies to it verbatim, and it

--- a/userspace-dp/src/afxdp/flood_counters.rs
+++ b/userspace-dp/src/afxdp/flood_counters.rs
@@ -2,7 +2,8 @@
 //!
 //! The sibling of [`crate::afxdp::zone_counters`], for the other half of the
 //! dead per-zone counter families the #3643 HIDE marked "not available". Where
-//! the traffic half accounts forwarded VOLUME, this one accounts flood DROPS:
+//! the traffic half accounts forwarded VOLUME, this one accounts flood EVENTS
+//! — as two separate triples, DROPS and (#7086) ALARMS:
 //! the counts `show security screen ids-option statistics` renders as
 //! "SYN flood events" / "ICMP flood events" / "UDP flood events" per zone
 //! (`dataplane.FloodState.SynCount/ICMPCount/UDPCount`).
@@ -17,11 +18,26 @@
 //! per zone. So there was nothing to publish: this module is the per-zone tally
 //! itself, added on the drop path.
 //!
-//! ## Drop path, not forward path — but still coalesced
+//! ## Two arms, never merged
 //!
 //! [`record_zone_flood_drop`] is called only from
 //! [`crate::afxdp::BatchCounters::record_screen_drop`], i.e. only when a screen
 //! check has already decided to DROP. That is off the forwarding fast path.
+//!
+//! [`record_zone_flood_alarm`] (#7086) is its counterpart on the
+//! `alarm-without-drop` arm of `stage_screen_check`: the check TRIPPED, the
+//! drop was suppressed, a log-only alarm was raised and the packet was
+//! PERMITTED and forwarded. It accumulates into a SEPARATE triple and is never
+//! folded into the drop counts — a counter whose name and call-site contract
+//! say DROP must not report forwarded packets. Junos `alarm-without-drop`
+//! suppresses the drop, not the statistic, so both arms are real flood events;
+//! what differs is the disposition, and the surface needs to tell them apart.
+//!
+//! Note the alarm arm is the HOTTER of the two: `alarm-without-drop` is a
+//! per-ZONE profile flag, so a zone in alarm mode suppresses every flood drop
+//! it would take, and a volumetric flood runs that path per packet on every
+//! worker with no drop thinning it. Both arms share the LUT, the per-zone
+//! atomic block and the per-batch fold; only the destination triple differs.
 //!
 //! It is nevertheless coalesced per RX batch rather than `fetch_add`ing
 //! directly, because a screen drop is not rare when it matters: a SYN flood is
@@ -230,6 +246,14 @@ struct FloodTotalsAtomic {
     syn: AtomicU64,
     icmp: AtomicU64,
     udp: AtomicU64,
+    /// #7086: the same three families counted on the ALARM arm — a flood
+    /// check tripped, `alarm-without-drop` suppressed the drop, and the
+    /// packet was PERMITTED and forwarded. Kept in a separate triple from
+    /// the drop counts above, never folded into them: a counter whose name
+    /// and call-site contract say DROP must not report permitted packets.
+    syn_alarms: AtomicU64,
+    icmp_alarms: AtomicU64,
+    udp_alarms: AtomicU64,
 }
 
 impl FloodTotalsAtomic {
@@ -243,6 +267,30 @@ impl FloodTotalsAtomic {
             1 => self.icmp.fetch_add(count, Ordering::Relaxed),
             _ => self.udp.fetch_add(count, Ordering::Relaxed),
         };
+    }
+
+    /// #7086: the alarm-arm sibling of [`Self::add`]. Separate fields, so a
+    /// zone that is alarming and permitting can never be read as dropping.
+    #[inline]
+    fn add_alarm(&self, kind: usize, count: u64) {
+        if count == 0 {
+            return;
+        }
+        match kind {
+            0 => self.syn_alarms.fetch_add(count, Ordering::Relaxed),
+            1 => self.icmp_alarms.fetch_add(count, Ordering::Relaxed),
+            _ => self.udp_alarms.fetch_add(count, Ordering::Relaxed),
+        };
+    }
+
+    /// #7086: alarm-arm counterpart of [`Self::load`], same relaxed contract.
+    #[cfg(test)]
+    fn load_alarms(&self) -> (u64, u64, u64) {
+        (
+            self.syn_alarms.load(Ordering::Relaxed),
+            self.icmp_alarms.load(Ordering::Relaxed),
+            self.udp_alarms.load(Ordering::Relaxed),
+        )
     }
 
     /// Independent relaxed loads. Each field is exact; the triple is
@@ -263,6 +311,12 @@ impl FloodTotalsAtomic {
         self.syn.store(0, Ordering::Relaxed);
         self.icmp.store(0, Ordering::Relaxed);
         self.udp.store(0, Ordering::Relaxed);
+        // #7086: the operator clear is one action over the whole per-zone
+        // flood block. Zeroing only the drop triple would leave a cleared
+        // zone reporting pre-clear alarm totals.
+        self.syn_alarms.store(0, Ordering::Relaxed);
+        self.icmp_alarms.store(0, Ordering::Relaxed);
+        self.udp_alarms.store(0, Ordering::Relaxed);
     }
 }
 
@@ -286,6 +340,24 @@ impl FloodCounterStore {
 
     /// Sparse snapshot for the status wire: one row per zone with any flood
     /// events. Deterministic order (sorted by zone id) for a stable wire.
+    ///
+    /// ## #7086: still DROPS-only, deliberately
+    ///
+    /// The alarm triple is NOT part of this predicate and is not on the wire
+    /// yet. Widening the predicate to emit a row for an alarm-only zone,
+    /// without also teaching the Go render about alarms, would strictly
+    /// WORSEN the surface: `Manager.ReadFloodCounters` returns
+    /// `ErrCounterNotPopulated` only when the offset map has no row, so a row
+    /// of zeroed drop counts renders "SYN flood events: 0" on a zone that is
+    /// actively alarming — a confident wrong answer replacing an honest
+    /// "not available".
+    ///
+    /// That is not hypothetical for some zones and safe for others:
+    /// `alarm-without-drop` is a per-ZONE profile flag, so an alarming zone
+    /// has zero drops BY CONSTRUCTION and is exactly the row this predicate
+    /// omits. Predicate and render must therefore change together, in the
+    /// follow-up that gives the flood surface the same cause-naming treatment
+    /// #7907 gave the zone half.
     pub(in crate::afxdp) fn snapshot(&self) -> Vec<ZoneFloodCounterStatus> {
         let totals = self.totals.lock().expect("flood counter store poisoned");
         let mut out: Vec<ZoneFloodCounterStatus> = totals
@@ -351,7 +423,25 @@ impl FloodCounterStore {
             for (kind, counts) in pending.counts.iter().enumerate() {
                 totals.add(kind, counts[slot]);
             }
+            for (kind, alarms) in pending.alarms.iter().enumerate() {
+                totals.add_alarm(kind, alarms[slot]);
+            }
         }
+    }
+
+    /// #7086 test-only read of a zone's ALARM triple. Deliberately not on
+    /// `snapshot`: see the note there for why the wire stays drops-only until
+    /// the surface can render the alarming-and-permitting state.
+    #[cfg(test)]
+    pub(in crate::afxdp) fn alarm_zones_for_test(&self) -> Vec<(u16, (u64, u64, u64))> {
+        let totals = self.totals.lock().expect("flood counter store poisoned");
+        let mut out: Vec<(u16, (u64, u64, u64))> = totals
+            .iter()
+            .map(|(&zone_id, t)| (zone_id, t.load_alarms()))
+            .filter(|(_, (s, i, u))| *s != 0 || *i != 0 || *u != 0)
+            .collect();
+        out.sort_unstable_by_key(|(zone_id, _)| *zone_id);
+        out
     }
 
     /// Test-only handle to the map mutex, so a test can hold the shared store
@@ -369,6 +459,10 @@ impl FloodCounterStore {
 /// worker thread on the drop path; folded into the shared store per RX batch.
 struct FloodPending {
     counts: [[u64; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS],
+    /// #7086: alarm-arm deltas, same slot/kind indexing as `counts`. Shares
+    /// `touched_slots` with it — a slot is touched if EITHER arm recorded,
+    /// so the fold and the reset stay one walk over one bitmask.
+    alarms: [[u64; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS],
     /// #6946: one bit per touched slot, replacing a single `touched: bool`.
     /// See the ZonePending field of the same name; the flood case matters
     /// more because this accumulator is fed from the screen DROP path, so it
@@ -381,6 +475,7 @@ impl Default for FloodPending {
     fn default() -> Self {
         Self {
             counts: [[0; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS],
+            alarms: [[0; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS],
             touched_slots: 0,
         }
     }
@@ -395,6 +490,12 @@ impl FloodPending {
             mask &= mask - 1;
             for counts in self.counts.iter_mut() {
                 counts[slot] = 0;
+            }
+            // #7086: a touched slot may carry an alarm delta, a drop delta or
+            // both. Clearing only `counts` would re-fold stale alarm deltas
+            // into the next batch.
+            for alarms in self.alarms.iter_mut() {
+                alarms[slot] = 0;
             }
         }
         self.touched_slots = 0;
@@ -431,6 +532,53 @@ pub(in crate::afxdp) fn record_zone_flood_drop(
         let mut p = pending.borrow_mut();
         let s = slot as usize;
         p.counts[kind][s] = p.counts[kind][s].saturating_add(1);
+        p.touched_slots |= 1u64 << s;
+    });
+}
+
+/// #7086: record one flood check that TRIPPED but was suppressed by the zone's
+/// `alarm-without-drop` profile — a log-only alarm was raised and the packet
+/// was PERMITTED and forwarded.
+///
+/// ## Why this is a separate tally and not a call into `record_zone_flood_drop`
+///
+/// Feeding the alarm arm into the drop counter would make a counter whose
+/// name, module doc and call-site contract all say DROP report packets that
+/// were forwarded. An operator reading "N flood drops" on a zone where nothing
+/// was dropped is worse off than one reading "not available". So the alarm arm
+/// gets its own triple, and the surface can distinguish three states: dropping
+/// / alarming-and-permitting / nothing recorded.
+///
+/// ## Why it is batched, like the drop path and more so
+///
+/// `alarm-without-drop` is a per-ZONE profile flag (`ScreenProfile`), so a zone
+/// in alarm mode suppresses EVERY flood drop it would otherwise take. Under a
+/// volumetric flood this path therefore runs per packet on every worker at
+/// once, with no drop to thin the traffic out — strictly hotter than the drop
+/// path this mirrors, and exactly the MESI ping-pong against the coordinator's
+/// status reads that #1187 documents. Hence the same flat-LUT lookup plus
+/// thread-local accumulate, folded once per RX batch: no hash, no atomic, no
+/// allocation on the packet path.
+///
+/// A non-flood reason, an unzoned packet, or a zone with no slot contributes
+/// nothing, identically to the drop recorder.
+#[inline]
+pub(in crate::afxdp) fn record_zone_flood_alarm(
+    slot_map: &FloodCounterSlotMap,
+    zone_id: u16,
+    reason: &str,
+) {
+    let Some(kind) = flood_reason_index(reason) else {
+        return;
+    };
+    let slot = slot_map.slot_of(zone_id);
+    if slot == 0 {
+        return;
+    }
+    FLOOD_PENDING.with(|pending| {
+        let mut p = pending.borrow_mut();
+        let s = slot as usize;
+        p.alarms[kind][s] = p.alarms[kind][s].saturating_add(1);
         p.touched_slots |= 1u64 << s;
     });
 }
@@ -832,5 +980,116 @@ mod tests {
         let snap = store.snapshot();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].syn_flood_events, 1);
+    }
+
+    // ---------------- #7086: the alarm arm ----------------
+
+    /// The operator clear is one action over a zone's whole flood block. If
+    /// `FloodTotalsAtomic::reset` zeroes only the drop triple, a cleared zone
+    /// keeps reporting pre-clear alarm totals for ever — the counters never
+    /// decay on their own.
+    #[test]
+    fn clear_zeroes_the_alarm_triple_too_7086() {
+        const Z: u16 = 4242;
+        let store = FloodCounterStore::default();
+        let map = FloodCounterSlotMap::build(&[Z], &store);
+
+        record_zone_flood_alarm(&map, Z, "udp-flood");
+        record_zone_flood_alarm(&map, Z, "syn-flood");
+        flush_recorded_flood_counters(&store, &map);
+        assert_eq!(
+            store.alarm_zones_for_test(),
+            vec![(Z, (1, 0, 1))],
+            "precondition: the alarms must be there to be cleared"
+        );
+
+        store.clear();
+        assert!(
+            store.alarm_zones_for_test().is_empty(),
+            "clear must zero the ALARM triple as well as the drop triple"
+        );
+    }
+
+    /// `FloodPending::reset` clears the per-slot deltas of every TOUCHED slot.
+    /// A slot can be touched by either arm, so a reset that clears only
+    /// `counts` leaves the alarm delta in place and the NEXT batch folds it a
+    /// second time.
+    ///
+    /// The shape matters: the second batch records a DROP on the same slot, so
+    /// the slot is touched and folded again. A test that simply flushed twice
+    /// would return early on `touched_slots == 0` and never re-fold — passing
+    /// against the broken reset.
+    #[test]
+    fn a_flushed_alarm_delta_is_not_refolded_by_the_next_batch_7086() {
+        const Z: u16 = 909;
+        let store = FloodCounterStore::default();
+        let map = FloodCounterSlotMap::build(&[Z], &store);
+
+        record_zone_flood_alarm(&map, Z, "icmp-flood");
+        flush_recorded_flood_counters(&store, &map);
+        assert_eq!(store.alarm_zones_for_test(), vec![(Z, (0, 1, 0))]);
+
+        // Second batch: a DROP on the same slot, so the slot is touched and
+        // the fold walks it again.
+        record_zone_flood_drop(&map, Z, "icmp-flood");
+        flush_recorded_flood_counters(&store, &map);
+
+        assert_eq!(
+            store.alarm_zones_for_test(),
+            vec![(Z, (0, 1, 0))],
+            "the alarm delta was already folded in the first batch; folding it \
+             again would double-count every alarm on any zone that later takes \
+             a drop in the same slot"
+        );
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(
+            snap[0].icmp_flood_events, 1,
+            "the second batch's drop must land exactly once"
+        );
+    }
+
+    /// The alarm arm must apply the same reason filter as the drop arm: a
+    /// non-flood screen reason is a real alarm but not a FLOOD alarm, and
+    /// folding it into one of the three families would make "UDP flood alarms"
+    /// silently include port scans.
+    #[test]
+    fn a_non_flood_reason_contributes_no_zone_alarm_7086() {
+        const Z: u16 = 77;
+        let store = FloodCounterStore::default();
+        let map = FloodCounterSlotMap::build(&[Z], &store);
+
+        record_zone_flood_alarm(&map, Z, "port-scan");
+        record_zone_flood_alarm(&map, Z, "teardrop");
+        record_zone_flood_alarm(&map, Z, "syn-cookie");
+        flush_recorded_flood_counters(&store, &map);
+
+        assert!(
+            store.alarm_zones_for_test().is_empty(),
+            "only the three flood families may enter the per-zone alarm tally"
+        );
+    }
+
+    /// An unzoned packet or a zone with no hot-path slot contributes nothing,
+    /// identically to the drop recorder — the `slot == 0` sentinel guard.
+    #[test]
+    fn an_unslotted_zone_contributes_no_alarm_7086() {
+        const MAPPED: u16 = 11;
+        const UNMAPPED: u16 = 12;
+        let store = FloodCounterStore::default();
+        let map = FloodCounterSlotMap::build(&[MAPPED], &store);
+
+        record_zone_flood_alarm(&map, UNMAPPED, "syn-flood");
+        flush_recorded_flood_counters(&store, &map);
+        assert!(
+            store.alarm_zones_for_test().is_empty(),
+            "a zone with no slot must not attribute its alarms to slot 0"
+        );
+
+        // Positive control: the SAME call on a mapped zone does record, so the
+        // emptiness above is the slot guard and not a broken fixture.
+        record_zone_flood_alarm(&map, MAPPED, "syn-flood");
+        flush_recorded_flood_counters(&store, &map);
+        assert_eq!(store.alarm_zones_for_test(), vec![(MAPPED, (1, 0, 0))]);
     }
 }

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -650,6 +650,14 @@ pub(super) fn stage_screen_check(
                         event_now_ns_from_secs(now_secs),
                     );
                     screen.record_alarm_without_drop();
+                    // #7086: the check TRIPPED; only the drop was suppressed. Tally
+                    // it per zone on the ALARM triple so the surface can tell
+                    // "alarming and permitting" from "nothing recorded".
+                    crate::afxdp::flood_counters::record_zone_flood_alarm(
+                        &worker_ctx.forwarding.flood_counter_slot_map,
+                        zone_id,
+                        reason,
+                    );
                     StageOutcome::Continue(ScreenCheckOutcome::Pass)
                 } else {
                     emit_screen_drop_event(
@@ -757,6 +765,14 @@ pub(super) fn stage_screen_check(
                     event_now_ns_from_secs(now_secs),
                 );
                 screen.record_alarm_without_drop();
+                // #7086: the check TRIPPED; only the drop was suppressed. Tally
+                // it per zone on the ALARM triple so the surface can tell
+                // "alarming and permitting" from "nothing recorded".
+                crate::afxdp::flood_counters::record_zone_flood_alarm(
+                    &worker_ctx.forwarding.flood_counter_slot_map,
+                    zone_id,
+                    reason,
+                );
                 StageOutcome::Continue(ScreenCheckOutcome::Pass)
             } else {
                 emit_screen_drop_event(
@@ -792,6 +808,19 @@ pub(super) fn stage_screen_check(
                     event_now_ns_from_secs(now_secs),
                 );
                 screen.record_alarm_without_drop();
+                // #7086: mirror the drop arm below, which passes this same
+                // "syn-cookie" literal to record_screen_drop. That reason is
+                // NOT one of flood_reason_index's three, so both arms
+                // contribute nothing to the per-zone flood tally today. The
+                // call is here anyway so the two arms cannot DRIFT: if
+                // "syn-cookie" ever becomes a counted family, it starts
+                // counting on the alarm arm and the drop arm together, rather
+                // than re-creating #7086 for a new reason.
+                crate::afxdp::flood_counters::record_zone_flood_alarm(
+                    &worker_ctx.forwarding.flood_counter_slot_map,
+                    zone_id,
+                    "syn-cookie",
+                );
                 StageOutcome::Continue(ScreenCheckOutcome::Pass)
             } else {
                 emit_screen_drop_event(

--- a/userspace-dp/src/afxdp/poll_stages_tests.rs
+++ b/userspace-dp/src/afxdp/poll_stages_tests.rs
@@ -2135,6 +2135,25 @@ fn run_stage_screen_capture(
     flow: Option<&SessionFlow>,
 ) -> (bool, u64, Vec<crate::event_stream::codec::DataplaneEventPayload>) {
     let forwarding = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+    run_stage_screen_capture_in(&forwarding, screen, frame, meta, flow)
+}
+
+/// #7086: the same live drive, against a CALLER-OWNED forwarding state.
+///
+/// `run_stage_screen_capture` builds a fresh `ForwardingState` per call, which
+/// also means a fresh `FloodCounterStore` per call. That is invisible to a test
+/// asserting a verdict, but fatal to one asserting an accumulated per-zone
+/// tally: the thread-local accumulator survives across calls while the store it
+/// would fold into does not, so there is no run in which N packets and their
+/// totals meet. Owning the state lets a test drive the stage repeatedly and
+/// then flush ONCE into the store those packets actually accumulated against.
+fn run_stage_screen_capture_in(
+    forwarding: &ForwardingState,
+    screen: &mut ScreenState,
+    frame: &[u8],
+    meta: UserspaceDpMeta,
+    flow: Option<&SessionFlow>,
+) -> (bool, u64, Vec<crate::event_stream::codec::DataplaneEventPayload>) {
     let ident = BindingIdentity {
         slot: 0,
         queue_id: 0,
@@ -2168,7 +2187,7 @@ fn run_stage_screen_capture(
         ident: &ident,
         binding_lookup: &binding_lookup,
         mirror_targets: &mirror_targets,
-        forwarding: &forwarding,
+        forwarding,
         ha_state: &ha_state,
         dynamic_neighbors: &dynamic_neighbors,
         neighbor_resolver: None,
@@ -2550,6 +2569,194 @@ fn fabric_ingress_skips_rate_flood_direct_still_counts_4155() {
     assert!(
         d3 && c3 == 1,
         "3rd direct packet crosses udp-flood threshold 2 and DROPS"
+    );
+}
+
+/// Zone `lan` UDP-flood screen at threshold `n`, PLUS the Junos profile-wide
+/// `alarm-without-drop` audit modifier. Same profile as `udp_flood_screen`
+/// otherwise, so the pair differs on exactly the axis under test (#7086).
+fn udp_flood_screen_alarm_without_drop(n: u32) -> ScreenState {
+    let mut profiles = FxHashMap::default();
+    profiles.insert(
+        "lan".to_string(),
+        ScreenProfile {
+            udp_flood_threshold: n,
+            alarm_without_drop: true,
+            ..ScreenProfile::default()
+        },
+    );
+    let mut screen = ScreenState::new();
+    screen.update_profiles(profiles);
+    screen
+}
+
+/// #7086 fail-on-revert: a zone under `alarm-without-drop` that is tripping a
+/// flood check must accumulate per-zone flood ALARMS, and must NOT accumulate
+/// per-zone flood DROPS.
+///
+/// This is the issue's exact statement, driven through the LIVE
+/// `stage_screen_check` rather than through `record_zone_flood_alarm` directly:
+/// the defect was that the alarm arm never reached the tally at all, so a test
+/// that calls the recorder itself would pass against the broken tree. What is
+/// under test is the WIRING of the three alarm arms, not the recorder.
+///
+/// The two legs differ on exactly one axis — `alarm_without_drop` — and the
+/// drop leg is the positive control: it proves the fixture really crosses the
+/// UDP-flood threshold, so the alarm leg's empty drop snapshot is the
+/// suppression under test and not a flood that never happened. Without it,
+/// a fixture that tripped nothing would produce an identical "no drops" row.
+///
+/// It also binds the SEPARATION both ways: drop mode records drops and zero
+/// alarms, alarm mode records alarms and zero drops. Folding the alarm arm
+/// into the drop counter — the obvious fix this issue rejects — turns the
+/// alarm leg's `snapshot().is_empty()` assertion RED.
+#[test]
+fn alarm_without_drop_flood_tallies_zone_alarms_not_drops_7086() {
+    use crate::afxdp::flood_counters::flush_recorded_flood_counters;
+    const FRAG_PROTO_UDP: u8 = 17;
+    // Same benign flowless non-first UDP fragment the #4155 test uses: it
+    // trips NO L3 fragment screen, so only the source-independent UDP flood
+    // counter can act on it and the reason is unambiguously "udp-flood".
+    let frame = ipv4_fragment_frame(0x00B9, FRAG_PROTO_UDP, 100);
+    let meta = ipv4_fragment_meta(&frame, FRAG_PROTO_UDP);
+    assert!(
+        parse_session_flow_from_bytes(&frame, meta).is_none(),
+        "the fragment must be flowless so the flowless screen path runs"
+    );
+
+    // --- Leg 1, POSITIVE CONTROL: no alarm modifier. Threshold 2, four
+    // packets, so packets 3 and 4 cross and DROP.
+    let drop_fwd = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+    let mut drop_screen = udp_flood_screen(2);
+    let mut observed_drops = 0u64;
+    for _ in 0..4 {
+        let (_, drops, _) =
+            run_stage_screen_capture_in(&drop_fwd, &mut drop_screen, &frame, meta, None);
+        observed_drops += drops;
+    }
+    assert_eq!(
+        observed_drops, 2,
+        "control: threshold 2 over four packets must DROP exactly the 3rd \
+         and 4th. If this is 0 the fixture never reached the flood check and \
+         the alarm leg below would prove nothing"
+    );
+    flush_recorded_flood_counters(
+        &drop_fwd.flood_counter_store,
+        &drop_fwd.flood_counter_slot_map,
+    );
+    let drop_rows = drop_fwd.flood_counter_store.snapshot();
+    assert_eq!(
+        drop_rows.len(),
+        1,
+        "control: exactly one zone must carry per-zone flood DROPS"
+    );
+    assert_eq!(
+        drop_rows[0].udp_flood_events, 2,
+        "control: both suppressible drops are attributed to the ingress zone"
+    );
+    assert!(
+        drop_fwd.flood_counter_store.alarm_zones_for_test().is_empty(),
+        "control: a DROPPING zone raises no alarms, so the alarm triple must \
+         stay empty — the two arms are separate tallies, not one renamed"
+    );
+
+    // --- Leg 2, THE SUBJECT: identical inputs plus `alarm-without-drop`.
+    let alarm_fwd = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+    let mut alarm_screen = udp_flood_screen_alarm_without_drop(2);
+    for i in 0..4 {
+        let (dropped, drops, _) =
+            run_stage_screen_capture_in(&alarm_fwd, &mut alarm_screen, &frame, meta, None);
+        assert!(
+            !dropped && drops == 0,
+            "iteration {i}: alarm-without-drop must FORWARD and take no drop"
+        );
+    }
+    assert_eq!(
+        alarm_screen.alarm_without_drop_events(),
+        2,
+        "the same two packets that dropped in the control must raise two \
+         suppressed-drop alarms here"
+    );
+    flush_recorded_flood_counters(
+        &alarm_fwd.flood_counter_store,
+        &alarm_fwd.flood_counter_slot_map,
+    );
+
+    // The reported gap: before #7086 this zone had NOTHING published, so
+    // ReadFloodCounters returned ErrCounterNotPopulated and every surface
+    // rendered "the zone has recorded no flood events" during a live flood.
+    let alarm_rows = alarm_fwd.flood_counter_store.alarm_zones_for_test();
+    assert_eq!(
+        alarm_rows.len(),
+        1,
+        "a zone under a live flood ALARM must appear in the per-zone alarm \
+         tally; empty here is the #7086 defect (nothing published, surface \
+         renders \"not available\")"
+    );
+    assert_eq!(
+        alarm_rows[0].1,
+        (0, 0, 2),
+        "both alarms must land in the UDP family of the alarming zone"
+    );
+    assert!(
+        alarm_fwd.flood_counter_store.snapshot().is_empty(),
+        "an ALARMING zone dropped nothing, so the DROP triple must stay \
+         empty. Feeding the alarm arm into record_zone_flood_drop — the \
+         obvious fix #7086 rejects — reds here: it would make a counter \
+         whose name and call-site contract say DROP report packets that \
+         were permitted and forwarded"
+    );
+}
+
+/// #7086 drift guard: EVERY `alarm-without-drop` arm must record a per-zone
+/// flood alarm.
+///
+/// The drop side cannot drift, because every screen drop site funnels through
+/// the one `BatchCounters::record_screen_drop` method and the tally hangs off
+/// that. The alarm side has no such funnel — the suppression is decided inline
+/// in three separate arms of `stage_screen_check`, and `record_alarm_without_drop`
+/// lives in the `screen` module, which cannot see the afxdp slot map. So the
+/// per-zone call is made at each arm, and nothing but this test stops a fourth
+/// arm from being added with the alarm event and without the tally, which is
+/// #7086 re-created for whatever check that arm serves.
+///
+/// Asserts the pairing, not a magic number: the count is derived from the arms
+/// themselves, so adding a properly-wired arm keeps this green.
+#[test]
+fn every_alarm_without_drop_arm_records_a_zone_flood_alarm_7086() {
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("afxdp")
+            .join("poll_stages.rs"),
+    )
+    .expect("poll_stages.rs must be readable");
+    // Strip line comments: this test file and the call sites both NAME the
+    // symbols below, and a scan satisfied by prose describing what it should
+    // find would pass against arms that record nothing.
+    let code: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let arms = code.matches("screen.record_alarm_without_drop();").count();
+    let tallies = code.matches("record_zone_flood_alarm(").count();
+
+    // Non-vacuity first: if the alarm arms were restructured away, the
+    // equality below holds at 0 == 0 and this guard silently stops guarding.
+    assert!(
+        arms > 0,
+        "found no alarm-without-drop arms in poll_stages.rs — either the \
+         suppression moved, in which case this guard scans the wrong file, or \
+         it was removed. Either way it is not evidence the arms are wired"
+    );
+    assert_eq!(
+        arms, tallies,
+        "{arms} alarm-without-drop arm(s) but {tallies} per-zone flood alarm \
+         tally call(s): an arm suppresses a flood drop without recording it, \
+         so that zone publishes nothing and every flood surface renders \
+         \"the zone has recorded no flood events\" during a live alarm (#7086)"
     );
 }
 


### PR DESCRIPTION
A zone configured `alarm-without-drop` that is tripping a SYN/ICMP/UDP flood
check published **nothing at all**. #6938 hung the per-zone flood tally off
`BatchCounters::record_screen_drop` — the one method every screen DROP site
funnels through — but `stage_screen_check`'s alarm arms suppress the drop and
forward the packet, so they never reach it. `FloodCounterStore::snapshot` omits
all-zero rows and the Go side replaces its offset map from that sparse snapshot,
so `ReadFloodCounters` returned `ErrCounterNotPopulated` and all four render
sites printed *"the zone has recorded no flood events"* during a live flood.

Junos `alarm-without-drop` suppresses the drop, not the statistic. Both arms are
real flood **events**; what differs is the disposition.

## Not by feeding the alarm into the drop counter

Per the design on the issue, and worth restating: that counter's name, module
doc and call-site contract all say DROP. Making it report packets that were
permitted and forwarded turns an honest "not available" into a confident wrong
answer — the same class as `Enforced: yes` for a rule the helper drops (#7885).

So the alarm arm gets **its own triple** beside the drop triple, never folded
into it, and the surface gains a third distinguishable state: dropping /
alarming-and-permitting / nothing recorded. Both arms share the flat 64 KiB LUT,
the per-zone atomic block and the single per-RX-batch fold; `FloodPending` gains
a parallel `alarms` array under the same `touched_slots` bitmask, so the fold and
the reset stay one walk.

Batching is *more* load-bearing here, not less: `alarm_without_drop` is a
per-ZONE profile flag, so an alarming zone suppresses **every** flood drop it
would take, and a volumetric flood runs this path per packet on every worker with
no drop thinning it — strictly hotter than the drop path it mirrors, and exactly
the MESI ping-pong against the coordinator's status reads that #1187 documents.

## The measurement that fixed the scope boundary

`alarm_without_drop` is checked **per zone**, not per check. So an alarming zone
has zero flood drops *by construction* — it is precisely the row the sparse
snapshot omits — and `Manager.ReadFloodCounters` returns
`ErrCounterNotPopulated` only when the offset map has **no row**.

Therefore publishing alarm-only zones without teaching the Go render about
alarms would render **"SYN flood events: 0"** on a zone under a live flood
alarm: strictly worse than the bug being fixed. Predicate and render are
inseparable, so both are deferred to the surface follow-up (the #7907
cause-naming treatment). This PR stops at the counter — which is where the
design put it; the measurement is why that boundary is correct rather than
merely convenient. The `snapshot` site now documents it.

The third arm (`SynCookieChallenge`) passes the same `"syn-cookie"` literal its
own drop counterpart passes. That reason is not one of `flood_reason_index`'s
three, so both arms contribute nothing today; the call is present so the two
cannot **drift** if it ever becomes a counted family.

## Mutation matrix

Full suite, no `-run` filter, `--test-threads=1`. RED requires named
`^test ... FAILED` lines **and** tests-collected > 0.

| cell | edit | rc | collected | verdict | what red |
|------|------|----|-----------|---------|----------|
| control | none | 0 | 4836 | GREEN | — |
| m1 | delete all three tally calls (the defect) | 101 | 4834 | RED | behavioural + drift guard |
| m2 | rejected fix: alarm arms call `record_zone_flood_drop` **instead** | 101 | 4834 | RED | behavioural (alarm-tally) + drift guard |
| m3 | rejected fix: record **both** — isolates the separation assert | 101 | 4835 | RED | behavioural, `snapshot().is_empty()` only |
| m4 | `FloodPending::reset` stops clearing alarm deltas | 101 | 4835 | RED | refold cell only |
| m5 | operator clear stops zeroing the alarm triple | 101 | 4835 | RED | clear cell only |
| m6 | alarm recorder loses its reason filter | 101 | 4835 | RED | non-flood-reason cell only |

**m3 exists because m2 was not enough.** m2 reds on an assertion that runs
*before* the separation check, so the contract the issue's rejected fix violates
was still unproven. The additive cell records alarms correctly *and* feeds the
drop counter, which is the only shape that reaches `snapshot().is_empty()`.

## Instrument notes

- The subject is driven through the **live `stage_screen_check`**, not through
  `record_zone_flood_alarm`. The defect was that the arms never reached the
  recorder, so a test calling the recorder directly passes against the broken
  tree — it would bind the library, not the wiring.
- `run_stage_screen_capture` built a fresh `ForwardingState`, hence a fresh
  `FloodCounterStore`, **per call** — invisible to a verdict assertion, fatal to
  an accumulated tally, since the thread-local accumulator survives across calls
  while the store does not. A caller-owned-forwarding variant was added.
- The drop leg is a **positive control**: it proves the fixture crosses the
  UDP-flood threshold, so the alarm leg's empty drop snapshot is the suppression
  under test and not a flood that never happened.
- The drift guard derives its expected count **from the arms themselves**. The
  drop side cannot drift because of its funnel; the alarm side has none
  (`record_alarm_without_drop` lives in `screen`, which cannot see the afxdp slot
  map), so nothing else stops a fourth arm from re-creating this bug.

## Docs

`docs/userspace-dataplane-gaps.md` said the tally "lives on the DROP path" —
updated with the alarm arm, the separation rationale and the wire boundary.
Reasoning in `docs/log/7086.md`.

Closes #7086