### PR TITLE
session: key the interface map on the wire VID, not the unit number

### DIFF
--- a/pkg/cli/session_display.go
+++ b/pkg/cli/session_display.go
@@ -22,13 +22,31 @@ func sessionDisplayVLANID(unit *config.InterfaceUnit) uint16 {
 	if unit == nil {
 		return 0
 	}
-	if unit.VlanID > 0 {
-		return uint16(unit.VlanID)
-	}
-	if unit.Number > 0 {
-		return uint16(unit.Number)
-	}
-	return 0
+	// #7153: the WIRE VID, and only the wire VID. Session rows carry
+	// SessionValue.IngressVlanID as the helper stamped it off the frame, so a
+	// key built from anything else cannot match one.
+	//
+	// The old `unit.Number` fallback could never match. When `vlan-id` is unset
+	// the unit is UNTAGGED on the wire: pkg/dataplane/compiler_iface.go takes
+	// `vlanID = unit.VlanID` (0 here), and buildInterfaceNetworkdModels creates
+	// a `.N` sub-interface only when `unit.VlanID > 0` — so no sub-interface
+	// exists, the address lands on the parent netdev, and frames arrive with VID
+	// 0. Keying such a unit under its NUMBER produced {ifindex, N} while every
+	// session row for it keys {ifindex, 0}: a permanent miss for any untagged
+	// unit N > 0.
+	//
+	// The shape the fallback was written for does not need it. The loss cluster's
+	// reth0.50 / reth0.80 set `vlan-id 50` / `vlan-id 80` explicitly
+	// (docs/ha-cluster-userspace.conf), so VlanID is populated and this returns
+	// it. The fallback's own test synthesized units with Number set and VlanID
+	// unset — a config the compiler treats as untagged — and asserted the map
+	// shape rather than whether a session row could ever match it.
+	//
+	// Two units with no vlan-id on one interface now collide on {ifindex, 0},
+	// which is correct: only one can own the untagged traffic. The caller
+	// resolves that to the LOWEST unit explicitly — RangeUnits ranges a map, so
+	// leaving it to first-write-wins would pick by Go's randomized map order.
+	return uint16(unit.VlanID)
 }
 
 func buildSessionEgressIfaces(cfg *config.Config) map[sessionIfaceKey]string {
@@ -53,6 +71,14 @@ func buildSessionEgressIfacesWithLookup(cfg *config.Config, lookupIfindex func(s
 		if err != nil {
 			return
 		}
+		// #7153: two units with no `vlan-id` on one interface both key on wire
+		// VID 0 — correct, since only one can own the untagged traffic. The
+		// winner is the LOWEST unit number, chosen explicitly rather than by
+		// first-write-wins: config.RangeUnits ranges a map, so first-write-wins
+		// resolves by Go's randomized map order and the displayed name would
+		// differ between two runs on one config. A test asserting stability
+		// across iterations catches that; a single-shot assertion does not.
+		winner := make(map[sessionIfaceKey]int)
 		config.RangeUnits(ifc, func(_ int, unit *config.InterfaceUnit) {
 			displayName := ifName
 			if unit.Number != 0 || unit.VlanID != 0 {
@@ -62,9 +88,11 @@ func buildSessionEgressIfacesWithLookup(cfg *config.Config, lookupIfindex func(s
 				ifindex: uint32(parentIfindex),
 				vlanID:  sessionDisplayVLANID(unit),
 			}
-			if _, exists := egressIfaces[key]; !exists {
-				egressIfaces[key] = displayName
+			if held, exists := winner[key]; exists && held <= unit.Number {
+				return
 			}
+			winner[key] = unit.Number
+			egressIfaces[key] = displayName
 		})
 	})
 	return egressIfaces

--- a/pkg/cli/session_display_test.go
+++ b/pkg/cli/session_display_test.go
@@ -15,15 +15,28 @@ func TestSessionDisplayVLANID(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to unit number", func(t *testing.T) {
+	// #7153: it must NOT fall back to the unit number. A unit with no
+	// `vlan-id` is UNTAGGED on the wire — the compiler takes vlanID from
+	// unit.VlanID and networkd builds a `.N` sub-interface only when that is
+	// > 0 — so session rows for it carry VID 0. Keying under the NUMBER built
+	// {ifindex, 80} against rows that key {ifindex, 0}: a permanent miss.
+	t.Run("does not fall back to unit number: unset vlan-id is untagged", func(t *testing.T) {
 		unit := &config.InterfaceUnit{Number: 80}
-		if got := sessionDisplayVLANID(unit); got != 80 {
-			t.Fatalf("sessionDisplayVLANID() = %d, want 80", got)
+		if got := sessionDisplayVLANID(unit); got != 0 {
+			t.Fatalf("sessionDisplayVLANID() = %d, want 0 — a unit with no vlan-id is "+
+				"untagged on the wire, and a key of %d can never match a session row", got, got)
 		}
 	})
 }
 
-func TestBuildSessionEgressIfaces_UsesUnitNumberWhenVlanIDUnset(t *testing.T) {
+// #7153: renamed and re-pointed. It was TestBuildSessionEgressIfaces_UsesUnitNumberWhenVlanIDUnset
+// and synthesized `50: {Number: 50}` with no VlanID — a config the compiler
+// treats as UNTAGGED, so it asserted a map shape no session row could match.
+//
+// The cluster it cites does not have that shape: docs/ha-cluster-userspace.conf
+// sets `vlan-id 50` and `vlan-id 80` explicitly. The fixture now matches the
+// real config, so the test proves what its name claims.
+func TestBuildSessionEgressIfaces_KeysOnWireVLANID_7153(t *testing.T) {
 	cfg := &config.Config{
 		Chassis: config.ChassisConfig{
 			Cluster: &config.ClusterConfig{NodeID: 0},
@@ -33,8 +46,8 @@ func TestBuildSessionEgressIfaces_UsesUnitNumberWhenVlanIDUnset(t *testing.T) {
 				"reth0": {
 					Name: "reth0",
 					Units: map[int]*config.InterfaceUnit{
-						50: {Number: 50},
-						80: {Number: 80},
+						50: {Number: 50, VlanID: 50},
+						80: {Number: 80, VlanID: 80},
 					},
 				},
 				"ge-0/0/2": {

--- a/pkg/cli/session_iface_untagged_unit_7153_test.go
+++ b/pkg/cli/session_iface_untagged_unit_7153_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7153: an UNTAGGED unit N > 0 never resolved. The map keyed it under its unit
+// NUMBER while every session row for it carries wire VID 0, so
+// sessionFilter.resolveIngressIfaces missed and fell back to every interface
+// bound to the ifindex — silently widening a filter the operator wrote to be
+// exact.
+//
+// The table is the four config shapes from the issue, and the third row is the
+// defect. The first two are the controls that stop the fix being "return 0
+// always": an explicit vlan-id must still key on it, which is what the real
+// cluster config (docs/ha-cluster-userspace.conf) uses.
+func TestUntaggedUnitResolvesOnWireVID_7153(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		unit    *config.InterfaceUnit
+		wantVID uint16
+	}{
+		{"explicit vlan-id keys on it", &config.InterfaceUnit{Number: 50, VlanID: 50}, 50},
+		{"vlan-id differs from number", &config.InterfaceUnit{Number: 80, VlanID: 50}, 50},
+		{"UNTAGGED unit N>0 keys on 0", &config.InterfaceUnit{Number: 3}, 0},
+		{"unit 0", &config.InterfaceUnit{Number: 0}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionDisplayVLANID(tc.unit); got != tc.wantVID {
+				t.Errorf("sessionDisplayVLANID(%+v) = %d, want %d", tc.unit, got, tc.wantVID)
+			}
+		})
+	}
+}
+
+// End to end through the map builder, which is where the miss actually bit.
+func TestUntaggedUnitIsReachableInTheEgressMap_7153(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+					3: {Number: 3}, // no vlan-id -> untagged
+				}},
+			},
+		},
+	}
+	m := buildSessionEgressIfacesWithLookup(cfg, func(name string) (int, error) {
+		if name == "ge-0-0-0" {
+			return 42, nil
+		}
+		t.Fatalf("unexpected lookup %q", name)
+		return 0, nil
+	})
+
+	// The key a session row for this unit actually carries.
+	if got, ok := m[sessionIfaceKey{ifindex: 42, vlanID: 0}]; !ok || got != "ge-0/0/0.3" {
+		t.Errorf("the WIRE key {42,0} does not resolve (got %q, ok=%v). Session rows for an "+
+			"untagged unit carry VID 0, so this is the only key that can match one; before "+
+			"#7153 the unit was filed under {42,3} and resolveIngressIfaces fell back to "+
+			"every interface on the ifindex", got, ok)
+	}
+	// And the old key must be gone, or the map merely gained an entry and the
+	// stale one still shadows a real unit 3 elsewhere.
+	if got, ok := m[sessionIfaceKey{ifindex: 42, vlanID: 3}]; ok {
+		t.Errorf("the unit is STILL filed under its number as {42,3} -> %q; the number is not "+
+			"a wire VID and nothing keys there", got)
+	}
+}
+
+// Two units with no vlan-id on one interface collide on {ifindex, 0} — correct,
+// since only one can own the untagged traffic. First-write-wins over RangeUnits'
+// ordering must resolve it deterministically to the lowest unit rather than
+// whichever map iteration happened to land last.
+func TestUntaggedCollisionResolvesToLowestUnit_7153(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+					0: {Number: 0},
+					3: {Number: 3},
+				}},
+			},
+		},
+	}
+	for i := 0; i < 8; i++ {
+		m := buildSessionEgressIfacesWithLookup(cfg, func(string) (int, error) { return 42, nil })
+		got := m[sessionIfaceKey{ifindex: 42, vlanID: 0}]
+		if got != "ge-0/0/0" {
+			t.Fatalf("iteration %d: {42,0} = %q, want \"ge-0/0/0\" — two untagged units "+
+				"collide on VID 0 and the resolution must be deterministic, not "+
+				"map-iteration order", i, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #7153

The `{ifindex, vlanID} -> interface-name` map that **both** the `If:`/`Out:`
display columns and the #4983 ingress filter resolve through fell back to
`unit.Number` when `vlan-id` was unset. Session rows carry
`SessionValue.IngressVlanID` as the helper stamped it off the frame, so that key
**could never match one**.

A unit with no `vlan-id` is UNTAGGED on the wire: `compiler_iface.go` takes
`vlanID = unit.VlanID` (0 here) and `buildInterfaceNetworkdModels` creates a `.N`
sub-interface only when `unit.VlanID > 0`. No sub-interface exists, the address
lands on the parent netdev, frames arrive with VID 0 — while the map filed the
unit under `{ifindex, N}`.

**Every untagged unit N > 0 was a permanent miss**, and
`resolveIngressIfaces` answers a miss by falling back to *every* interface bound
to the ifindex — silently widening a filter the operator wrote to be exact.

## The shape the fallback was written for does not need it

Its test synthesized `50: {Number: 50}` with no `VlanID` — a config the compiler
treats as **untagged** — and asserted the map's *shape* rather than whether a
session row could match it. The cluster it cites sets `vlan-id 50` / `vlan-id 80`
**explicitly** (`docs/ha-cluster-userspace.conf`), so `VlanID` is populated and
the fallback never ran there.

That test is renamed and its fixture corrected to the real config, so it now
proves what its name claims. The `sessionDisplayVLANID` subtest asserting the
fallback is re-pointed to assert its absence.

## A claim of mine that the test disproved

Two units with no `vlan-id` on one interface collide on `{ifindex, 0}` — correct,
since only one can own the untagged traffic. **I wrote in the code comment that
first-write-wins would resolve it to the lowest unit. The test I wrote for that
claim failed.** `config.RangeUnits` ranges a map, so first-write-wins resolves by
Go's randomized map order and the displayed name would differ between two runs on
one config.

The winner is now the lowest unit, chosen explicitly, and the test asserts
stability **across repeated builds** — a single-shot assertion would have passed
against the non-deterministic version.

## Validation

`pkg/cli` green. Table covers all four config shapes from the issue, with the two
explicit-`vlan-id` rows as controls so the fix cannot be "return 0 always".
Repo-wide gate below.