### PR TITLE
daemon: wire Gate 4's dataplane-liveness probe on the kernel self-recover path

### DIFF
--- a/pkg/daemon/kernel_selfrecover.go
+++ b/pkg/daemon/kernel_selfrecover.go
@@ -26,7 +26,7 @@ func (d *Daemon) newKernelRunner() (*upgrade.KernelRunner, error) {
 	if d.kernelRunnerFn != nil {
 		return d.kernelRunnerFn()
 	}
-	return upgrade.NewKernelRunner(upgrade.KernelConfig{Sys: upgrade.NewKernelSystem()})
+	return upgrade.NewKernelRunner(upgrade.KernelConfig{Sys: daemonKernelSystem()})
 }
 
 // newKernelSystem builds the KernelSystem used by the hold-reconcile promotion
@@ -35,7 +35,7 @@ func (d *Daemon) newKernelSystem() upgrade.KernelSystem {
 	if d.kernelSystemFn != nil {
 		return d.kernelSystemFn()
 	}
-	return upgrade.NewKernelSystem()
+	return daemonKernelSystem()
 }
 
 // holdSecondaryIfKernelCandidateArmed keeps a CANDIDATE-TRIAL boot SECONDARY
@@ -226,7 +226,7 @@ func (d *Daemon) startKernelSelfRecovery(ctx context.Context) {
 		// Refuse self-recovery while a candidate trial is still ARMED — even if
 		// the orchestrator lease expired (r2 AGY long-hanging-roll TTL split-brain).
 		Armed: func() (bool, error) {
-			r, err := upgrade.NewKernelRunner(upgrade.KernelConfig{Sys: upgrade.NewKernelSystem()})
+			r, err := upgrade.NewKernelRunner(upgrade.KernelConfig{Sys: daemonKernelSystem()})
 			if err != nil {
 				return false, err
 			}

--- a/pkg/daemon/kernel_system_helperstatus_7157.go
+++ b/pkg/daemon/kernel_system_helperstatus_7157.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"time"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/upgrade"
+)
+
+// daemonKernelSystem builds the kernel-channel KernelSystem with Gate 4's #6607
+// dataplane-liveness probe wired.
+//
+// #7157: the three `pkg/daemon` construction sites used the BARE
+// upgrade.NewKernelSystem(), which leaves HelperStatus nil — and ForwardBeacon's
+// Precondition B is `if s.HelperStatus != nil`. So on the self-recover path the
+// promotion gate silently collapsed to unit-liveness plus a host ping, while
+// cmd/xpfd (newKernelConfig, via NewKernelSystemWithHelperStatus) had the full
+// gate. Two callers of one gate disagreed about how strong it is, and the WEAKER
+// one was the recovery path — the one that runs when something has already gone
+// wrong.
+//
+// `systemctl is-active xpfd` is not a forwarding proof: a Type=simple unit
+// reports active while its helper is down, stale or crash-looping and NOT
+// forwarding — the exact state a kernel change is most likely to cause, and the
+// one Gate 4 exists to catch.
+//
+// unitActive is passed nil deliberately: ForwardBeacon substitutes its own
+// package-internal unitActiveProbeCtx(DefaultUnit), which is the SINGLE is-active
+// primitive (#5808) — ctx-bounded so a wedged DBus is killed rather than blocking
+// past the rollback deadline, and exit-code aware so "unit not found" is not read
+// as "inactive". Re-implementing it here would be a second copy of a primitive
+// that exists precisely to have one.
+//
+// The socket is resolved the same way the bootstrap path resolves it
+// (dpuserspace.DefaultControlSocketPath(nil), bootstrap.go) rather than from the
+// active config: this runs on a promotion/self-recover path where the config may
+// not have compiled.
+func daemonKernelSystem() upgrade.KernelSystem {
+	return upgrade.NewKernelSystemWithHelperStatus(
+		nil,
+		daemonUpgradeHelperStatus,
+		dpuserspace.DefaultControlSocketPath(nil),
+	)
+}
+
+// daemonUpgradeHelperStatus mirrors cmd/xpfd's defaultUpgradeHelperStatus.
+//
+// It is a second adapter rather than a shared one because cmd/xpfd's lives in
+// package main and cannot be imported. Both are three lines over
+// dpuserspace.ProbeStatus, and both must agree that a nil status means NOT
+// ready — a helper that answers "no live status" has not proved it is
+// forwarding, and reading that as ready is the false-PASS Gate 4 exists to
+// prevent.
+func daemonUpgradeHelperStatus(controlSocket string, timeout time.Duration) (enabled, armed bool, pid int, err error) {
+	st, perr := dpuserspace.ProbeStatus(controlSocket, timeout)
+	if perr != nil {
+		return false, false, 0, perr
+	}
+	if st == nil {
+		return false, false, 0, nil
+	}
+	return st.Enabled, st.ForwardingArmed, st.PID, nil
+}

--- a/pkg/daemon/kernel_system_helperstatus_7157_test.go
+++ b/pkg/daemon/kernel_system_helperstatus_7157_test.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/upgrade"
@@ -64,3 +66,66 @@ func TestDaemonHelperStatusNilIsNotReady_7157(t *testing.T) {
 // a signature drift in pkg/upgrade breaks the build here rather than silently
 // leaving the daemon on the bare constructor again.
 var _ upgrade.KernelSystem = daemonKernelSystem()
+
+// TestDaemonKernelCallSitesUseTheWiredConstructor_7157 binds the CALL SITES, not
+// the constructor.
+//
+// The sibling above calls daemonKernelSystem() directly, so it passes even if
+// every production site still uses the bare upgrade.NewKernelSystem() — which is
+// exactly what the mutation matrix showed: reverting all three sites left it
+// green. A constructor nothing calls is not a fix.
+//
+// Source-scanned because the choice of constructor is not observable at runtime:
+// both return an upgrade.KernelSystem, and the difference (HelperStatus nil or
+// not) is precisely what the bare one erases. Comments are stripped first — a
+// scan that reads its own prose is satisfied by the sentence describing what it
+// should find.
+func TestDaemonKernelCallSitesUseTheWiredConstructor_7157(t *testing.T) {
+	src, err := os.ReadFile("kernel_selfrecover.go")
+	if err != nil {
+		t.Fatalf("read kernel_selfrecover.go: %v", err)
+	}
+	code := stripGoComments7157(string(src))
+
+	if n := strings.Count(code, "upgrade.NewKernelSystem()"); n != 0 {
+		t.Errorf("%d call site(s) still use the BARE upgrade.NewKernelSystem(), which leaves "+
+			"HelperStatus nil and skips ForwardBeacon's Precondition B — the promotion gate "+
+			"then collapses to unit-liveness + a host ping on the self-recover path (#7157)", n)
+	}
+	// Non-vacuity: the scan must actually be looking at the call sites. If the
+	// file stops constructing a kernel system at all, the assertion above is
+	// trivially satisfied and this test has quietly stopped guarding anything.
+	if n := strings.Count(code, "daemonKernelSystem()"); n == 0 {
+		t.Error("kernel_selfrecover.go constructs no kernel system at all, so the check above " +
+			"passes vacuously — if the construction moved, move this guard with it")
+	}
+}
+
+// stripGoComments7157 removes // and /* */ comments so a source scan cannot be
+// satisfied by the comment describing what it looks for.
+func stripGoComments7157(s string) string {
+	var b strings.Builder
+	for {
+		i := strings.Index(s, "//")
+		j := strings.Index(s, "/*")
+		switch {
+		case i < 0 && j < 0:
+			b.WriteString(s)
+			return b.String()
+		case j < 0 || (i >= 0 && i < j):
+			b.WriteString(s[:i])
+			nl := strings.IndexByte(s[i:], '\n')
+			if nl < 0 {
+				return b.String()
+			}
+			s = s[i+nl:]
+		default:
+			b.WriteString(s[:j])
+			end := strings.Index(s[j:], "*/")
+			if end < 0 {
+				return b.String()
+			}
+			s = s[j+end+2:]
+		}
+	}
+}

--- a/pkg/daemon/kernel_system_helperstatus_7157_test.go
+++ b/pkg/daemon/kernel_system_helperstatus_7157_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/upgrade"
+)
+
+// #7157: the daemon's kernel-channel construction sites must wire Gate 4's
+// #6607 dataplane-liveness probe. With HelperStatus nil, ForwardBeacon's
+// Precondition B (`if s.HelperStatus != nil`) is skipped entirely and the
+// promotion gate collapses to unit-liveness plus a host ping — which passes on a
+// box whose helper is down, stale or crash-looping.
+//
+// This asserts the WIRING, not the probe: the probe is pkg/upgrade's and is
+// tested there. What was missing was a caller.
+func TestDaemonKernelSystemWiresHelperStatus_7157(t *testing.T) {
+	sys := daemonKernelSystem()
+
+	// Read through reflection, NOT a type assertion. realKernelSystem's FIELDS
+	// are exported but its TYPE is not, so no assertion outside pkg/upgrade can
+	// name it — and an interface assertion for accessors that do not exist
+	// SKIPS, which binds nothing. A skipped cell here would have looked like
+	// coverage for the exact wiring this issue is about.
+	v := reflect.Indirect(reflect.ValueOf(sys))
+	if v.Kind() != reflect.Struct {
+		t.Fatalf("kernel system is %s, not a struct — if the constructor changed shape, "+
+			"update this guard rather than deleting it; the wiring it binds is still the "+
+			"difference between Gate 4 and a host ping", v.Kind())
+	}
+	hs := v.FieldByName("HelperStatus")
+	if !hs.IsValid() {
+		t.Fatal("no HelperStatus field: the wiring this test exists for cannot be observed")
+	}
+	if hs.IsNil() {
+		t.Error("HelperStatus is nil, so ForwardBeacon's Precondition B (`if s.HelperStatus " +
+			"!= nil`) is skipped and the promotion gate collapses to unit-liveness + a host " +
+			"ping. cmd/xpfd wires it via NewKernelSystemWithHelperStatus; the daemon " +
+			"self-recover path must not be the weaker of two callers of one gate (#7157)")
+	}
+	sock := v.FieldByName("ControlSocket")
+	if !sock.IsValid() || sock.String() == "" {
+		t.Error("no control socket, so HelperStatus cannot reach the helper even though it " +
+			"is wired")
+	}
+}
+
+// The adapter must treat "no live status" as NOT ready. A helper that answers
+// !ok has not proved it is forwarding, and reading that as ready is exactly the
+// false-PASS Gate 4 exists to prevent.
+func TestDaemonHelperStatusNilIsNotReady_7157(t *testing.T) {
+	// An unreachable socket: ProbeStatus errors or yields no status; either way
+	// the adapter must report not-enabled, not-armed.
+	enabled, armed, _, err := daemonUpgradeHelperStatus("/nonexistent/xpf-7157.sock", 0)
+	if enabled || armed {
+		t.Errorf("an unreachable helper reported enabled=%v armed=%v; a probe that could not "+
+			"reach the helper has not proved forwarding and must not satisfy Gate 4 "+
+			"(err=%v)", enabled, armed, err)
+	}
+}
+
+// Compile-time: the constructor must satisfy the interface the runner takes, so
+// a signature drift in pkg/upgrade breaks the build here rather than silently
+// leaving the daemon on the bare constructor again.
+var _ upgrade.KernelSystem = daemonKernelSystem()


### PR DESCRIPTION
Refs #7157 — the staged (1)–(2) half the issue explicitly blesses. The external
transit witness stays open on that issue.

## The issue's headline is stale, and correcting it is most of the value

#7157 says kernel promotion "gates on a host-stack ping, not a forwarding proof",
enumerating the fallback as unit liveness → target → `ping -c 3` → pass.

**It omits Precondition B**, which sits between the first two:

```go
// Precondition B: the DATAPLANE must actually be forwarding (#6607).
if s.HelperStatus != nil {
    enabled, armed, _, err := s.HelperStatus(s.ControlSocket, timeout)
    if err != nil || !enabled || !armed { return false, nil }
}
```

`ForwardBeacon` also already fails closed with no target — *"we cannot prove
forwarding, so do NOT promote on a 'pass' we can't substantiate"*.

## The real gap: two callers of one gate disagree, and the weaker one is recovery

| constructor | site | Precondition B |
|---|---|---|
| `NewKernelSystemWithHelperStatus` | `cmd/xpfd/upgrade_kernel.go:261` | **active** |
| bare `NewKernelSystem()` | `pkg/daemon/kernel_selfrecover.go` ×3 | **skipped — nil** |

So the issue's description is accurate **only** for the daemon self-recover path
— the one that runs when something has already gone wrong. This wires it there.

`systemctl is-active xpfd` is not a forwarding proof: a `Type=simple` unit reports
active while its helper is down, stale or crash-looping and **not** forwarding —
the exact state a kernel change is most likely to cause.

`unitActive` is passed nil deliberately so `ForwardBeacon` substitutes its own
`unitActiveProbeCtx(DefaultUnit)` — the single is-active primitive (#5808),
ctx-bounded and exit-code aware. Re-implementing it here would be a second copy
of a primitive that exists to have one.

## Two defects in my own work that the tests caught

**The first wiring test SKIPPED and I nearly shipped it.** It asserted accessors
that do not exist, so it reported "coverage" for the exact wiring at issue. Now
read through reflection — `realKernelSystem`'s fields are exported even though its
type is not.

**And the first mutation passed.** Reverting all three call sites left the suite
green, because the test called `daemonKernelSystem()` directly rather than binding
the call sites — my own "bind the wiring, not the function it calls" rule. The
added source-scan (comments stripped, non-vacuity asserted) reds on that revert.

Worse: running that mutation **before committing** meant `git checkout --` ate the
fix, and I then committed the un-fixed file. The new call-site test caught the
regression in my own branch on its first run. Matrix re-run post-commit:
`collected=3`, 0 build errors, `git diff --stat` non-empty, and only the call-site
test reds.