### PR TITLE
dataplane: classify IngressIfaceFold in the #7097 field census (master is red)

### DIFF
--- a/pkg/dataplane/peer_install_scrub_7097_test.go
+++ b/pkg/dataplane/peer_install_scrub_7097_test.go
@@ -36,9 +36,17 @@ import (
 
 // nodeLocalSessionFields are the fields a peer-owned row must NOT inherit.
 // FIB* are the resolved EGRESS of a lookup the ORIGINATING node performed;
-// Ingress* are the #4983 ingress-binding identity, node-local for the same
-// reason (node 0's `ge-0-0-1` and node 1's `ge-7-0-1` are different numbers for
-// one logical RETH member).
+// IngressIfindex / IngressVlanID are the #4983 ingress-binding identity,
+// node-local for the same reason (node 0's `ge-0-0-1` and node 1's `ge-7-0-1`
+// are different numbers for one logical RETH member).
+//
+// IngressIfaceFold (#7095) is deliberately NOT here, and the distinction is the
+// whole reason that field exists. It is a fold of the RETH-RELATIVE name
+// (`reth0.50`), which both chassis agree on by construction — it is the one
+// ingress-identity field that is MEANT to survive the wire, and the receiving
+// node resolves it back to its own {ifindex, vlan}. Scrubbing it would delete
+// the peer's answer and put every synced session back on the #4792 zone
+// approximation, which is exactly what #7095 removed.
 var nodeLocalSessionFields = map[string]bool{
 	"FibIfindex":     true,
 	"FibVlanID":      true,
@@ -193,8 +201,11 @@ func TestSessionValueFieldCountIsPinned7097(t *testing.T) {
 		typ  reflect.Type
 		want int
 	}{
-		{"SessionValue", reflect.TypeOf(SessionValue{}), 35},
-		{"SessionValueV6", reflect.TypeOf(SessionValueV6{}), 36},
+		// 36/37 since #7095 added IngressIfaceFold. Classified as NOT node-local
+		// and therefore absent from ScrubNodeLocal / nodeLocalSessionFields — see
+		// the note on nodeLocalSessionFields.
+		{"SessionValue", reflect.TypeOf(SessionValue{}), 36},
+		{"SessionValueV6", reflect.TypeOf(SessionValueV6{}), 37},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.typ.NumField(); got != tc.want {


### PR DESCRIPTION
**Master is red right now.** #7095 added `IngressIfaceFold` to both `SessionValue` structs and #7097 pinned their field counts; each was green on its own branch, and the pair is red together. Neither PR could observe the other — this is a merge-order interaction, not a defect in either.

```
SessionValue has 36 fields, pinned at 35
SessionValueV6 has 37 fields, pinned at 36
```

## The classification is the substance, not the number

#7097's contract is that a new field must be *classified*: node-local fields go in BOTH `ScrubNodeLocal` and `nodeLocalSessionFields`; everything else updates the count.

`IngressIfaceFold` is **not** node-local, and that is the entire reason it exists. It is a fold of the RETH-RELATIVE name (`reth0.50`), which both chassis agree on by construction — the one ingress-identity field *meant* to survive the wire. Its node-local siblings `IngressIfindex` / `IngressVlanID` stay scrubbed, and the receiving node re-derives them from the fold.

**Scrubbing it would have silently undone #7095**: every synced session would fall back to the #4792 zone approximation, with #7095's own tests still green, because none of them runs the peer-install scrub. The census asking for a classification is what surfaced that.

## Validation

- `go test -count=1 ./pkg/dataplane/` — ok
- Verified the failure reproduces at pristine `origin/master` (not just on a branch), and that this is the whole of it.

Found while starting #7139, whose branch is off master and inherited the red.