### PR TITLE
userspace: pin the socket directory and canonicalise the liveness probe (#7139)

### DIFF
--- a/docs/log/7139.md
+++ b/docs/log/7139.md
@@ -1,0 +1,59 @@
+# #7139 — resolve socket paths through a trusted directory
+
+## Timestamp
+2026-08-28
+
+## Action
+Close both #5839 residuals in `removeStaleUnixSocket`: pin the socket's parent
+directory with a descriptor, and key the liveness probe on the canonical path
+rather than the configured spelling.
+
+## Reachability, established before choosing a fix
+
+**The check-to-use window is reachable, and the primitive is bounded.**
+`ValidateUnixSocketPath` accepts any absolute path, so a committed
+`/tmp/xpf.sock` puts the parent in a world-writable directory. But `unlink(2)`
+does not follow a symlink in the FINAL component, so re-pointing a parent gives
+"delete the configured basename in a directory of my choosing", plus a way to
+defeat the live-listener refusal — not arbitrary file deletion. Worth stating
+precisely rather than as "a TOCTOU".
+
+**The aliasing bug is reachable by configuration alone, and is the likelier
+real-world failure.** Measured: a live socket reached through a symlinked parent
+is absent from `/proc/net/unix` under that spelling, so it read as stale and was
+unlinked out from under its listener. `/var/run` -> `/run` is a symlink on every
+systemd distro.
+
+## The issue's suggested mechanism is wrong
+
+It asks to compare `Lstat`'s inode against the `/proc/net/unix` inode column.
+Those are different objects — the socket file's filesystem inode, and the
+socket's own inode in sockfs. Measured on one live socket: **23374170** vs
+**773414179**. The comparison matches nothing, so every live socket would be
+judged stale and unlinked: a worse bug than the one being fixed, wearing the
+shape of a tightening.
+
+Dialing as a probe was already ruled out by the existing header — on the event
+socket it would make the daemon adopt the probe as its new helper.
+
+So liveness is canonical-path keyed. Only the DIRECTORY is resolved: following a
+symlink at the socket NAME would equate two distinct sockets.
+
+## Fallback direction
+An unresolvable directory degrades to a lexical clean. That can only make the
+comparison MORE likely to match, and a match REFUSES the unlink — so the failure
+mode is a visible refusal to remove a possibly-stale socket, never the removal
+of a live one.
+
+## Out of scope
+Pinning both sockets under an xpfd-owned `/run/xpf` and dropping the arbitrary
+path (#7139's third bullet). It subsumes the class but is operator-visible and
+needs its own #1960 no-brick analysis.
+
+## Note
+This branch also carries the master-red fix for the #7095/#7097 field census
+(PR #7918), which it inherited by branching off master.
+
+## Validation
+- `go test -count=1 ./pkg/dataplane/... ./pkg/config/` — ok
+- 4-cell mutation matrix, green control — see PR body

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -2349,7 +2349,7 @@ system {
 | control-socket | — | Unix socket for control protocol (typed leaf: absolute, no `.`/`..` component, ≤107 octets — see below) |
 | state-file | — | JSON state persistence path |
 
-### Socket path handling (#5273, #5839)
+### Socket path handling (#5273, #5839, #7139)
 
 `control-socket` is operator-supplied and xpfd runs as root, so both helper
 sockets are treated as untrusted paths at every bring-up.
@@ -2365,8 +2365,11 @@ never relies on it.
 is the single implementation of stale-socket removal for BOTH the control socket
 and the event socket. Before it unlinks anything it:
 
-1. `Lstat`s the path, tolerating "does not exist" (the normal first boot) and
-   judging a symlink on its own inode rather than following it;
+1. opens the socket's DIRECTORY once (`O_PATH|O_DIRECTORY`) and does everything
+   below relative to that descriptor, then `fstatat`s the final component with
+   `AT_SYMLINK_NOFOLLOW` — tolerating "does not exist" for either the socket or
+   the directory (the normal first boot) and judging a symlink on its own inode
+   rather than following it;
 2. refuses any path that is not a Unix socket — a regular file, directory,
    FIFO, device, or symlink is preserved, not deleted;
 3. refuses a socket the kernel Unix socket table still lists, i.e. one a LIVE
@@ -2376,17 +2379,39 @@ and the event socket. Before it unlinks anything it:
    AF_XDP queues. An unreadable `/proc/net/unix` is inconclusive and fails
    closed. The probe is non-invasive by design: DIALING the event socket would
    make the daemon accept the probe as its new helper and drop the real one;
-4. surfaces an `os.Remove` failure instead of discarding it.
+4. surfaces an `unlinkat` failure instead of discarding it.
 
-**Known residual (#7139).** Those checks judge a path STRING, and the unlink is
-a separate syscall on that same string. A live socket reached through a
-different spelling of the same file — most plausibly a symlinked parent
-directory — is not matched in `/proc/net/unix` and so reads as stale, and the
-target or its parent can be swapped between the check and the unlink. Closing
-either needs the trusted-directory rework (`openat2` with `RESOLVE_BENEATH`, or
-an inode-keyed liveness decision) that #7139 tracks. The typed `control-socket`
-leaf removes the spelling most likely to be written by hand (a `.`/`..`
-component) from any strict commit, but does not close the alias.
+**#7139 closed two ways, neither a stricter string test.**
+
+*The parent is pinned.* Every check and the unlink act on one directory
+descriptor, so a parent component cannot be re-pointed between them. That
+window was reachable — `ValidateUnixSocketPath` accepts any absolute path, so a
+committed `/tmp/xpf.sock` puts the parent in a world-writable directory — but
+the primitive was bounded: `unlink(2)` does not follow a symlink in the FINAL
+component, so it was "delete the configured basename in a directory of my
+choosing", plus a way to defeat the live-listener refusal, not arbitrary file
+deletion. What remains is a swap of the final component WITHIN the pinned
+directory, which is inherent to removing by name (`unlinkat` takes a name, not
+a descriptor) and requires the attacker to already be able to write the
+socket's own directory.
+
+*Liveness is keyed on the canonical path.* `/proc/net/unix` lists the string the
+LISTENER passed to `bind()`, which need not be the spelling xpf holds — and
+`/var/run` -> `/run` is a symlink on every systemd distro, so a LIVE socket read
+as stale and was unlinked out from under its listener. Both sides are now
+canonicalised, and only for entries whose basename already matches so a host
+with thousands of Unix sockets does not pay a symlink resolution each. Only the
+DIRECTORY is resolved: following a symlink at the socket NAME would equate two
+distinct sockets, so a live listener on one would refuse the unlink of the other.
+
+*Not inode-keyed*, which #7139 suggested: the socket file's filesystem inode and
+the socket's own inode in sockfs are different objects (measured: 23374170 vs
+773414179 for one live socket), so that comparison matches nothing and would
+judge every live socket stale.
+
+*Still open:* pinning both sockets under an xpfd-owned `/run/xpf` and dropping
+the arbitrary path. That subsumes the class but is an operator-visible config
+change needing its own #1960 no-brick analysis.
 
 `EventStream.Start` additionally holds a sidecar `flock` across the call, which
 serializes daemon-side owners of the socket it binds. The control socket has no

--- a/pkg/dataplane/userspace/stale_socket.go
+++ b/pkg/dataplane/userspace/stale_socket.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // Socket-kind labels for removeStaleUnixSocket. They appear verbatim in the
@@ -54,25 +57,80 @@ const (
 // socket has no such lock because xpfd does not bind it — the Rust helper does,
 // and it does not participate in the flock protocol.
 //
-// KNOWN RESIDUAL (#7139): checks 1-3 judge a path STRING, and check 4 unlinks
-// that same string in a separate syscall. A live socket reached through a
-// different spelling of the same file — most plausibly a symlinked parent
-// directory — is not matched in /proc/net/unix and so reads as stale, and the
-// target or its parent can be swapped between the check and the unlink. Closing
-// either needs the trusted-directory rework (openat2 with RESOLVE_BENEATH, or
-// an inode-keyed liveness decision) tracked in #7139, not a further string
-// test here.
+// #7139 CLOSED TWO WAYS, and neither is a stricter string test.
+//
+// THE PARENT IS PINNED. The directory is opened ONCE (O_PATH|O_DIRECTORY) and
+// every subsequent operation is relative to that descriptor — fstatat for the
+// checks, unlinkat for the removal. Previously each step re-resolved the whole
+// path string, so an attacker who could re-point a parent component between two
+// of them redirected the unlink into a different directory. `unlink` does not
+// follow a symlink in the FINAL component, so that was never arbitrary file
+// deletion; it was "delete the configured basename in a directory of my
+// choosing", plus a way to defeat the live-listener refusal in check 3. Both
+// need the path's parent to be attacker-writable, which the config permits
+// today: ValidateUnixSocketPath accepts any absolute path, so a committed
+// `/tmp/xpf.sock` puts the parent in a world-writable directory.
+//
+// What remains after pinning is a swap of the FINAL component within that same
+// directory, which is inherent to removing by name — unlinkat takes a name, not
+// a descriptor. It is strictly smaller: the attacker must already be able to
+// write the socket's own directory.
+//
+// LIVENESS IS KEYED ON THE CANONICAL PATH, not the configured spelling. The
+// kernel table lists the string the listener passed to bind(), which need not
+// be the spelling xpf holds, and `/var/run` -> `/run` is a symlink on every
+// systemd distro — so a LIVE socket read as stale and was unlinked out from
+// under its listener. Both sides are now canonicalised before comparison.
+//
+// NOT INODE-KEYED, and the issue's suggestion to compare Lstat's inode against
+// the /proc/net/unix inode column is wrong — measured, not assumed. They are
+// different objects: the filesystem inode of the bound socket file and the
+// socket's own inode in sockfs. On one live socket here they read 23374170 and
+// 773414179. Comparing them matches NOTHING, so every live socket would be
+// judged stale and unlinked — a worse bug than the one being fixed, wearing the
+// shape of a tightening.
+//
+// STILL OUT OF SCOPE (#7139's third bullet): pinning both sockets under an
+// xpfd-owned /run/xpf and dropping the arbitrary path. That subsumes the whole
+// class, but it is an operator-visible config change and needs its own #1960
+// no-brick analysis for deployments that already set a custom path.
 func removeStaleUnixSocket(kind, path string) error {
-	info, err := os.Lstat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
+	dir, base := filepath.Split(path)
+	if base == "" {
+		return fmt.Errorf("refusing to unlink %s %s: path names no file", kind, path)
 	}
+	if dir == "" {
+		dir = "."
+	}
+
+	// Resolve the DIRECTORY once and hold it. Symlinks are followed here on
+	// purpose — an operator naming /var/run/xpf means the real /run/xpf, and
+	// refusing that would break a legitimate configuration. What the descriptor
+	// buys is that every step below acts on THIS directory, so no later
+	// re-pointing of a parent component can move the target.
+	dirFD, err := unix.Open(dir, unix.O_DIRECTORY|unix.O_PATH|unix.O_CLOEXEC, 0)
 	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			// No directory means no socket. A first boot before the runtime
+			// directory exists is the normal case, not an error.
+			return nil
+		}
+		return fmt.Errorf("open %s directory %s: %w", kind, dir, err)
+	}
+	defer unix.Close(dirFD)
+
+	var st unix.Stat_t
+	if err := unix.Fstatat(dirFD, base, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil
+		}
 		return fmt.Errorf("inspect %s %s: %w", kind, path, err)
 	}
-	if info.Mode()&os.ModeSocket == 0 {
+	// AT_SYMLINK_NOFOLLOW so a SYMLINK is judged on its own inode: a symlink is
+	// not a socket and is refused below rather than followed to its target.
+	if st.Mode&unix.S_IFMT != unix.S_IFSOCK {
 		return fmt.Errorf("refusing to unlink %s %s: existing path is a %s, not a Unix socket",
-			kind, path, describeFileMode(info.Mode()))
+			kind, path, describeFileMode(modeFromStat(st.Mode)))
 	}
 
 	active, err := unixSocketPathActive(path)
@@ -82,10 +140,31 @@ func removeStaleUnixSocket(kind, path string) error {
 	if active {
 		return fmt.Errorf("refusing to unlink %s %s: it already has a live listener", kind, path)
 	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := unix.Unlinkat(dirFD, base, 0); err != nil && !errors.Is(err, unix.ENOENT) {
 		return fmt.Errorf("remove stale %s %s: %w", kind, path, err)
 	}
 	return nil
+}
+
+// modeFromStat converts a raw st_mode file-type to the os.FileMode bits
+// describeFileMode reads, so the operator-facing wording is unchanged by the
+// move from os.Lstat to fstatat.
+func modeFromStat(m uint32) os.FileMode {
+	switch m & unix.S_IFMT {
+	case unix.S_IFDIR:
+		return os.ModeDir
+	case unix.S_IFLNK:
+		return os.ModeSymlink
+	case unix.S_IFIFO:
+		return os.ModeNamedPipe
+	case unix.S_IFSOCK:
+		return os.ModeSocket
+	case unix.S_IFCHR:
+		return os.ModeDevice | os.ModeCharDevice
+	case unix.S_IFBLK:
+		return os.ModeDevice
+	}
+	return 0
 }
 
 // unixSocketPathActive reports whether the kernel Unix socket table lists a
@@ -97,16 +176,58 @@ func unixSocketPathActive(path string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("inspect kernel Unix socket table for %s: %w", path, err)
 	}
+	want := canonicalSocketPath(path)
+	base := filepath.Base(path)
 	for _, line := range strings.Split(string(data), "\n") {
 		fields := strings.Fields(line)
 		// Columns are fixed through Flags/Type/St/Inode; the path is the
 		// 8th field onward, rejoined because a bound path may contain
 		// spaces.
-		if len(fields) >= 8 && strings.Join(fields[7:], " ") == path {
+		if len(fields) < 8 {
+			continue
+		}
+		bound := strings.Join(fields[7:], " ")
+		if bound == path {
+			return true, nil
+		}
+		// #7139: the table lists the string the LISTENER bound, which need not
+		// be the spelling this node holds. Canonicalise before deciding — but
+		// only for entries whose basename already matches, so a host with
+		// thousands of Unix sockets does not pay a symlink resolution each.
+		if filepath.Base(bound) != base {
+			continue
+		}
+		if canonicalSocketPath(bound) == want {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+// canonicalSocketPath resolves a socket path's DIRECTORY through symlinks and
+// rejoins the final component.
+//
+// The directory is resolved and the base is not, deliberately: the base names
+// the socket itself, whose own identity is the question, while the directory is
+// where the aliasing lives (`/var/run` -> `/run`). Resolving the whole path
+// would follow a symlink AT the socket name and could equate two different
+// sockets.
+//
+// An unresolvable directory falls back to a lexical cleanup rather than
+// failing. This function only ever makes the comparison MORE likely to match,
+// and matching means "a live listener holds it" — which refuses the unlink. So
+// the failure direction is a refusal to remove a socket that may be stale,
+// visible to the operator, rather than a removal of one that is live.
+func canonicalSocketPath(p string) string {
+	dir, base := filepath.Split(p)
+	if dir == "" {
+		dir = "."
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return filepath.Join(resolved, base)
 }
 
 // describeFileMode names the file type an operator sees at a refused path, so

--- a/pkg/dataplane/userspace/stale_socket_trusted_dir_7139_test.go
+++ b/pkg/dataplane/userspace/stale_socket_trusted_dir_7139_test.go
@@ -1,0 +1,187 @@
+package userspace
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stale_socket_trusted_dir_7139_test.go — #7139.
+//
+// Two residuals of #5839, both measured before they were fixed:
+//
+//  1. the liveness probe compared the configured path STRING against
+//     /proc/net/unix, so a live socket reached through another spelling of the
+//     same file read as STALE and was unlinked out from under its listener;
+//  2. every check re-resolved the whole path, so a parent component could be
+//     re-pointed between a check and the unlink.
+//
+// The fixtures use a SHORT scratch root because AF_UNIX sun_path is 108 octets
+// and t.TempDir() under a long TMPDIR silently exceeds it — a bind that fails
+// for length looks exactly like a bind that fails for the reason under test.
+
+func shortTempDir7139(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "x7139")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// TestLiveSocketThroughSymlinkedParentIsNotUnlinked_7139 is residual 1, and it
+// is the outage case rather than the attack case: `/var/run` -> `/run` is a
+// symlink on every systemd distro, so this is reachable by configuration alone.
+func TestLiveSocketThroughSymlinkedParentIsNotUnlinked_7139(t *testing.T) {
+	real := shortTempDir7139(t)
+	sock := filepath.Join(real, "c.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Skipf("cannot bind a unix socket here: %v", err)
+	}
+	defer ln.Close()
+
+	// A second spelling of the very same file, via a symlinked parent.
+	alias := real + "-link"
+	if err := os.Symlink(real, alias); err != nil {
+		t.Skipf("cannot symlink: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(alias) })
+	aliasSock := filepath.Join(alias, "c.sock")
+
+	// Precondition: the alias spelling is genuinely absent from the kernel
+	// table, which is what made the old string compare answer "stale". Without
+	// this the cell could pass because the table happened to list both.
+	data, err := os.ReadFile("/proc/net/unix")
+	if err != nil {
+		t.Skipf("cannot read /proc/net/unix: %v", err)
+	}
+	if strings.Contains(string(data), aliasSock) {
+		t.Fatalf("precondition: the kernel table lists the ALIAS spelling %q, so this "+
+			"fixture no longer reproduces the aliasing the fix is for", aliasSock)
+	}
+
+	err = removeStaleUnixSocket(socketKindControl, aliasSock)
+	if err == nil {
+		t.Fatal("removeStaleUnixSocket UNLINKED a live socket reached through a " +
+			"symlinked parent. Its listener keeps serving an unreachable inode while " +
+			"the next bring-up binds a fresh socket at the same path — two helpers " +
+			"contending for the same AF_XDP queues, with the first undialable (#7139)")
+	}
+	if !strings.Contains(err.Error(), "live listener") {
+		t.Fatalf("refused for the WRONG REASON: %v. It must be recognised as live, not "+
+			"rejected for some incidental property of the path", err)
+	}
+	if _, statErr := os.Stat(sock); statErr != nil {
+		t.Fatalf("the socket file is gone after a refusal: %v", statErr)
+	}
+}
+
+// TestStaleSocketIsStillRemoved_7139 is the negative control: without it every
+// assertion above is satisfied by a function that refuses everything.
+func TestStaleSocketIsStillRemoved_7139(t *testing.T) {
+	dir := shortTempDir7139(t)
+	sock := filepath.Join(dir, "c.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Skipf("cannot bind: %v", err)
+	}
+	// Close WITHOUT removing the file: the classic stale socket, left by a
+	// helper that died.
+	if ul, ok := ln.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+	_ = ln.Close()
+	if _, err := os.Stat(sock); err != nil {
+		t.Skipf("listener removed its own socket, cannot stage a stale one: %v", err)
+	}
+
+	if err := removeStaleUnixSocket(socketKindControl, sock); err != nil {
+		t.Fatalf("a genuinely stale socket must be removed, got: %v", err)
+	}
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("stale socket still present after removal: %v", err)
+	}
+}
+
+// TestNonSocketIsRefusedThroughTheDirFD_7139 keeps #5839's data-destruction
+// guarantee across the move from os.Lstat/os.Remove to fstatat/unlinkat. The
+// file-type wording is operator-facing, so it is asserted, not just the refusal.
+func TestNonSocketIsRefusedThroughTheDirFD_7139(t *testing.T) {
+	dir := shortTempDir7139(t)
+	for _, tc := range []struct {
+		name, want string
+		create     func(string) error
+	}{
+		{"regular_file", "regular file", func(p string) error { return os.WriteFile(p, []byte("x"), 0o600) }},
+		{"directory", "directory", func(p string) error { return os.Mkdir(p, 0o755) }},
+		{"symlink", "symlink", func(p string) error { return os.Symlink("/dev/null", p) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(dir, tc.name)
+			if err := tc.create(p); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			err := removeStaleUnixSocket(socketKindControl, p)
+			if err == nil {
+				t.Fatalf("removeStaleUnixSocket DELETED a %s. #5839's whole subject is "+
+					"that xpfd runs as root and the path is operator-supplied", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error names the wrong file type: %v (want %q)", err, tc.want)
+			}
+			if _, statErr := os.Lstat(p); statErr != nil {
+				t.Fatalf("the %s was removed despite the refusal: %v", tc.name, statErr)
+			}
+		})
+	}
+}
+
+// TestMissingSocketAndMissingDirAreNotErrors_7139: a first boot has neither, and
+// that is the normal path, not a failure. The directory case is new — the old
+// code Lstat'd the file and never opened the parent.
+func TestMissingSocketAndMissingDirAreNotErrors_7139(t *testing.T) {
+	dir := shortTempDir7139(t)
+	if err := removeStaleUnixSocket(socketKindControl, filepath.Join(dir, "absent.sock")); err != nil {
+		t.Fatalf("absent socket must be tolerated: %v", err)
+	}
+	if err := removeStaleUnixSocket(socketKindControl, filepath.Join(dir, "no-such-dir", "c.sock")); err != nil {
+		t.Fatalf("absent DIRECTORY must be tolerated (first boot before the runtime "+
+			"directory exists), got: %v", err)
+	}
+}
+
+// TestCanonicalSocketPathResolvesDirNotBase_7139 pins the asymmetry directly.
+//
+// The directory is resolved and the base is not: the base names the socket whose
+// identity is the question, and following a symlink AT that name would equate
+// two different sockets.
+func TestCanonicalSocketPathResolvesDirNotBase_7139(t *testing.T) {
+	real := shortTempDir7139(t)
+	alias := real + "-link"
+	if err := os.Symlink(real, alias); err != nil {
+		t.Skipf("cannot symlink: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(alias) })
+
+	got := canonicalSocketPath(filepath.Join(alias, "c.sock"))
+	want := canonicalSocketPath(filepath.Join(real, "c.sock"))
+	if got != want {
+		t.Fatalf("two spellings of one file canonicalised differently: %q vs %q", got, want)
+	}
+
+	// A symlink AT the base must NOT be followed: two names pointing at one
+	// target are still two sockets as far as bind() is concerned.
+	other := filepath.Join(real, "other.sock")
+	if err := os.Symlink(filepath.Join(real, "c.sock"), other); err != nil {
+		t.Skipf("cannot symlink: %v", err)
+	}
+	if canonicalSocketPath(other) == want {
+		t.Fatal("canonicalSocketPath followed a symlink at the BASE, equating two " +
+			"distinct socket names; a live listener on one would then refuse the " +
+			"unlink of the other")
+	}
+}


### PR DESCRIPTION
Closes #7139

> Includes the master-red fix from **#7918** (the #7095/#7097 field census),
> inherited by branching off master. If #7918 merges first this reduces to the
> socket change alone.

## Reachability, established before choosing a fix

**The check-to-use window is reachable, and the primitive is bounded — worth
stating precisely rather than as "a TOCTOU".** `ValidateUnixSocketPath` accepts
any absolute path, so a committed `/tmp/xpf.sock` puts the parent in a
world-writable directory. But `unlink(2)` does **not** follow a symlink in the
FINAL component, so re-pointing a parent gives *"delete the configured basename
in a directory of my choosing"*, plus a way to defeat the live-listener refusal —
not arbitrary file deletion.

**The aliasing bug is reachable by configuration alone and is the likelier
real-world failure.** Measured: a live socket reached through a symlinked parent
is absent from `/proc/net/unix` under that spelling, so it read as **stale** and
was unlinked out from under its listener. `/var/run` → `/run` is a symlink on
every systemd distro. Unlinking a live socket does not stop the listener — it
makes it unreachable (including to the #1993 boot armed-probe) while the next
bring-up binds a fresh socket at the same name and then fails to claim the AF_XDP
queues.

## What I did — the structural fix, per your steer

**The parent is pinned.** The directory is opened once (`O_PATH|O_DIRECTORY`) and
the checks and the unlink run relative to that descriptor: `fstatat` with
`AT_SYMLINK_NOFOLLOW`, then `unlinkat`. Symlinks in the *directory* path are
still followed, deliberately — an operator naming `/var/run/xpf` means the real
`/run/xpf`, and refusing that would break a legitimate config. What remains is a
swap of the final component *within* the pinned directory, inherent to removing
by name (`unlinkat` takes a name, not a descriptor), and it requires the attacker
to already be able to write the socket's own directory.

**Liveness is canonical-path keyed**, and only for entries whose basename already
matches, so a host with thousands of Unix sockets does not pay a symlink
resolution each. Only the DIRECTORY is resolved: following a symlink at the
socket NAME would equate two distinct sockets, and a live listener on one would
then refuse the unlink of the other.

## The issue's proposed mechanism is wrong, measured not assumed

#7139 asks to compare `Lstat`'s inode against the `/proc/net/unix` inode column.
Those are **different objects** — the socket file's filesystem inode, and the
socket's own inode in sockfs. On one live socket here:

```
filesystem inode (Lstat)    = 23374170
/proc/net/unix inode column = 773414179
```

The comparison matches nothing, so **every live socket would be judged stale and
unlinked** — a worse bug than the one being fixed, wearing the shape of a
tightening. Dialing as a probe was already ruled out by the existing header: on
the event socket it would make the daemon adopt the probe as its new helper.

**The fallback direction is deliberate.** An unresolvable directory degrades to a
lexical clean, which can only make the comparison MORE likely to match — and a
match REFUSES the unlink. The failure mode is a visible refusal to remove a
possibly-stale socket, never the removal of a live one.

## Out of scope, and why

#7139's third bullet — pin both sockets under an xpfd-owned `/run/xpf` and drop
the arbitrary path — subsumes the whole class, but it is an operator-visible
config change and needs its own #1960 no-brick analysis for deployments already
setting a custom path. The issue says so itself; recorded rather than
half-started.

## Validation

- `go test -count=1 ./...` — 0 failures, `git ls-files -u` empty before gating
- Mutation matrix, green control:

| cell | mutation | named failing tests |
|---|---|---|
| CONTROL | none | 0 (green) |
| T1 | liveness compares the raw string again | `TestLiveSocketThroughSymlinkedParentIsNotUnlinked_7139` |
| T2 | canonicalise the whole path (follow a symlink at the base) | `TestCanonicalSocketPathResolvesDirNotBase_7139` |
| T3 | drop `AT_SYMLINK_NOFOLLOW` | `TestRemoveStaleUnixSocketRefusesNonSocketPaths_5839` |

T3 reds the **pre-existing #5839 guard**, which is the answer to "did the rewrite
keep the data-destruction property" — it did, and the old cell still owns it.

(An earlier T1 came back VOID with a build error — my mutation left variables
unused. Rerun as T1b once it compiled, and it bites.)

The fixtures use a short `/tmp` scratch root on purpose: AF_UNIX `sun_path` is
108 octets and `t.TempDir()` under a long `TMPDIR` silently exceeds it, so a bind
failing for length would look exactly like a bind failing for the reason under
test.

No cluster smoke: socket lifecycle on the local node, no forwarding or HA
behaviour change.
