### PR TITLE
Give the reverse companion its own unobserved-field reset (#7917)

### DIFF
--- a/docs/log/7917.md
+++ b/docs/log/7917.md
@@ -1,0 +1,57 @@
+# #7917 — reverse companion inherits the forward direction's ingress identity
+
+- **Timestamp**: 2026-08-28
+- **Action**: gave the reverse companion its own named reset; cleared the #4983
+  ingress identity in all three spellings; pinned the divergence from the #7097
+  node-local scrub.
+- **File(s)**: `pkg/dataplane/session_reverse_companion.go` (new),
+  `pkg/dataplane/userspace/manager_sessions.go`,
+  `pkg/dataplane/reverse_companion_reset_7917_test.go` (new),
+  `pkg/dataplane/userspace/reverse_companion_ingress_7917_test.go` (new),
+  `docs/session-sync-architecture.md`
+
+## What the investigation added to the filed issue
+
+The issue was filed from #7097 as "the companion inherits `IngressIfindex` /
+`IngressVlanID`". Re-deriving at master found a third field and a second
+surface:
+
+- **`IngressIfaceFold` (#7095) is also inherited**, and it matters more than the
+  other two. `buildSessionSyncRequestV4` does NOT build the request's
+  `IngressIfindex` from `val.IngressIfindex` — since #7095 it RESOLVES it from
+  the fold. So the companion leaked the forward binding to the **helper**, not
+  only to the BPF map row. A fix that cleared the two node-local fields and left
+  the fold would have passed a struct-level census and changed nothing on the
+  wire.
+- That settles the "two rules or one" question with evidence rather than
+  argument. `ScrubNodeLocal` must NOT clear the fold — it is cluster-stable and
+  must cross the wire. The companion reset MUST. **The two field sets now
+  genuinely differ**, which is why the tempting delegation to `ScrubNodeLocal` is
+  wrong, and why the divergence is pinned in a test.
+
+## Base
+
+Stacked on `fix/7095-fold-resolver-deadlock` (PR #7922). Not for convenience:
+the wire-level test needs a RESOLVABLE non-zero fold, and with the #7095
+resolver deadlock present that call never returns. Written against master the
+test would have had to use `fold == 0`, which makes the forward-side assertion
+vacuous.
+
+## Guards
+
+- `TestReverseCompanionResetCoversExactlyTheUnobservedFields7917` — census over
+  the reset, both families, both directions, anti-vacuity floor.
+- `TestCompanionResetAndNodeLocalScrubAreDifferentRules7917` — the divergence
+  pin, with its own anti-vacuity check that the two sets still OVERLAP (two
+  unrelated sets would satisfy `!DeepEqual` for the wrong reason).
+- `TestReverseCompanionCarriesNoIngressIdentityV4/V6_7917` — wire-level, through
+  the real session socket. Asserts the companion request carries no ingress
+  identity AND that the forward request still does (the over-reach control:
+  clearing both halves would satisfy the subject while destroying what #4983
+  exists to provide).
+
+Note on the wire test: identify the forward/companion pair by SOURCE IP, not
+port. The builder converts ports network->host, so comparing a raw literal
+mislabels the pair — and an inverted label turns the two assertions into each
+other's opposite. That happened on the first run and is why the identification
+is by IP.

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -131,11 +131,36 @@ census, both directions, plus a struct field-count pin) and
 peer-install site delegates and none has re-grown a private list) are what keep
 the one list complete.
 
-The reverse COMPANION that `mirrorSessionPairV4` / `...V6` synthesize is a
-different case and deliberately does not use this helper: it resets fields
-because the reverse direction has not been OBSERVED yet, not because they belong
-to another node. Folding the two would make a future node-local field
-automatically a reverse-companion reset, which does not follow.
+The reverse COMPANION that `mirrorSessionPairV4` / `...V6` synthesize has its
+own reset, `SessionValue.ResetUnobservedForReverseCompanion()`
+(`pkg/dataplane/session_reverse_companion.go`, #7917). It clears fields because
+the reverse direction has not OBSERVED them yet, not because they belong to
+another node — a different question with a different answer.
+
+Before #7917 the companion cleared only the cached FIB result, so it inherited
+the FORWARD direction's #4983 ingress identity. `pkg/dataplane/types.go` already
+named the companion as the first legitimate-`0` population and gave the reason —
+the forward flow's egress is a PREDICTION of where the reply will arrive, not an
+OBSERVATION of where it did, and routing may be asymmetric — so the code
+contradicted the contract the design note states.
+
+The two resets are NOT interchangeable, and since #7095 they no longer even
+cover the same fields:
+
+| field | `ScrubNodeLocal` | companion reset |
+|---|---|---|
+| `Fib*` (5) | yes | yes |
+| `IngressIfindex` / `IngressVlanID` | yes | yes |
+| `IngressIfaceFold` | **no** | **yes** |
+
+`IngressIfaceFold` is the #7095 CLUSTER-STABLE fold whose entire purpose is to
+cross the wire so the #4983 identity survives a failover, so the node-local scrub
+must leave it alone. The companion must clear it, because
+`buildSessionSyncRequestV4` resolves the request's ingress identity FROM the fold
+(`resolveIngressFoldLocked`) — a companion that keeps it stamps the forward
+direction's binding onto the row the helper installs, which is the wire half of
+the same defect. `TestCompanionResetAndNodeLocalScrubAreDifferentRules7917` pins
+the divergence so the two cannot be folded together.
 
 **#7581 — a synced import with no pool to reserve from is not a collision.**
 Before publishing a peer-synced session the helper reserves its translated NAT

--- a/pkg/dataplane/reverse_companion_reset_7917_test.go
+++ b/pkg/dataplane/reverse_companion_reset_7917_test.go
@@ -1,0 +1,126 @@
+package dataplane
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #7917: the reverse companion must not inherit the FORWARD direction's ingress
+// identity.
+//
+// `mirrorSessionPairV4`/`V6` synthesize a reverse companion by copying the
+// forward value, swapping the zones, and clearing the cached FIB result. They did
+// not clear the #4983 ingress identity, so the companion carried the forward
+// direction's ingress binding — a value `pkg/dataplane/types.go` names as a
+// legitimate-`0` population, because a prediction of where the reply will arrive
+// is not an observation of where it did and routing may be asymmetric.
+//
+// These tests use the same census shape as the #7097 scrub guard (fill every
+// field with a sentinel, compare the zeroed set against a declared set in BOTH
+// directions), and add the one thing that change did not need: a pin that this
+// reset and `ScrubNodeLocal` stay DIFFERENT rules.
+
+// companionResetFields are the fields a reverse companion must not inherit.
+var companionResetFields = map[string]bool{
+	// Forward egress — the reply's egress is a separate lookup.
+	"FibIfindex": true,
+	"FibVlanID":  true,
+	"FibDmac":    true,
+	"FibSmac":    true,
+	"FibGen":     true,
+	// Forward ingress — unobserved for the reply, in all three spellings.
+	"IngressIfindex":   true,
+	"IngressVlanID":    true,
+	"IngressIfaceFold": true,
+}
+
+func assertCompanionCensus(t *testing.T, before, after reflect.Value) {
+	t.Helper()
+	reset := zeroedFields(before, after)
+	if len(reset) == 0 {
+		t.Fatal("the companion reset cleared NOTHING — the fixture or the call did " +
+			"not run, and the two directional checks below would both pass vacuously")
+	}
+	for name := range companionResetFields {
+		if !reset[name] {
+			t.Errorf("%s records something the REVERSE direction has not observed, "+
+				"but the companion inherited it from the forward session. That is a "+
+				"confident value on an unobserved binding, which is the failure mode "+
+				"`0` exists to avoid (#7917)", name)
+		}
+	}
+	for name := range reset {
+		if !companionResetFields[name] {
+			t.Errorf("the companion reset clears %s, which is not declared unobserved. "+
+				"Either it is and this list is stale, or the reset is destroying a "+
+				"field the companion legitimately carries — the forward row's counters "+
+				"and zones are deliberately NOT reset here (#7917)", name)
+		}
+	}
+}
+
+func TestReverseCompanionResetCoversExactlyTheUnobservedFields7917(t *testing.T) {
+	t.Run("v4", func(t *testing.T) {
+		var val SessionValue
+		fillNonZero(t, reflect.ValueOf(&val).Elem())
+		before := reflect.ValueOf(val)
+		val.ResetUnobservedForReverseCompanion()
+		assertCompanionCensus(t, before, reflect.ValueOf(val))
+	})
+	t.Run("v6", func(t *testing.T) {
+		var val SessionValueV6
+		fillNonZero(t, reflect.ValueOf(&val).Elem())
+		before := reflect.ValueOf(val)
+		val.ResetUnobservedForReverseCompanion()
+		assertCompanionCensus(t, before, reflect.ValueOf(val))
+	})
+}
+
+// The divergence pin. The tempting simplification is to make the companion call
+// `ScrubNodeLocal` — it clears most of the same fields. This asserts why that is
+// wrong, in a form that fails if someone does it.
+//
+// The two rules answer different questions:
+//
+//	ScrubNodeLocal                    "does this value belong to another NODE?"
+//	ResetUnobservedForReverseCompanion "has this DIRECTION observed this yet?"
+//
+// `IngressIfaceFold` is where they visibly part company, and it is not a
+// hypothetical: #7095 added it as a CLUSTER-STABLE fold whose whole purpose is
+// to cross the wire, so the node-local scrub must leave it alone — while the
+// companion must clear it, because the wire request derives its ingress identity
+// from the fold and would otherwise stamp the forward binding on the reply.
+func TestCompanionResetAndNodeLocalScrubAreDifferentRules7917(t *testing.T) {
+	if !companionResetFields["IngressIfaceFold"] {
+		t.Fatal("the companion reset must clear IngressIfaceFold: the helper wire " +
+			"request derives its ingress identity from the fold, so a companion that " +
+			"keeps it stamps the FORWARD direction's binding on the reply (#7917)")
+	}
+	if nodeLocalSessionFields["IngressIfaceFold"] {
+		t.Fatal("ScrubNodeLocal must NOT clear IngressIfaceFold: it is the #7095 " +
+			"CLUSTER-STABLE fold, and zeroing it on a peer install is what it exists " +
+			"to prevent — the #4983 identity would stop surviving a failover (#7917)")
+	}
+	if reflect.DeepEqual(companionResetFields, nodeLocalSessionFields) {
+		t.Fatal("the reverse-companion reset and the node-local scrub now cover the " +
+			"same fields. They are different rules — 'belongs to another node' and " +
+			"'this direction has not observed it' — and collapsing them makes every " +
+			"future node-local field a companion reset and vice versa, neither of " +
+			"which follows (#7917)")
+	}
+
+	// Anti-vacuity: the check above is only meaningful while both sets are
+	// non-empty and actually overlap. Two unrelated sets would satisfy
+	// !DeepEqual for the wrong reason.
+	var shared int
+	for name := range companionResetFields {
+		if nodeLocalSessionFields[name] {
+			shared++
+		}
+	}
+	if shared == 0 {
+		t.Fatal("the two sets no longer overlap at all, so the divergence assertion " +
+			"above proves nothing about them being confusable — re-read whether " +
+			"either list is still describing what this test thinks it describes")
+	}
+}

--- a/pkg/dataplane/session_reverse_companion.go
+++ b/pkg/dataplane/session_reverse_companion.go
@@ -1,0 +1,69 @@
+package dataplane
+
+// The reverse companion's "not yet observed" reset (#7917).
+//
+// When a forward session is installed, a REVERSE companion is synthesized for
+// it so the reply direction is already present before it is needed. The
+// companion is built by copying the forward value and adjusting the parts that
+// are direction-dependent — the zone pair is swapped, `IsReverse` is set, and
+// `ReverseKey` points back.
+//
+// Some fields must additionally be CLEARED, because they record an OBSERVATION
+// the reverse direction has not made yet:
+//
+//   - the cached FIB result. It is the forward direction's resolved egress; the
+//     reply's egress is a different lookup and must be re-resolved locally.
+//   - the #4983 ingress identity. `pkg/dataplane/types.go` names the reverse
+//     companion as the first legitimate-`0` population and gives the reason:
+//     "its own ingress has not been OBSERVED yet ... the forward flow's egress
+//     IS known at install — it is the wrong datum, being a PREDICTION of where
+//     the reply will arrive rather than an OBSERVATION of where it did, and
+//     routing may be asymmetric."
+//
+// WHY THIS IS NOT `ScrubNodeLocal` (#7097), THE OTHER RESET OVER THESE FIELDS.
+// The two overlap but are different rules, and as of #7095 they no longer even
+// cover the same fields:
+//
+//   - `ScrubNodeLocal` strips values that BELONG TO ANOTHER NODE. It must NOT
+//     touch `IngressIfaceFold`, whose entire purpose is to be cluster-stable and
+//     cross the wire so the #4983 identity survives a failover.
+//   - this reset strips values the reverse direction HAS NOT OBSERVED. It MUST
+//     clear `IngressIfaceFold`, because "where the first packet arrived" is
+//     exactly as unobserved for the reply as the node-local ifindex is — and the
+//     helper wire request derives its ingress identity FROM the fold
+//     (`buildSessionSyncRequestV4` -> `resolveIngressFold`), so leaving it set
+//     stamps the FORWARD direction's ingress binding onto the companion.
+//
+// Folding the two would make every future node-local field automatically a
+// reverse-companion reset, and every future companion reset automatically a
+// cross-node scrub. Neither implication holds.
+// `TestCompanionResetAndNodeLocalScrubAreDifferentRules7917` pins the divergence.
+
+// ResetUnobservedForReverseCompanion clears every field that records something
+// the REVERSE direction has not observed yet. Call it on the copy destined to
+// become a forward session's reverse companion, after the zone swap.
+func (v *SessionValue) ResetUnobservedForReverseCompanion() {
+	// Forward egress — the reply's egress is a separate lookup.
+	v.FibIfindex = 0
+	v.FibVlanID = 0
+	v.FibDmac = [6]byte{}
+	v.FibSmac = [6]byte{}
+	v.FibGen = 0
+	// Forward ingress — where the reply will arrive is a prediction, not an
+	// observation, and routing may be asymmetric.
+	v.IngressIfindex = 0
+	v.IngressVlanID = 0
+	v.IngressIfaceFold = 0
+}
+
+// ResetUnobservedForReverseCompanion is the IPv6 twin.
+func (v *SessionValueV6) ResetUnobservedForReverseCompanion() {
+	v.FibIfindex = 0
+	v.FibVlanID = 0
+	v.FibDmac = [6]byte{}
+	v.FibSmac = [6]byte{}
+	v.FibGen = 0
+	v.IngressIfindex = 0
+	v.IngressVlanID = 0
+	v.IngressIfaceFold = 0
+}

--- a/pkg/dataplane/userspace/manager_sessions.go
+++ b/pkg/dataplane/userspace/manager_sessions.go
@@ -81,12 +81,16 @@ func (m *Manager) mirrorSessionPairV4(key dataplane.SessionKey, val dataplane.Se
 		revVal.ReverseKey = key
 		revVal.IngressZone = val.EgressZone
 		revVal.EgressZone = val.IngressZone
-		// Clear FIB cache — reverse egress must be re-resolved locally.
-		revVal.FibIfindex = 0
-		revVal.FibVlanID = 0
-		revVal.FibDmac = [6]byte{}
-		revVal.FibSmac = [6]byte{}
-		revVal.FibGen = 0
+		// #7917: clear everything the REPLY direction has not observed — the
+		// forward egress (re-resolved locally) AND the #4983 ingress identity.
+		// The ingress half was missing: the companion inherited the FORWARD
+		// direction's ingress binding, which `pkg/dataplane/types.go` names as a
+		// legitimate-`0` population precisely because a prediction of where the
+		// reply will arrive is not an observation of where it did. Since #7095
+		// that also means clearing `IngressIfaceFold` — the wire request derives
+		// its ingress identity from the fold, so leaving it set stamps the
+		// forward binding onto the companion the helper receives.
+		revVal.ResetUnobservedForReverseCompanion()
 		reqs = append(reqs, m.buildSessionSyncRequestV4("upsert", val.ReverseKey, &revVal))
 	}
 	// Snapshot reads are complete; transmit both requests under ONE sessionMu
@@ -239,12 +243,16 @@ func (m *Manager) mirrorSessionPairV6(key dataplane.SessionKeyV6, val dataplane.
 		revVal.ReverseKey = key
 		revVal.IngressZone = val.EgressZone
 		revVal.EgressZone = val.IngressZone
-		// Clear FIB cache — reverse egress must be re-resolved locally.
-		revVal.FibIfindex = 0
-		revVal.FibVlanID = 0
-		revVal.FibDmac = [6]byte{}
-		revVal.FibSmac = [6]byte{}
-		revVal.FibGen = 0
+		// #7917: clear everything the REPLY direction has not observed — the
+		// forward egress (re-resolved locally) AND the #4983 ingress identity.
+		// The ingress half was missing: the companion inherited the FORWARD
+		// direction's ingress binding, which `pkg/dataplane/types.go` names as a
+		// legitimate-`0` population precisely because a prediction of where the
+		// reply will arrive is not an observation of where it did. Since #7095
+		// that also means clearing `IngressIfaceFold` — the wire request derives
+		// its ingress identity from the fold, so leaving it set stamps the
+		// forward binding onto the companion the helper receives.
+		revVal.ResetUnobservedForReverseCompanion()
 		reqs = append(reqs, m.buildSessionSyncRequestV6("upsert", val.ReverseKey, &revVal))
 	}
 	// Snapshot reads are complete; transmit both requests under ONE sessionMu

--- a/pkg/dataplane/userspace/reverse_companion_ingress_7917_test.go
+++ b/pkg/dataplane/userspace/reverse_companion_ingress_7917_test.go
@@ -1,0 +1,185 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #7917: the reverse companion must not carry the FORWARD direction's ingress
+// identity onto the helper wire.
+//
+// `mirrorSessionPairV4`/`V6` synthesize a reverse companion from the forward
+// value. They cleared the cached FIB result but not the #4983 ingress identity,
+// so the companion inherited where the FORWARD flow's first packet arrived —
+// a prediction of where the reply will land, not an observation of where it did,
+// and routing may be asymmetric.
+//
+// THIS TEST GOES THROUGH THE WIRE, NOT THE STRUCT, ON PURPOSE. The struct-level
+// census lives in `pkg/dataplane`. What matters here is the request the helper
+// actually receives, and the request does not carry `IngressIfindex` from
+// `val.IngressIfindex` at all — since #7095 it is RESOLVED from
+// `val.IngressIfaceFold` (`buildSessionSyncRequestV4` -> `resolveIngressFoldLocked`).
+// A fix that zeroed only the two node-local fields and left the fold would pass
+// a struct-level check and still stamp the forward binding on the companion the
+// helper installs. Only reading the emitted request can tell those apart.
+//
+// The FORWARD assertion is the over-reach control. Clearing the ingress identity
+// on both halves would satisfy "the companion carries none" while destroying the
+// datum #4983 exists to provide; the forward request must still carry it.
+
+// captureSessionSync stands up the helper session socket, runs `emit`, and
+// returns the sync requests the manager transmitted, in order.
+func captureSessionSync(t *testing.T, emit func(m *Manager)) []SessionSyncRequest {
+	t.Helper()
+	dir := t.TempDir()
+	ln, err := net.Listen("unix", filepath.Join(dir, "userspace-dp-sessions.sock"))
+	if err != nil {
+		t.Fatalf("listen session socket: %v", err)
+	}
+	defer ln.Close()
+
+	got := make(chan SessionSyncRequest, 8)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				dec := json.NewDecoder(conn)
+				enc := json.NewEncoder(conn)
+				for {
+					var req ControlRequest
+					if err := dec.Decode(&req); err != nil {
+						return
+					}
+					if req.SessionSync != nil {
+						got <- *req.SessionSync
+					}
+					if err := enc.Encode(ControlResponse{OK: true}); err != nil {
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	m := New()
+	m.proc = &exec.Cmd{}
+	m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+	// #7095: make the fold RESOLVE, so a leaked fold is observable as a non-zero
+	// wire ifindex. With no resolver every request would carry 0 and the
+	// companion assertion would pass without the fix.
+	m.SetIngressFoldResolver(func(fold uint32) (uint32, uint16, bool) {
+		if fold == forwardTestFold {
+			return forwardTestIfindex, forwardTestVLAN, true
+		}
+		return 0, 0, false
+	})
+
+	emit(m)
+
+	var out []SessionSyncRequest
+	deadline := time.After(5 * time.Second)
+	for len(out) < 2 {
+		select {
+		case req := <-got:
+			out = append(out, req)
+		case <-deadline:
+			t.Fatalf("only %d session sync requests arrived in 5s; the forward and "+
+				"its reverse companion are both required or the comparison below is "+
+				"about nothing", len(out))
+		}
+	}
+	return out
+}
+
+const (
+	forwardTestFold    uint32 = 0xC0FFEE01
+	forwardTestIfindex uint32 = 4242
+	forwardTestVLAN    uint16 = 80
+)
+
+func TestReverseCompanionCarriesNoIngressIdentityV4_7917(t *testing.T) {
+	key := dataplane.SessionKey{
+		SrcIP: [4]byte{10, 0, 61, 102}, DstIP: [4]byte{172, 16, 80, 200},
+		SrcPort: 1111, DstPort: 2222, Protocol: 6,
+	}
+	val := dataplane.SessionValue{
+		ReverseKey: dataplane.SessionKey{
+			SrcIP: [4]byte{172, 16, 80, 200}, DstIP: [4]byte{10, 0, 61, 102},
+			SrcPort: 2222, DstPort: 1111, Protocol: 6,
+		},
+		IngressIfindex:   77,
+		IngressVlanID:    80,
+		IngressIfaceFold: forwardTestFold,
+	}
+	reqs := captureSessionSync(t, func(m *Manager) { m.mirrorSessionPairV4(key, val) })
+
+	// Identify the pair by SOURCE IP, not port: the builder converts ports
+	// network->host (`networkUint16ToHost`), so comparing against the raw
+	// literal silently mislabels which request is which — and an inverted label
+	// turns this cell's two assertions into each other's opposite, which is a
+	// green-for-the-wrong-reason away from a false pass.
+	fwd, rev := reqs[0], reqs[1]
+	if fwd.SrcIP != "10.0.61.102" {
+		fwd, rev = rev, fwd
+	}
+	if fwd.SrcIP != "10.0.61.102" || rev.SrcIP != "172.16.80.200" {
+		t.Fatalf("could not identify the forward/companion pair: src IPs %q and %q",
+			reqs[0].SrcIP, reqs[1].SrcIP)
+	}
+
+	// Over-reach control: the forward half must KEEP its ingress identity.
+	if fwd.IngressIfindex != int(forwardTestIfindex) {
+		t.Errorf("the FORWARD request lost its ingress identity (ifindex %d, want %d). "+
+			"Clearing it on both halves would satisfy the companion assertion below "+
+			"while destroying the datum #4983 exists to provide (#7917)",
+			fwd.IngressIfindex, forwardTestIfindex)
+	}
+	// The subject.
+	if rev.IngressIfindex != 0 || rev.IngressVLANID != 0 {
+		t.Errorf("the reverse companion carries ingress identity {ifindex %d, vlan %d}, "+
+			"which is the FORWARD direction's binding. The reply's own ingress has not "+
+			"been observed and routing may be asymmetric, so this names a device on a "+
+			"prediction (#7917)", rev.IngressIfindex, rev.IngressVLANID)
+	}
+}
+
+func TestReverseCompanionCarriesNoIngressIdentityV6_7917(t *testing.T) {
+	var src, dst [16]byte
+	copy(src[:], net.ParseIP("2001:db8:1::102").To16())
+	copy(dst[:], net.ParseIP("2001:db8:2::200").To16())
+	key := dataplane.SessionKeyV6{SrcIP: src, DstIP: dst, SrcPort: 1111, DstPort: 2222, Protocol: 6}
+	val := dataplane.SessionValueV6{
+		ReverseKey:       dataplane.SessionKeyV6{SrcIP: dst, DstIP: src, SrcPort: 2222, DstPort: 1111, Protocol: 6},
+		IngressIfindex:   77,
+		IngressVlanID:    80,
+		IngressIfaceFold: forwardTestFold,
+	}
+	reqs := captureSessionSync(t, func(m *Manager) { m.mirrorSessionPairV6(key, val) })
+
+	fwd, rev := reqs[0], reqs[1]
+	if fwd.SrcIP != "2001:db8:1::102" {
+		fwd, rev = rev, fwd
+	}
+	if fwd.SrcIP != "2001:db8:1::102" || rev.SrcIP != "2001:db8:2::200" {
+		t.Fatalf("could not identify the v6 forward/companion pair: src IPs %q and %q",
+			reqs[0].SrcIP, reqs[1].SrcIP)
+	}
+	if fwd.IngressIfindex != int(forwardTestIfindex) {
+		t.Errorf("the v6 FORWARD request lost its ingress identity (ifindex %d, want %d) (#7917)",
+			fwd.IngressIfindex, forwardTestIfindex)
+	}
+	if rev.IngressIfindex != 0 || rev.IngressVLANID != 0 {
+		t.Errorf("the v6 reverse companion carries the FORWARD direction's ingress "+
+			"identity {ifindex %d, vlan %d} (#7917)", rev.IngressIfindex, rev.IngressVLANID)
+	}
+}


### PR DESCRIPTION
Closes #7917

> Depends on **#7922** (the #7095 resolver deadlock), now merged and included
> here. The dependency was real, not stylistic: the wire-level test needs a
> RESOLVABLE non-zero `IngressIfaceFold`, and with that deadlock present the call
> never returns. Written before #7922 the test would have had to use `fold == 0`,
> which makes the forward-side assertion vacuous.

## The defect

`mirrorSessionPairV4`/`V6` synthesize a reverse companion by copying the forward
value, swapping the zones, and clearing the cached FIB result. They did not clear
the #4983 ingress identity, so the companion inherited where the **forward**
flow's first packet arrived.

`pkg/dataplane/types.go` already names the reverse companion as the first
legitimate-`0` population and gives the reason:

> the reverse companion (**its own ingress has not been OBSERVED yet**). The
> forward flow's egress IS known at install — it is the wrong datum, being a
> PREDICTION of where the reply will arrive rather than an OBSERVATION of where
> it did, and routing may be asymmetric.

The code contradicted the contract the design note states.

## What re-deriving at master added

I filed this issue myself out of #7097, as "the companion inherits
`IngressIfindex` / `IngressVlanID`". That enumeration was a floor.

**A third field, and a second surface.** `buildSessionSyncRequestV4` does not
build the request's `IngressIfindex` from `val.IngressIfindex` at all — since
#7095 it RESOLVES it from `IngressIfaceFold`. The companion inherited the fold
too, so it leaked the forward binding to the **helper**, not only to the BPF map
row. **A fix that cleared the two node-local fields and left the fold would have
passed a struct-level census and changed nothing on the wire.**

## Why this is not `ScrubNodeLocal`, now with evidence

The tempting simplification is to call `ScrubNodeLocal` (#7097) — it clears most
of the same fields. The issue argued against that from principle. The fold
settles it from fact:

| field | `ScrubNodeLocal` | companion reset |
|---|---|---|
| `Fib*` (5) | yes | yes |
| `IngressIfindex` / `IngressVlanID` | yes | yes |
| `IngressIfaceFold` | **no** | **yes** |

The scrub must NOT clear the fold — it is cluster-stable and exists precisely to
cross the wire so the #4983 identity survives a failover. The companion MUST. The
two answer different questions — *"does this belong to another NODE?"* against
*"has this DIRECTION observed it?"* — and **their field sets now genuinely
differ**. Folding them would make every future node-local field a companion reset
and every future companion reset a cross-node scrub; neither implication holds.

## Guards

| test | binds |
|---|---|
| `TestReverseCompanionResetCoversExactlyTheUnobservedFields7917` | census over the reset, both families, both directions, anti-vacuity floor |
| `TestCompanionResetAndNodeLocalScrubAreDifferentRules7917` | the divergence, with its own anti-vacuity check that the two sets still **overlap** — two unrelated sets satisfy `!DeepEqual` for the wrong reason |
| `TestReverseCompanionCarriesNoIngressIdentityV4/V6_7917` | wire-level, through the real session socket: the companion request carries no ingress identity **and the forward request still does** |

That last clause is the over-reach control — clearing both halves would satisfy
the subject while destroying the datum #4983 exists to provide. It has to go
through the wire rather than the struct, because only the emitted request
distinguishes a fix that cleared the fold from one that did not.

Worth recording: the wire test identifies the forward/companion pair by **source
IP, not port**. The builder converts ports network-to-host, so comparing a raw
literal mislabels the pair — and an inverted label turns the two assertions into
each other's opposite. That happened on the first run, and the output read as
"the forward lost its identity and the companion kept it", the exact inverse of
the truth.

## Mutation

Full-suite over `./pkg/dataplane/ ./pkg/dataplane/userspace/`, named-failing-test
gated, `git diff --stat` per cell.

| cell | mutation | diff | verdict | reds |
|---|---|---|---|---|
| C0 | none | — | GREEN | — |
| M1 | drop `IngressIfaceFold` from the v4 reset | -1 | **RED** | census/v4 **and the wire test** |
| M2 | drop the node-local pair, keep the fold | -2 | **RED** | census/v4 **only** |
| M3 | revert the v4 call site to the shipped inline FIB list | +5/-1 | **RED** | wire test only |
| M4 | over-reach: clear the FORWARD half too | +1 | **RED** | wire test (the control fired) |
| M5 | fold the reset into `ScrubNodeLocal` | +1/-2 | **RED** | census/v6, divergence pin, wire test |
| M6 | reorder the assignments (benign) | +4/-4 | GREEN | — |

**M1 and M2 together are the point.** M2 reds the census and leaves the wire test
GREEN — correct, because the wire only ever sees the fold. M1 reds both. The two
guards are complementary rather than redundant, and a fix addressing only one half
of the identity is caught by exactly one of them. M5 confirms the divergence pin
does the job it was written for.

## Docs

`docs/session-sync-architecture.md`: the paragraph I added in #7097 said the
companion "deliberately does not use this helper", which understated it — it now
carries the field table above, the contradiction with `types.go`, and the wire
half. `docs/log/7917.md` has the working log.

## Validation

`TMPDIR=/var/tmp go test -count=1 ./...` — rc=0, **0** `--- FAIL`, 69 packages
`ok`, 0 build failures. Re-ran the two touched packages green after merging
current `origin/master`. No Rust source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y