### PR TITLE
cluster: give SessionSyncWireVersion its own counter

### DIFF
--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -43,6 +43,11 @@ const (
 	// equal today (this build speaks 1 and is compatible back to 1); a future
 	// incompatible bump raises Current AND sets this floor to the oldest peer the
 	// new build can still sync with (which may equal Current if no back-compat).
+	//
+	// #7925: a SESSION-WIRE-only change does not touch this. SessionSyncWireVersion
+	// is its own counter now, so widening the session key bumps that alone and
+	// leaves this window intact for the heartbeat/failover semantics that did not
+	// change. Re-evaluate this floor only on a CurrentHAProtocolVersion bump.
 	MinCompatHAProtocolVersion = CurrentHAProtocolVersion
 
 	// maxHeartbeatSize is the max packet size we'll read/write.

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -24,16 +24,31 @@ var syncMagic = [4]byte{'B', 'P', 'S', 'Y'}
 // the version the #1930 INC-3 mixed-base image-replace gate must compare across
 // a mixed-base cluster: two nodes can only sync sessions if they speak the same
 // sync wire schema. Bump this whenever the `syncMsg*` set or `syncHeader`
-// changes incompatibly. The header has no on-wire version field today
-// (compatibility has ridden the HA protocol version); this constant makes the
-// sync schema version explicit for the gate. It tracks CurrentHAProtocolVersion
-// (NOT LegacyHAProtocolVersion): the sync wire schema and the HA protocol have
-// evolved together, so a CurrentHAProtocolVersion bump that changes the
-// `syncMsg*`/`syncHeader` format carries the sync version with it. Deriving
-// from the fixed Legacy constant would silently pin the gate to the stale
-// schema version after an HA bump (Copilot). If the sync wire format ever
-// diverges from the HA protocol version, replace this with its own counter.
-const SessionSyncWireVersion = uint16(CurrentHAProtocolVersion)
+// changes incompatibly. The header has no on-wire version field today, so a
+// changed layout cannot be negotiated per-message — this constant is what makes
+// the schema version visible to the gate at all.
+//
+// #7925: this is now its OWN counter, no longer `uint16(CurrentHAProtocolVersion)`.
+// It tracked the HA version because the two had always evolved together, and
+// `sync.go` named the exit condition itself: "if the sync wire format ever
+// diverges from the HA protocol version, replace this with its own counter."
+// Widening the session key (#7160) is that divergence — it changes THIS wire and
+// leaves heartbeat/failover semantics alone.
+//
+// The split matters because the mixed-base gate checks the two DIFFERENTLY
+// (upgrade.GateMixedBaseSwap, mirrored in scripts/deploy/xpf-deploy.py):
+// the HA protocol is accepted over a WINDOW [MinCompatHAProtocolVersion,
+// CurrentHAProtocolVersion], while the session-sync version must match EXACTLY.
+// Welded together, a session-wire-only change was forced to push the HA version
+// out from under its own floor as a side effect, failing the window for peers
+// that remained fully compatible on everything that had not changed.
+//
+// So: bump THIS when the `syncMsg*` set or `syncHeader` changes. Bump
+// CurrentHAProtocolVersion when heartbeat / failover / RG-handoff semantics
+// change. A change to both bumps both. They are equal today (1) and that
+// equality is a coincidence of history, NOT an invariant — do not write a test
+// that pins them to each other.
+const SessionSyncWireVersion = uint16(1)
 
 const (
 	syncMsgSessionV4              = 1

--- a/pkg/cluster/sync_wire_version_independent_7925_test.go
+++ b/pkg/cluster/sync_wire_version_independent_7925_test.go
@@ -1,0 +1,111 @@
+package cluster
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// #7925: SessionSyncWireVersion must be its OWN counter, not derived from
+// CurrentHAProtocolVersion.
+//
+// WHY A SOURCE-LEVEL CHECK AND NOT A VALUE COMPARISON. Both constants are 1
+// today, and they were equal before this change too — when SessionSyncWireVersion
+// was literally `uint16(CurrentHAProtocolVersion)`. So `SessionSyncWireVersion ==
+// 1` and `SessionSyncWireVersion == CurrentHAProtocolVersion` are BOTH true
+// before and after the split. No comparison of values can tell the two states
+// apart; the only observable difference is whether the declaration still names
+// the HA constant. That is a fact about the source, so the source is what gets
+// asserted.
+//
+// WHY go/parser AND NOT grep. The doc comment on the declaration deliberately
+// quotes the old form — "no longer `uint16(CurrentHAProtocolVersion)`" — to
+// record what changed. A textual scan is therefore satisfied by the very comment
+// explaining the fix, and would report the constant as still derived. Parsing to
+// an AST and inspecting only the VALUE EXPRESSION excludes comments by
+// construction rather than by a strip step that could itself be wrong.
+//
+// Bump rule this guards, from the declaration's own doc: bump
+// SessionSyncWireVersion when the `syncMsg*` set or `syncHeader` changes; bump
+// CurrentHAProtocolVersion when heartbeat / failover / RG-handoff semantics
+// change. Their equality today is a coincidence of history, not an invariant.
+
+// haProtocolIdentsIn reports which HA-protocol constant names appear in an
+// expression. Shared by the assertion and its positive control so the control
+// exercises the same walker the assertion relies on.
+func haProtocolIdentsIn(expr ast.Expr) []string {
+	watched := map[string]bool{
+		"CurrentHAProtocolVersion":   true,
+		"LegacyHAProtocolVersion":    true,
+		"MinCompatHAProtocolVersion": true,
+	}
+	var found []string
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && watched[id.Name] {
+			found = append(found, id.Name)
+		}
+		return true
+	})
+	return found
+}
+
+func sessionSyncWireVersionExpr(t *testing.T) ast.Expr {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "sync.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing sync.go: %v", err)
+	}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if name.Name != "SessionSyncWireVersion" || i >= len(vs.Values) {
+					continue
+				}
+				return vs.Values[i]
+			}
+		}
+	}
+	// Not finding it is a failure, never a pass: a renamed or relocated constant
+	// must not read as "no HA reference found".
+	t.Fatal("SessionSyncWireVersion const declaration not found in sync.go — if it " +
+		"moved, move this test with it; a missing declaration must not silently pass")
+	return nil
+}
+
+func TestSessionSyncWireVersionIsNotDerivedFromHAProtocol7925(t *testing.T) {
+	if found := haProtocolIdentsIn(sessionSyncWireVersionExpr(t)); len(found) > 0 {
+		t.Errorf("SessionSyncWireVersion is declared in terms of %v, so a session-wire-only "+
+			"change is forced to bump the HA protocol version as a side effect. That pushes "+
+			"the HA version out from under MinCompatHAProtocolVersion and fails "+
+			"GateMixedBaseSwap's [floor,current] window for peers that stayed compatible on "+
+			"heartbeat/failover — the two are checked differently (HA: window; session-sync: "+
+			"exact equality), which is why they must be able to move apart (#7925)", found)
+	}
+}
+
+// Positive control. Without it, a walker that visited nothing — a wrong node
+// type, an early return — would report "no HA reference" for the same reason a
+// correctly split constant does, and the assertion above would pass whether or
+// not the split ever happened.
+func TestHAProtocolIdentWalkerDetectsADerivedExpression7925(t *testing.T) {
+	derived, err := parser.ParseExpr("uint16(CurrentHAProtocolVersion)")
+	if err != nil {
+		t.Fatalf("parsing the control expression: %v", err)
+	}
+	found := haProtocolIdentsIn(derived)
+	if len(found) != 1 || found[0] != "CurrentHAProtocolVersion" {
+		t.Fatalf("the walker must find CurrentHAProtocolVersion in the pre-#7925 form "+
+			"`uint16(CurrentHAProtocolVersion)`; got %v. Until it does, a clean result from "+
+			"the assertion above means nothing", found)
+	}
+}


### PR DESCRIPTION
`SessionSyncWireVersion` was `uint16(CurrentHAProtocolVersion)`, welding the cross-chassis session-sync wire schema to the HA protocol version. `sync.go` named its own exit condition — *"if the sync wire format ever diverges from the HA protocol version, replace this with its own counter"* — and widening the session key (#7160) is that divergence, so the counter is split now, ahead of it.

## Why the weld cost something

`GateMixedBaseSwap` checks the two versions **differently**:

| version | check |
|---|---|
| HA protocol | **window** `[MinCompatHAProtocolVersion, CurrentHAProtocolVersion]` |
| session-sync | **exact equality** (the frame header carries no version field) |

Welded, a session-wire-only change was forced to bump the HA protocol as a side effect — pushing it out from under its own compat floor and failing the window for peers that stayed fully compatible on the heartbeat/failover semantics that had not changed.

## Behaviour-neutral by construction

Both constants are `1` today, which is precisely the argument for landing this separately: it makes #7160's diff readable as a semantic change rather than a wire bump tangled with a key widening.

## The test, and why it is shaped this way

Both constants were equal **before** this change too, so `SessionSyncWireVersion == 1` and `SessionSyncWireVersion == CurrentHAProtocolVersion` are both true on either side of the split. **No comparison of values can distinguish the two states.** The only observable difference is whether the declaration still names the HA constant — a fact about the source, so the source is what is asserted.

It uses `go/parser`, not grep, for a specific reason: the new doc comment deliberately quotes the old form (`no longer uint16(CurrentHAProtocolVersion)`) to record what changed, so **a textual scan is satisfied by the very comment explaining the fix**. Inspecting the parsed value expression excludes comments by construction rather than by a strip step that could itself be wrong.

A positive control feeds the pre-split expression through the same walker. Without it, a walker that visited nothing would report "not derived" for the same reason a correct split does, and the assertion would pass whether or not the split happened.

## Validation

- Full Go suite on the branch: **rc=0, 69 packages, 0 FAIL**.
- Mutation — restore `uint16(CurrentHAProtocolVersion)`: reds `TestSessionSyncWireVersionIsNotDerivedFromHAProtocol7925` **by name**, full package run (35.6s, unfiltered), positive control stays green.
- No new coverage added for the gate's window/exact-equality axes — `imageversions_test.go` already owns both, and duplicating them would be noise.

Docs: the bump rule is stated on each declaration, and `MinCompatHAProtocolVersion` gains a note that a session-wire-only bump no longer touches it.

Closes #7925