### PR TITLE
config: reject VRF overlap combined with PBR routing-instance steering

### DIFF
--- a/docs/log/7924.md
+++ b/docs/log/7924.md
@@ -1,0 +1,66 @@
+# #7924 — narrow commit rejection for the cross-tenant session collision
+
+- **Timestamp**: 2026-08-28
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap.go`,
+  `pkg/config/compiler_opts.go`, `pkg/config/compiler_tailgates.go`,
+  two test files
+- **Disposition change only.** No new analyser: the overlap set and its PBR-term
+  source already existed and are pinned by
+  `compiler_validate_vrf_overlap_2387_test.go`.
+
+## The condition, and why it is this one
+
+Reject iff **overlap exists AND a PBR `then routing-instance` term exists**.
+
+The PBR half is a CONFIG-LEVEL fact, not a property of the overlapping pair, and
+that is deliberate. The mechanism is that the established-session fast path
+short-circuits before `ingress_route_table_override`; a `then routing-instance`
+term is what sets that override. With no such term nothing re-homes a flow's
+table mid-path, so the collision is unreachable. The flag is therefore set for
+ANY steering term, including one carrying no source/destination prefixes — such a
+term contributes nothing to the overlap sets but still installs the override.
+
+## Why not broad
+
+`compiler_validate_vrf_overlap.go:48-56` argues against a broad reject and is
+right: overlapping address space is the primary reason VRFs exist. The narrow
+form rejects only configurations that are ALREADY silently wrong.
+
+## #1960 no-brick
+
+`lenientVRFOverlapPBR` downgrades the rejection on the tolerant load / HA
+peer-sync paths. Rejecting there would refuse to boot a node on a config its PEER
+already accepted and is forwarding — worse than the collision, because it takes
+the node down entirely rather than mis-forwarding some flows. The warning
+survives the downgrade, so the lenient path does not lose the pre-#7924 advisory
+too.
+
+## The middle row, proved
+
+| overlap | PBR | expected | result |
+|---|---|---|---|
+| yes | yes | reject | PASS |
+| yes | no  | commits (warn unchanged) | PASS |
+| no  | yes | commits clean | PASS |
+
+**Widening the reject (deleting the PBR conjunct) reds the MIDDLE ROW ONLY**, 5
+tests collected — a genuine red, not a build break. The first attempt at that
+mutation WAS a build break (`sawPBRRoutingInstance` went unused), which is a VOID
+cell rather than a red; it was redone as `(sawPBRRoutingInstance || true)` so the
+variable stays used.
+
+## A pre-existing test had to move, not be weakened
+
+`TestVRFOverlapWarnsViaPBRTerms` builds exactly the overlap+PBR shape and so
+became unreachable through `CompileConfig`. Its subject is that **PBR terms FEED
+the overlap detector** — the very input this rejection depends on. It was moved
+to the tolerant path (identical warning, still emitted) rather than rewritten
+into a disposition assertion, which would have deleted the only coverage of that
+feed and left #7924 resting on a source nothing pins.
+
+## Debt
+
+This is a WORKAROUND. The real fix is #7160 (widen the session key with
+`StableRoutingInstanceTableID`), staged behind #7925 which is merged. This gate
+refuses a configuration the dataplane cannot forward correctly; it does not make
+that configuration work, and must not substitute for #7160.

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -924,6 +924,28 @@ type compileOpts struct {
 	// is inert. Commit stays strict so the operator's next edit fails loudly.
 	// Same doctrine as lenientNATHostMask.
 	lenientNPTv6 bool
+	// lenientVRFOverlapPBR (#7924) downgrades the NARROW cross-tenant
+	// session-collision gate from a hard compile error to a cfg.Warnings entry.
+	//
+	// The strict commit path rejects ONLY the combination that is already
+	// silently wrong: overlapping L3 across distinct routing-instances AND a PBR
+	// `then routing-instance` term. That pairing is a live cross-tenant policy
+	// bypass — the established-session fast path short-circuits BEFORE
+	// ingress_route_table_override, so a second flow sharing a 5-tuple inherits
+	// the first flow's cached egress, NAT and POLICY decision across a tenant
+	// boundary.
+	//
+	// Plain VRF overlap with no PBR steering keeps its warning and still
+	// commits; overlapping address space is the primary reason VRFs exist and a
+	// broad reject would break designs that work correctly today.
+	//
+	// The tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config still BOOTS (#1960 no-brick) —
+	// rejecting here would brick a node on a config its peer already accepted,
+	// which is a worse outcome than the collision this gate exists to stop.
+	// Commit stays strict so the operator's next edit fails loudly. Same
+	// doctrine as lenientNPTv6.
+	lenientVRFOverlapPBR bool
 	// lenientNAT64Prefix (#3886) downgrades the NAT64 `prefix` /96 commit gate
 	// (validateNAT64PrefixStrict) from a hard compile error to a cfg.Warnings
 	// entry. The strict commit / commit-check path hard-rejects a NAT64
@@ -2434,6 +2456,7 @@ func lenientCompileOpts() compileOpts {
 		lenientFilterTerminalConflict:          true,
 		lenientFilterDSCP:                      true,
 		lenientNPTv6:                           true,
+		lenientVRFOverlapPBR:                   true,
 		lenientNAT64Prefix:                     true,
 		lenientNATPoolOverlap:                  true,
 		lenientFirewallRefs:                    true,

--- a/pkg/config/compiler_tailgates.go
+++ b/pkg/config/compiler_tailgates.go
@@ -105,7 +105,14 @@ func runTailGates(cfg *Config, opts compileOpts) error {
 	// the session identity (Track B — a routing-domain id in SessionKey) is an
 	// OPEN #2387 decision, so the warning states the limitation and points at
 	// the issue rather than promising a fix.
-	cfg.Warnings = append(cfg.Warnings, validateVRFOverlap(cfg)...)
+	// #7924: now returns an error for the NARROW cross-tenant case (overlap AND a
+	// PBR `then routing-instance` term). The warnings are appended either way, so
+	// the lenient path keeps the pre-#7924 advisory verbatim.
+	vrfOverlapWarnings, err := validateVRFOverlap(cfg, opts.lenientVRFOverlapPBR)
+	cfg.Warnings = append(cfg.Warnings, vrfOverlapWarnings...)
+	if err != nil {
+		return err
+	}
 
 	// #2173: static-NAT / NAT64 host-mask gate. #2132 made the Rust
 	// dataplane tolerate the canonical /32-/128 host mask and PR #2167 then

--- a/pkg/config/compiler_validate_vrf_overlap.go
+++ b/pkg/config/compiler_validate_vrf_overlap.go
@@ -85,10 +85,21 @@ const (
 // routing-instances for overlap (net/netip Prefix.Overlaps — contains-or-equal).
 // Deterministic ordering (sorted RI names, sorted filter names, sorted
 // prefixes) so the warning set is stable across commits.
-func validateVRFOverlap(cfg *Config) []string {
+func validateVRFOverlap(cfg *Config, lenientPBR bool) ([]string, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil
 	}
+	// #7924: does ANY PBR term steer into a routing-instance? This is the second
+	// half of the narrow rejection condition, and it is deliberately a
+	// config-level fact rather than a property of the overlapping pair.
+	//
+	// The defect needs PBR to be steering at all: the established-session fast
+	// path short-circuits before `ingress_route_table_override`
+	// (poll_descriptor/mod.rs), and that override is what a `then
+	// routing-instance` term sets. With no such term nothing re-homes a flow's
+	// table mid-path, so two overlapping RIs cannot collide through it and the
+	// pre-#7924 warning is the correct disposition.
+	sawPBRRoutingInstance := false
 
 	// riPrefixes[riName] = de-duplicated, origin-tagged prefix set.
 	riPrefixes := map[string][]vrfOverlapPrefix{}
@@ -161,6 +172,12 @@ func validateVRFOverlap(cfg *Config) []string {
 			if term == nil || term.RoutingInstance == "" {
 				continue
 			}
+			// #7924: a `then routing-instance` term exists. Recorded even when the
+			// term carries no source/destination prefixes and so contributes
+			// nothing to the overlap sets — it still installs the table override
+			// the fast path skips, which is the mechanism, so gating on "the term
+			// contributed a prefix" would miss a match-all steering term.
+			sawPBRRoutingInstance = true
 			origin := fmt.Sprintf("filter %q term %q", filterName, term.Name)
 			for _, addr := range term.SourceAddresses {
 				addPrefix(term.RoutingInstance, addr, origin)
@@ -256,5 +273,26 @@ Scan:
 				"some overlaps may be unreported",
 			comparisons, len(warnings)))
 	}
-	return warnings
+	// #7924: promote to a REJECTION for the narrow combination that is already
+	// silently wrong — overlap AND PBR steering. See lenientVRFOverlapPBR for the
+	// #1960 no-brick reasoning behind the lenient downgrade.
+	//
+	// This is a WORKAROUND WITH A DEBT, not the fix. The real fix is #7160: widen
+	// the session key with a routing-domain discriminator
+	// (StableRoutingInstanceTableID) so the two flows stop colliding at all,
+	// staged behind #7925. This gate refuses a configuration the dataplane cannot
+	// currently forward correctly; it does not make that configuration work, and
+	// it must not become a substitute for #7160.
+	if len(warnings) > 0 && sawPBRRoutingInstance && !lenientPBR {
+		return warnings, fmt.Errorf(
+			"overlapping L3 across routing-instances combined with a PBR `then "+
+				"routing-instance` term is refused: the session identity carries no "+
+				"routing-instance discriminator, and the established-session fast path "+
+				"runs BEFORE the PBR table override, so a second flow sharing a 5-tuple "+
+				"inherits the first flow's cached egress, NAT and POLICY decision across "+
+				"the tenant boundary (#7924; tracked for a real fix by #7160). "+
+				"Overlapping VRF address space WITHOUT PBR steering still commits with a "+
+				"warning. First overlap: %s", warnings[0])
+	}
+	return warnings, nil
 }

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -75,10 +75,28 @@ import (
 // diagnosis. It selects on the diagnosis phrase, NOT on "#2387" — see the
 // comment on the filter below for why the issue reference cannot be the
 // selector.
+// vrf2387WarningsLenient is vrf2387Warnings on the TOLERANT path.
+//
+// #7924 promoted the overlap+PBR combination to a strict commit REJECTION, so a
+// caller whose subject is the WARNING for that combination can no longer reach
+// it through CompileConfig. The lenient path still emits the identical warning
+// (the rejection is a downgrade of it, not a replacement), so a test about
+// warning CONTENT keeps testing content rather than being rewritten into a test
+// about disposition — which #7924 covers separately and on purpose.
+func vrf2387WarningsLenient(t *testing.T, cmds []string) []string {
+	t.Helper()
+	return vrf2387WarningsWith(t, cmds, CompileConfigLenient)
+}
+
 func vrf2387Warnings(t *testing.T, cmds []string) []string {
 	t.Helper()
+	return vrf2387WarningsWith(t, cmds, CompileConfig)
+}
+
+func vrf2387WarningsWith(t *testing.T, cmds []string, compile func(*ConfigTree) (*Config, error)) []string {
+	t.Helper()
 	tree := buildTree(t, cmds)
-	cfg, err := CompileConfig(tree)
+	cfg, err := compile(tree)
 	if err != nil {
 		t.Fatalf("CompileConfig: %v", err)
 	}
@@ -165,7 +183,14 @@ func TestVRFOverlapWarnsViaPBRTerms(t *testing.T) {
 	// The same destination prefix steered into two different routing-instances
 	// by two PBR `then routing-instance` terms is the exact reachable-via-PBR
 	// trigger — overlap detected from the filter-term source.
-	warns := vrf2387Warnings(t, []string{
+	//
+	// #7924: this exact shape is now a strict commit REJECTION, so the warning is
+	// reached through the tolerant path. The subject of this test is unchanged and
+	// deliberately so — it binds that PBR TERMS FEED the overlap detector, which
+	// is the input #7924's rejection depends on. Rewriting it into a
+	// disposition assertion would have deleted the only coverage of that feed and
+	// left #7924 resting on a source nothing pins.
+	warns := vrf2387WarningsLenient(t, []string{
 		"set routing-instances RI-A instance-type virtual-router",
 		"set routing-instances RI-B instance-type virtual-router",
 		"set firewall family inet filter fbf term to-a from destination-address 172.16.9.0/24",

--- a/pkg/config/compiler_validate_vrf_overlap_pbr_7924_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_pbr_7924_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7924: overlapping L3 across routing-instances is only a LIVE cross-tenant
+// bypass when a PBR `then routing-instance` term is steering. The established-
+// session fast path short-circuits before `ingress_route_table_override`, so a
+// second flow sharing a 5-tuple inherits the first flow's cached egress, NAT and
+// POLICY decision across the tenant boundary — but nothing re-homes a flow's
+// table without that term.
+//
+// So the rejection is NARROW, and this table is what proves it is narrow rather
+// than broad. The MIDDLE ROW is the whole point: overlap with NO PBR must still
+// commit. Delete the PBR half of the condition and only that row reds — without
+// it a broad reject passes as a narrow one, and a broad reject would break the
+// overlapping-address-space designs VRFs exist to serve.
+func TestVRFOverlapRejectedOnlyWithPBRSteering_7924(t *testing.T) {
+	const (
+		ifA = "set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24"
+		ifB = "set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/24"
+		// Non-overlapping sibling for the third row.
+		ifC   = "set interfaces ge-0/0/2 unit 0 family inet address 192.168.7.2/24"
+		riA   = "set routing-instances RI-A instance-type virtual-router"
+		riAif = "set routing-instances RI-A interface ge-0/0/1.0"
+		riB   = "set routing-instances RI-B instance-type virtual-router"
+		riBif = "set routing-instances RI-B interface ge-0/0/2.0"
+		pbr   = "set firewall family inet filter fbf term t1 then routing-instance RI-B"
+	)
+
+	for _, tc := range []struct {
+		name       string
+		cmds       []string
+		wantReject bool
+		why        string
+	}{
+		{
+			// overlap YES, PBR YES -> reject.
+			name:       "overlap_and_pbr_steering",
+			cmds:       []string{ifA, ifB, riA, riAif, riB, riBif, pbr},
+			wantReject: true,
+			why: "this is the live cross-tenant policy bypass: the fast path skips " +
+				"the PBR table override, so a colliding 5-tuple inherits the other " +
+				"tenant's cached policy decision",
+		},
+		{
+			// THE MIDDLE ROW. overlap YES, PBR NO -> commits, warning unchanged.
+			name:       "overlap_without_pbr_still_commits",
+			cmds:       []string{ifA, ifB, riA, riAif, riB, riBif},
+			wantReject: false,
+			why: "overlapping address space is the primary reason VRFs exist. With " +
+				"no `then routing-instance` term nothing re-homes a flow's table " +
+				"mid-path, so the collision is not reachable and rejecting would " +
+				"break a design that works correctly today",
+		},
+		{
+			// overlap NO, PBR YES -> commits clean.
+			name:       "pbr_steering_without_overlap",
+			cmds:       []string{ifA, ifC, riA, riAif, riB, riBif, pbr},
+			wantReject: false,
+			why: "PBR steering into a VRF whose address space is disjoint cannot " +
+				"produce a 5-tuple collision at all",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, tc.cmds)
+			_, err := CompileConfig(tree)
+			if tc.wantReject && err == nil {
+				t.Fatalf("want a commit REJECTION — %s", tc.why)
+			}
+			if !tc.wantReject && err != nil {
+				t.Fatalf("want the config to COMMIT — %s; got: %v", tc.why, err)
+			}
+			if tc.wantReject && !strings.Contains(err.Error(), "#7924") {
+				t.Errorf("the rejection must cite #7924 so an operator can find the "+
+					"limitation and its tracking issue; got: %v", err)
+			}
+			if tc.wantReject && !strings.Contains(err.Error(), "#7160") {
+				t.Errorf("the rejection must cite #7160, the real fix, so this "+
+					"workaround does not read as the end state; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestVRFOverlapPBRRejectionIsLenientDowngraded_7924 pins the #1960 no-brick
+// half. A hard reject on the tolerant load / HA peer-sync path would refuse to
+// boot a node on a configuration its PEER already accepted and is forwarding —
+// strictly worse than the collision this gate exists to prevent, because it
+// takes the node down entirely rather than mis-forwarding some flows.
+//
+// The warning must survive the downgrade, or the lenient path reports nothing at
+// all and the operator loses the pre-#7924 advisory too.
+func TestVRFOverlapPBRRejectionIsLenientDowngraded_7924(t *testing.T) {
+	cmds := []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/24",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set routing-instances RI-B interface ge-0/0/2.0",
+		"set firewall family inet filter fbf term t1 then routing-instance RI-B",
+	}
+	tree := buildTree(t, cmds)
+
+	// Strict: rejected. This is the precondition — without it the lenient
+	// assertion below could pass because the config was never rejectable.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("precondition: the strict path must reject this config")
+	}
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("the tolerant / peer-sync path must still BOOT this config "+
+			"(#1960 no-brick): refusing it would take a node down on a "+
+			"configuration its peer already accepted; got: %v", err)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "overlapping L3 across routing-instances") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the lenient path must still carry the overlap WARNING — a silent " +
+			"downgrade loses the pre-#7924 advisory as well as the rejection")
+	}
+}

--- a/pkg/config/vrf_overlap_budget_5194_test.go
+++ b/pkg/config/vrf_overlap_budget_5194_test.go
@@ -40,7 +40,7 @@ func TestValidateVRFOverlapWarningCap_5194(t *testing.T) {
 		"fb": {Name: "fb", Terms: mkTerms("vrfB")},
 	}
 
-	warnings := validateVRFOverlap(cfg)
+	warnings, _ := validateVRFOverlap(cfg, true /* #7924: budget test measures WARNINGS, not the reject */)
 
 	// Overlap advisories are capped, plus exactly one truncation notice.
 	if len(warnings) != vrfOverlapMaxWarnings+1 {
@@ -70,7 +70,7 @@ func TestValidateVRFOverlapUnderCapNoTruncation_5194(t *testing.T) {
 			{Name: "b", RoutingInstance: "vrfB", SourceAddresses: []string{"10.0.0.0/24"}},
 		}},
 	}
-	warnings := validateVRFOverlap(cfg)
+	warnings, _ := validateVRFOverlap(cfg, true /* #7924: budget test measures WARNINGS, not the reject */)
 	if len(warnings) != 1 {
 		t.Fatalf("one overlap => 1 warning, got %d: %v", len(warnings), warnings)
 	}


### PR DESCRIPTION
Closes #7924
Refs #7160 — this is a **workaround with a debt**, not the fix. See the bottom.

Disposition change only. **No new analyser** — the overlap set and its PBR-term
source already existed and are pinned by
`compiler_validate_vrf_overlap_2387_test.go`.

## The defect

Two flows in different routing-instances sharing a 5-tuple collide in the
conntrack map: the session identity carries no routing-instance discriminator.
The collision is **live** under PBR `then routing-instance`, because the
established-session fast path short-circuits **before**
`ingress_route_table_override` — so a second flow inherits the first flow's
cached egress, NAT **and policy** decision across a tenant boundary.

Cross-tenant policy bypass, and it commits today with only a warning.

## The condition, and why the PBR half is config-level

Reject iff **overlap exists AND a PBR `then routing-instance` term exists.**

The PBR half is a config-level fact rather than a property of the overlapping
pair, deliberately: a `then routing-instance` term is what installs the table
override the fast path skips. So the flag is set for **any** steering term —
including one carrying no match prefixes, which contributes nothing to the
overlap sets but still installs the override. Gating on "the term contributed a
prefix" would miss a match-all steering term.

## Not broad, and the file already says why

`compiler_validate_vrf_overlap.go:48-56` argues against a broad reject and is
right: overlapping address space is the primary reason VRFs exist, and a broad
reject breaks designs that work correctly today. The narrow form refuses only
configurations that are **already silently wrong**.

## #1960 no-brick

`lenientVRFOverlapPBR` downgrades the rejection on the tolerant load / HA
peer-sync paths. Rejecting there would refuse to boot a node on a configuration
its **peer already accepted and is forwarding** — worse than the collision, since
it takes the node down entirely rather than mis-forwarding some flows. The
warning survives the downgrade, so the lenient path does not lose the pre-#7924
advisory either. Bound by
`TestVRFOverlapPBRRejectionIsLenientDowngraded_7924`, which asserts the strict
rejection first as its precondition — otherwise the lenient assertion could pass
on a config that was never rejectable.

## The middle row, proved rather than asserted

| overlap | PBR `then routing-instance` | expected | result |
|---|---|---|---|
| yes | yes | **reject** | PASS |
| yes | no  | commits, warning unchanged | PASS |
| no  | yes | commits clean | PASS |

**Widening the rejection (deleting the PBR conjunct) reds the MIDDLE ROW ONLY**,
with **5 tests collected** — a genuine red, not a build break.

Worth recording: the first attempt at that mutation *was* a build break
(`sawPBRRoutingInstance` went unused), which is a **VOID cell rather than a red**
— it proves nothing about the test. Redone as `(sawPBRRoutingInstance || true)`
so the variable stays used and the cell actually measures the assertion.

## A pre-existing test moved rather than weakened

`TestVRFOverlapWarnsViaPBRTerms` builds exactly this shape and so became
unreachable through `CompileConfig`. It was **moved to the tolerant path** — where
the identical warning is still emitted — rather than rewritten into a disposition
assertion.

Its subject is that **PBR terms FEED the overlap detector**, which is the input
this rejection depends on. Rewriting it would have deleted the only coverage of
that feed and left this gate resting on a source nothing pins.

## The debt

This is a **workaround**. The real fix is **#7160** — widen the session key with
`StableRoutingInstanceTableID` so the flows stop colliding at all — staged behind
#7925, which is merged.

This gate refuses a configuration the dataplane cannot currently forward
correctly. **It does not make that configuration work, and must not become a
substitute for #7160.**

## Validation

- `gofmt` clean; `go build ./...` ok
- `go test -count=1 ./pkg/config/ ./pkg/dataplane/...` — **ok on all five packages**