### PR TITLE
Apply the takeover readiness gate on cold boot (#7161)

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -42,6 +42,46 @@ yet. Here is what is true today:
   starting in the slower `DrainSessionDeltas` polling fallback. The gate keys on
   the listener being UP, not on the local helper currently being connected;
   transient stream disconnects are covered by polling
+- The takeover readiness gate applies on COLD BOOT, not only when the peer is
+  alive (#7161). `electSingleNode` previously gated on `m.peerAlive`, so the
+  gate was fully enforced on the peer-alive path and fully bypassed on the
+  peer-dead path — which is the path both a cold boot and a peer loss take. The
+  condition is now `(m.peerAlive || !m.peerEverSeen)`:
+  - **peer LOSS** (`peerEverSeen && !peerAlive`) keeps the fail-open. An
+    established cluster had a working primary and it died; a survivor that
+    refuses takeover is a TOTAL OUTAGE and may be the only node that can
+    forward.
+  - **cold BOOT** (`!peerEverSeen`) applies the gate. There is no established
+    forwarding to preserve, and a not-ready node that promotes forwards nothing
+    anyway — it claims the VIPs and the RG while unable to serve them, and
+    denies the peer a clean takeover. This is #103 acceptance criterion 1.
+
+  **POLICY CHANGE, declared:** a userspace-configured data RG with no published
+  dataplane fail-closes in `checkUserspaceTakeoverReadinessFor`, so on a cold
+  boot it now stays SECONDARY where it previously promoted. It forwards nothing
+  either way; the difference is that it now says so instead of advertising
+  itself primary for traffic it cannot carry.
+
+  The prior in-code rationale ("sync readiness is impossible without a peer")
+  was stale and has been replaced rather than narrowed: sync readiness is not a
+  term in that conjunction at all. `IsReadyForTakeover` consults local
+  interfaces, local VRRP and the local userspace dataplane — all determinable
+  with no peer — and `fabricReady` is already forced true when the peer is down.
+
+  **Degraded-promotion fallback** (`DefaultDegradedPromoteTimeout`, 2 min): after
+  that much CONTINUOUS not-readiness a single node promotes anyway, with the
+  reason surfaced on the election event and `DegradedPromoted` set, so a
+  readiness bug can never cost the cluster both nodes. Two properties are
+  load-bearing and are pinned by tests:
+  - it is gated on NO peer condition — not `peerAlive`, not `peerEverSeen`, not
+    sync connectivity. #110 shows the failure mode: `armSyncReadyTimer`'s
+    callback bails on `!d.syncPeerConnected`, so its fallback never fires in
+    exactly the peer-absent case it was written for. A fallback whose firing
+    depends on the condition it compensates for is not a fallback.
+  - it is armed at the DECLINE SITE in `electSingleNode`, not in `SetRGReady`. A
+    cold-boot RG starts not-ready and may never see a readiness TRANSITION, so
+    arming from the transition branch would leave it unarmed in precisely the
+    case it exists for.
 - Blackhole routes skipped in userspace mode (#354)
 - Helper watchdog threshold aligned with sync cadence (#349)
 - Reverse companions pre-installed via sync path (#310)

--- a/docs/log/7161.md
+++ b/docs/log/7161.md
@@ -1,0 +1,53 @@
+# #7161 — electSingleNode bypasses the readiness gate whenever the peer is not alive
+
+- **Timestamp**: 2026-08-28/29
+- **Action**: gated the readiness check on cold boot while preserving the
+  peer-loss fail-open; rewrote the stale rationale; added a peer-independent
+  degraded-promotion fallback.
+- **File(s)**: `pkg/cluster/election.go`, `pkg/cluster/manager.go`,
+  `pkg/cluster/readiness.go`, `pkg/cluster/group_state.go`,
+  `pkg/cluster/election_readiness_coldboot_7161_test.go` (new),
+  `pkg/daemon/daemon_ipmon_test.go`, `docs/ha-failover-status.md`
+
+## Premise re-verified at `origin/master` (`623f43d4b`)
+
+The gate reads `... && m.peerAlive`, and the comment reads "Bypass when peer is
+dead: sync readiness is impossible without a peer". Both as the issue describes.
+The design decision was made by the orchestrator and recorded on the issue; this
+implements it.
+
+## The one thing the brief did not predict
+
+`pkg/daemon` `TestIPMonPublishAllowedAnyPrimary` went RED. It is **the declared
+policy change, caught by a fixture**: `ipmonCluster` builds a cluster-mode
+manager (`ControlInterface: "control0"`) that never reports readiness and never
+sees a peer — a cold boot — and relied on the old fail-open to reach PRIMARY.
+
+Fixed by making the fixture establish the readiness the policy now requires
+(`SetRGReady(rg.ID, true, nil)`), not by weakening the gate. The test's subject
+is the ipmon publish gate; it now goes on being about that instead of quietly
+depending on election policy. Worth recording as the first observed instance of
+the knock-on the issue predicted.
+
+## Degraded fallback: the two properties that matter
+
+- **Gated on no peer condition.** #110's `armSyncReadyTimer` bails its callback
+  on `!d.syncPeerConnected`, so its fallback never fires in exactly the
+  peer-absent case it exists for. The test therefore runs with NO PEER EVER SEEN.
+- **Armed at the decline site, not in `SetRGReady`.** A cold-boot RG starts
+  not-ready and may never see a readiness TRANSITION, so arming from
+  `SetRGReady`'s transition branch would leave the fallback unarmed in precisely
+  the case it exists for — the same shape as #110, one layer up. The decline site
+  runs exactly when the fallback is needed, by construction.
+
+Both timer guards mirror `holdTimer`: the #4716 quiesced-manager check and the
+#5245 stale-RG identity check, because a timer that has already fired races
+config teardown.
+
+## Why the table has three rows
+
+Two rows (peer-alive-not-ready and cold-boot-not-ready, both secondary) are also
+satisfied by deleting the peer condition entirely — gating unconditionally and
+losing the peer-loss fail-open the issue explicitly defends. Only the middle row,
+peer-loss-not-ready expecting PRIMARY, separates the intended change from that
+total flip.

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -1,8 +1,10 @@
 package cluster
 
 import (
+	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -425,13 +427,42 @@ func (m *Manager) electSingleNode() {
 			continue
 		}
 		// Readiness gate: block new promotions in cluster mode until
-		// interfaces + VRRP are confirmed ready for holdTime.
-		// Does not gate standalone mode (no controlInterface).
-		// Bypass when peer is dead: sync readiness is impossible without
-		// a peer, and the surviving node must take over immediately.
-		if rg.State != StatePrimary && rg.Weight > 0 && m.controlInterface != "" && m.peerAlive {
+		// interfaces + VRRP are confirmed ready for holdTime. Does not gate
+		// standalone mode (no controlInterface).
+		//
+		// #7161: the gate applies on a COLD BOOT (`!peerEverSeen`) but is
+		// bypassed on a genuine peer LOSS (`peerEverSeen && !peerAlive`). The
+		// two cases differ for a real reason:
+		//
+		//   - peer LOSS: an established cluster had a working primary and it
+		//     died. A survivor that refuses takeover is a TOTAL OUTAGE, and it
+		//     may be the only node that can forward. Fail open.
+		//   - cold BOOT: there is no established forwarding to preserve, and a
+		//     not-ready node that promotes FORWARDS NOTHING ANYWAY — it claims
+		//     the VIPs and the RG while unable to serve them, and denies the
+		//     peer a clean takeover. Promoting buys nothing.
+		//
+		// The prior rationale here read "sync readiness is impossible without a
+		// peer". That argued for bypassing a term that is not in this
+		// conjunction: `IsReadyForTakeover` consults local interfaces
+		// (Monitor.RGInterfaceReady), local VRRP (RGVRRPReady /
+		// checkNoRethTakeoverReadiness) and the local userspace dataplane
+		// (checkUserspaceTakeoverReadinessFor) — all determinable with no peer —
+		// and `fabricReady` is already forced true when the peer is down.
+		//
+		// `peerEverSeen` introduces no new state: the non-preempt guard two
+		// blocks above already draws the same cold-boot/loss distinction with
+		// it, so this makes the two consistent.
+		degradedReason := ""
+		if rg.State != StatePrimary && rg.Weight > 0 && m.controlInterface != "" &&
+			(m.peerAlive || !m.peerEverSeen) {
 			if !rg.IsReadyForTakeover(m.takeoverHoldTime) {
-				continue
+				if reason, ok := m.degradedPromoteDueLocked(rg); ok {
+					degradedReason = reason
+				} else {
+					m.armDegradedTimerLocked(rg)
+					continue
+				}
 			}
 		}
 		oldState := rg.State
@@ -441,7 +472,14 @@ func (m *Manager) electSingleNode() {
 			rg.State = StateSecondary
 		}
 		if oldState != rg.State {
-			m.sendEvent(rg.GroupID, oldState, rg.State, "Only node present")
+			reason := "Only node present"
+			if degradedReason != "" && rg.State == StatePrimary {
+				rg.DegradedPromoted = true
+				reason = degradedReason
+				slog.Warn("cluster: promoting NOT-READY RG after degraded timeout",
+					"rg", rg.GroupID, "reason", degradedReason)
+			}
+			m.sendEvent(rg.GroupID, oldState, rg.State, reason)
 		}
 	}
 }
@@ -736,5 +774,98 @@ func (m *Manager) reconcileMonitorDebtsLocked(cfg *config.ClusterConfig) {
 			slog.Info("cluster: monitor debt reconciled on config change",
 				"rg", rgID, "old", oldWeight, "new", rg.Weight)
 		}
+	}
+}
+
+// degradedPromoteDueLocked reports whether the #7161 cold-boot readiness gate
+// has held this RG secondary for longer than degradedPromoteTimeout, and the
+// operator-facing reason if so.
+//
+// It reads only rg.NotReadySince and the clock. It consults NO peer condition —
+// that is the point. #110's armSyncReadyTimer bails its callback on
+// !d.syncPeerConnected, so its fallback never fires in exactly the peer-absent
+// case it exists for; a fallback gated on the condition it compensates for is
+// not a fallback.
+//
+// Caller must hold m.mu.
+func (m *Manager) degradedPromoteDueLocked(rg *RedundancyGroupState) (string, bool) {
+	if m.degradedPromoteTimeout <= 0 || rg.NotReadySince.IsZero() {
+		return "", false
+	}
+	held := time.Since(rg.NotReadySince)
+	if held < m.degradedPromoteTimeout {
+		return "", false
+	}
+	why := "readiness not reported"
+	if len(rg.ReadinessReasons) > 0 {
+		why = strings.Join(rg.ReadinessReasons, ", ")
+	}
+	return fmt.Sprintf(
+		"Promoted DEGRADED after %s not ready (%s); forwarding may be impaired",
+		held.Round(time.Second), why), true
+}
+
+// armDegradedTimerLocked stamps when the cold-boot gate first declined this RG
+// and schedules the wakeup that lets the degraded fallback actually fire.
+//
+// Both halves live HERE, at the decline site, rather than in SetRGReady. A
+// cold-boot RG starts not-ready and may never see a readiness TRANSITION, so
+// arming from SetRGReady's transition branch would leave the fallback unarmed in
+// precisely the case it exists for. The decline site, by construction, runs
+// exactly when the fallback is needed.
+//
+// Caller must hold m.mu.
+func (m *Manager) armDegradedTimerLocked(rg *RedundancyGroupState) {
+	if m.degradedPromoteTimeout <= 0 {
+		return
+	}
+	if rg.NotReadySince.IsZero() {
+		rg.NotReadySince = time.Now()
+	}
+	if rg.degradedTimer != nil {
+		return
+	}
+	remaining := m.degradedPromoteTimeout - time.Since(rg.NotReadySince)
+	if remaining < 0 {
+		remaining = 0
+	}
+	rgID := rg.GroupID
+	rg.degradedTimer = time.AfterFunc(remaining, func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		// Quiesced manager (#4716) and stale-RG (#5245) guards, matching
+		// holdTimer: a timer that had already fired races config teardown.
+		if m.stopped {
+			return
+		}
+		cur, ok := m.groups[rgID]
+		if !ok || cur != rg {
+			return
+		}
+		rg.degradedTimer = nil
+		if rg.Ready {
+			return
+		}
+		slog.Warn("cluster: degraded-promotion timeout expired, re-evaluating election",
+			"rg", rgID, "not_ready_for", time.Since(rg.NotReadySince).Round(time.Second))
+		// Deliberately NOT branched on m.peerAlive. This fallback exists for the
+		// peer-absent case; routing it through runElection when a peer appeared
+		// meanwhile is still correct, because runElection has its own gate.
+		if m.peerAlive {
+			m.runElection()
+		} else {
+			m.electSingleNode()
+		}
+	})
+}
+
+// clearDegradedStateLocked cancels the fallback once the RG is ready again, so a
+// later decline starts a fresh continuous-not-ready window rather than inheriting
+// a stale one. Caller must hold m.mu.
+func (m *Manager) clearDegradedStateLocked(rg *RedundancyGroupState) {
+	rg.NotReadySince = time.Time{}
+	if rg.degradedTimer != nil {
+		rg.degradedTimer.Stop()
+		rg.degradedTimer = nil
 	}
 }

--- a/pkg/cluster/election_readiness_coldboot_7161_test.go
+++ b/pkg/cluster/election_readiness_coldboot_7161_test.go
@@ -1,0 +1,196 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// #7161: electSingleNode applied the per-RG takeover readiness gate only when
+// `m.peerAlive`, so a node promoted while NOT READY on exactly the paths a cold
+// boot and a peer loss take.
+//
+// The fix gates on cold boot and keeps the fail-open on genuine peer loss:
+//
+//	(m.peerAlive || !m.peerEverSeen)
+//
+// The two differ for a real reason. On peer LOSS an established cluster had a
+// working primary and it died — a survivor refusing takeover is a total outage
+// and it may be the only node that can forward. On COLD BOOT there is no
+// established forwarding to preserve and a not-ready node that promotes forwards
+// nothing anyway; it claims the VIPs while unable to serve them.
+//
+// WHY THIS TABLE HAS THREE ROWS AND NOT TWO. Two rows — peer-alive-not-ready and
+// cold-boot-not-ready, both expecting secondary — are also satisfied by deleting
+// the gate's peer condition entirely, i.e. by gating unconditionally and losing
+// the peer-loss fail-open that the issue explicitly defends. Only the middle row
+// distinguishes the intended change from that total flip.
+
+func preemptColdBootManager7161(t *testing.T) *Manager {
+	t.Helper()
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100}))
+	cfg.ControlInterface = "em0" // cluster mode: the election gates are armed
+	m.UpdateConfig(cfg)
+	// Preempt so the separate `!rg.Preempt && !peerEverSeen` non-preempt guard
+	// two blocks above cannot mask the result — without this, the cold-boot row
+	// would pass for the wrong reason.
+	m.mu.Lock()
+	m.groups[0].Preempt = true
+	m.mu.Unlock()
+	return m
+}
+
+// setNotReady drives the RG not-ready through the real setter, then asserts the
+// precondition, so a cell can never measure a state it failed to establish.
+func setNotReady7161(t *testing.T, m *Manager) {
+	t.Helper()
+	m.SetRGReady(0, true, nil)
+	m.SetRGReady(0, false, []string{"interface ge-0/0/1 missing"})
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.groups[0].Ready {
+		t.Fatal("precondition: the RG must be NOT ready or every assertion below " +
+			"is about a different state than the one named")
+	}
+	m.groups[0].State = StateSecondary
+}
+
+func electState7161(m *Manager, peerAlive, peerEverSeen bool) NodeState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.peerAlive = peerAlive
+	m.peerEverSeen = peerEverSeen
+	m.electSingleNode()
+	return m.groups[0].State
+}
+
+func TestElectSingleNodeReadinessGateByPeerHistory7161(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		peerAlive    bool
+		peerEverSeen bool
+		want         NodeState
+		why          string
+	}{
+		{
+			name:      "peer alive, not ready -> secondary (unchanged)",
+			peerAlive: true, peerEverSeen: true, want: StateSecondary,
+			why: "the gate has always applied while the peer is alive; a regression " +
+				"here means the fix widened the bypass instead of narrowing it",
+		},
+		{
+			name:      "peer LOSS, not ready -> PRIMARY (fail-open preserved)",
+			peerAlive: false, peerEverSeen: true, want: StatePrimary,
+			why: "an established cluster lost its primary. A survivor that refuses " +
+				"takeover is a TOTAL OUTAGE and may be the only node that can " +
+				"forward. This row is what distinguishes the intended change from " +
+				"gating unconditionally",
+		},
+		{
+			name:      "COLD BOOT, not ready -> secondary (the change)",
+			peerAlive: false, peerEverSeen: false, want: StateSecondary,
+			why: "no established forwarding to preserve, and a not-ready node that " +
+				"promotes forwards nothing anyway — it claims the VIPs while unable " +
+				"to serve them and denies the peer a clean takeover (#103 criterion 1)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := preemptColdBootManager7161(t)
+			setNotReady7161(t, m)
+			if got := electState7161(m, tc.peerAlive, tc.peerEverSeen); got != tc.want {
+				t.Errorf("peerAlive=%v peerEverSeen=%v: state=%v, want %v — %s",
+					tc.peerAlive, tc.peerEverSeen, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// The degraded fallback, in the shape #110 got wrong.
+//
+// #110's armSyncReadyTimer bails its callback on `!d.syncPeerConnected`, so its
+// fallback never fires in exactly the peer-absent case it was written for. This
+// cell therefore runs with NO PEER EVER SEEN — the case the fallback exists for
+// — and would fail if the fallback were gated on any peer condition.
+func TestDegradedTimeoutPromotesWithNoPeerEverSeen7161(t *testing.T) {
+	m := preemptColdBootManager7161(t)
+	setNotReady7161(t, m)
+
+	m.mu.Lock()
+	m.degradedPromoteTimeout = 40 * time.Millisecond
+	m.mu.Unlock()
+
+	// First election: the gate declines AND arms the fallback. Both halves are
+	// at the decline site precisely because a cold-boot RG may never see a
+	// readiness TRANSITION for SetRGReady to hook.
+	if got := electState7161(m, false, false); got != StateSecondary {
+		t.Fatalf("precondition: the cold-boot gate must decline first; got %v", got)
+	}
+	m.mu.Lock()
+	armed := !m.groups[0].NotReadySince.IsZero()
+	m.mu.Unlock()
+	if !armed {
+		t.Fatal("the decline did not stamp NotReadySince, so the fallback has no " +
+			"window to measure and could never fire (#7161)")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		m.mu.Lock()
+		state, degraded := m.groups[0].State, m.groups[0].DegradedPromoted
+		m.mu.Unlock()
+		if state == StatePrimary {
+			if !degraded {
+				t.Error("promoted without DegradedPromoted set: the operator cannot " +
+					"tell a degraded promotion from a healthy one (#7161)")
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the degraded fallback never fired with no peer ever seen. That " +
+				"is #110's defect exactly: a fallback gated on the condition it " +
+				"compensates for is not a fallback (#7161)")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Becoming ready must CANCEL the fallback and forget the window, so a later
+// decline starts a fresh one. Without this a node that was briefly not-ready
+// long ago would promote instantly on its next decline.
+func TestReadyClearsTheDegradedWindow7161(t *testing.T) {
+	m := preemptColdBootManager7161(t)
+	setNotReady7161(t, m)
+	if got := electState7161(m, false, false); got != StateSecondary {
+		t.Fatalf("precondition: expected the gate to decline; got %v", got)
+	}
+
+	m.SetRGReady(0, true, nil)
+	m.mu.Lock()
+	cleared := m.groups[0].NotReadySince.IsZero() && m.groups[0].degradedTimer == nil
+	m.mu.Unlock()
+	if !cleared {
+		t.Fatal("becoming ready left the not-ready window and/or the timer in place; " +
+			"a later decline would inherit an already-satisfied window and promote " +
+			"a not-ready RG immediately (#7161)")
+	}
+}
+
+// The reason must name the readiness cause, not just the timeout — an operator
+// reading `show chassis cluster` needs to know WHY it was not ready.
+func TestDegradedReasonNamesTheReadinessCause7161(t *testing.T) {
+	m := preemptColdBootManager7161(t)
+	setNotReady7161(t, m)
+	m.mu.Lock()
+	m.degradedPromoteTimeout = time.Millisecond
+	m.groups[0].NotReadySince = time.Now().Add(-time.Hour)
+	reason, ok := m.degradedPromoteDueLocked(m.groups[0])
+	m.mu.Unlock()
+	if !ok {
+		t.Fatal("the fallback did not report due after an hour not ready")
+	}
+	if !strings.Contains(reason, "ge-0/0/1") {
+		t.Errorf("reason %q does not name the readiness cause; the operator is told "+
+			"a timeout elapsed but not what was wrong (#7161)", reason)
+	}
+}

--- a/pkg/cluster/group_state.go
+++ b/pkg/cluster/group_state.go
@@ -54,6 +54,12 @@ func (m *Manager) UpdateConfig(cfg *config.ClusterConfig) {
 				rg.holdTimer.Stop()
 				rg.holdTimer = nil
 			}
+			// #7161: the degraded fallback is torn down with the hold timer —
+			// both pin the Manager until they fire.
+			if rg.degradedTimer != nil {
+				rg.degradedTimer.Stop()
+				rg.degradedTimer = nil
+			}
 			for k := range m.monitorWeights {
 				if k.rgID == id {
 					delete(m.monitorWeights, k)

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -58,6 +58,22 @@ type RedundancyGroupState struct {
 	ReadinessReasons []string    // reasons why not ready (empty when ready)
 	holdTimer        *time.Timer // fires at ReadySince+holdTime to re-trigger election
 
+	// #7161 degraded-promotion fallback. NotReadySince is when the COLD-BOOT
+	// readiness gate first declined to promote this RG; degradedTimer fires at
+	// NotReadySince+degradedPromoteTimeout to re-run the election so the
+	// fallback has something to wake it. DegradedPromoted records that the RG
+	// was promoted through the fallback rather than by becoming ready, so the
+	// status render and the election event can say so.
+	//
+	// Both are stamped at the DECLINE SITE in electSingleNode, not in
+	// SetRGReady. A cold-boot RG starts not-ready and may never see a readiness
+	// TRANSITION, so arming from SetRGReady's transition branch would leave the
+	// fallback unarmed in exactly the case it exists for — the #110 shape this
+	// fallback is written to avoid repeating.
+	NotReadySince    time.Time
+	degradedTimer    *time.Timer
+	DegradedPromoted bool
+
 	// Transfer readiness is the stricter explicit-manual-failover readiness.
 	// It intentionally stays separate from takeover readiness so operators can
 	// distinguish election readiness from transfer protocol readiness.
@@ -481,6 +497,18 @@ type Manager struct {
 	// once readiness is established.
 	takeoverHoldTime time.Duration
 
+	// degradedPromoteTimeout bounds how long the #7161 cold-boot readiness gate
+	// may hold an RG secondary. After this much CONTINUOUS not-readiness the RG
+	// promotes anyway, with the reason surfaced, so a readiness bug can never
+	// cost the cluster both nodes.
+	//
+	// It is deliberately NOT gated on any peer condition — not peerAlive, not
+	// peerEverSeen, not sync connectivity. A fallback whose firing depends on
+	// the condition it compensates for is not a fallback (#110:
+	// armSyncReadyTimer's callback bails on !d.syncPeerConnected, so its
+	// fallback never fires in exactly the peer-absent case it was written for).
+	degradedPromoteTimeout time.Duration
+
 	// syncReady is true once bulk session sync has been received (or the
 	// readiness timeout released the hold). It gates NOTHING: no consumer
 	// reads it to decide RG promotion, in private-rg-election / no-reth-vrrp
@@ -548,6 +576,19 @@ type peerGroupSnapshot struct {
 // ready before election promotes it to primary. Zero means promote as soon as
 // readiness is established.
 const DefaultTakeoverHoldTime = 0
+
+// DefaultDegradedPromoteTimeout bounds the #7161 cold-boot readiness gate: after
+// this much continuous not-readiness a single node promotes anyway rather than
+// leaving the cluster with no primary.
+//
+// 2 minutes is chosen against the two failures it sits between. Too SHORT and it
+// defeats the gate on a node that is legitimately still coming up — interface
+// enumeration, VRRP settling and the userspace dataplane load are all on the
+// cold-boot path. Too LONG and a readiness bug strands a single-node cluster for
+// the length of an outage. A node that is not ready two minutes after boot is
+// not "still starting"; something is wrong, and forwarding degraded beats
+// forwarding nothing once there is no peer to take over instead.
+const DefaultDegradedPromoteTimeout = 2 * time.Minute
 const DefaultPreManualFailoverRetryTimeout = 5 * time.Second
 const DefaultPreManualFailoverRetryInterval = 500 * time.Millisecond
 const minTransferCommitGracePeriod = 10 * time.Second
@@ -590,6 +631,7 @@ func NewManager(nodeID, clusterID int) *Manager {
 		hbThreshold:                    DefaultHeartbeatThreshold,
 		history:                        NewEventHistory(64),
 		takeoverHoldTime:               DefaultTakeoverHoldTime,
+		degradedPromoteTimeout:         DefaultDegradedPromoteTimeout,
 		preManualFailoverRetryTimeout:  DefaultPreManualFailoverRetryTimeout,
 		preManualFailoverRetryInterval: DefaultPreManualFailoverRetryInterval,
 		failoverInProgress:             make(map[int]bool),
@@ -820,6 +862,12 @@ func (m *Manager) Stop() {
 		if rg.holdTimer != nil {
 			rg.holdTimer.Stop()
 			rg.holdTimer = nil
+		}
+		// #7161: the degraded fallback is torn down with the hold timer —
+		// both pin the Manager until they fire.
+		if rg.degradedTimer != nil {
+			rg.degradedTimer.Stop()
+			rg.degradedTimer = nil
 		}
 	}
 	m.mu.Unlock()

--- a/pkg/cluster/readiness.go
+++ b/pkg/cluster/readiness.go
@@ -73,6 +73,10 @@ func (m *Manager) SetRGReady(rgID int, ready bool, reasons []string) {
 		// Transition: not-ready → ready.
 		rg.ReadySince = time.Now()
 		rg.ReadinessReasons = nil
+		// #7161: the RG is ready, so cancel the degraded fallback and forget the
+		// not-ready window. A later decline must start a FRESH continuous window
+		// rather than inheriting one that has already been satisfied.
+		m.clearDegradedStateLocked(rg)
 		slog.Info("cluster: RG readiness: ready", "rg", rgID)
 
 		// Schedule a wakeup at ReadySince + takeoverHoldTime to

--- a/pkg/daemon/daemon_ipmon_test.go
+++ b/pkg/daemon/daemon_ipmon_test.go
@@ -526,6 +526,15 @@ func ipmonCluster(rgs ...*config.RedundancyGroup) *cluster.Manager {
 		ControlInterface: "control0",
 		RedundancyGroups: rgs,
 	})
+	// #7161: this fixture is cluster-mode (ControlInterface set) and has never
+	// seen a peer, which is a COLD BOOT. Since #7161 the takeover readiness gate
+	// applies on cold boot, so an RG that never reports readiness stays
+	// SECONDARY — it would forward nothing anyway. Report readiness so the
+	// preempt RGs reach PRIMARY and this test can go on being about the ipmon
+	// publish gate rather than about election policy.
+	for _, rg := range rgs {
+		m.SetRGReady(rg.ID, true, nil)
+	}
 	return m
 }
 


### PR DESCRIPTION
Closes #7161

Implements the design decision recorded on the issue. Premise re-verified at
`origin/master`: the gate reads `... && m.peerAlive`, and the comment reads
"Bypass when peer is dead: sync readiness is impossible without a peer".

## The change

```go
(m.peerAlive || !m.peerEverSeen)
```

- **peer LOSS** (`peerEverSeen && !peerAlive`) keeps the fail-open. An
  established cluster had a working primary and it died; a survivor that refuses
  takeover is a **total outage** and may be the only node that can forward.
- **cold BOOT** (`!peerEverSeen`) applies the gate. There is no established
  forwarding to preserve, and a not-ready node that promotes **forwards nothing
  anyway** — it claims the VIPs and the RG while unable to serve them, and denies
  the peer a clean takeover. This is #103 acceptance criterion 1.

`peerEverSeen` adds no state: the non-preempt guard two blocks above already
draws the same cold-boot/loss distinction with it.

The rationale was **rewritten, not narrowed**. "Sync readiness is impossible
without a peer" argued for bypassing a term that is not in that conjunction:
`IsReadyForTakeover` consults local interfaces, local VRRP and the local
userspace dataplane — all determinable with no peer — and `fabricReady` is
already forced true when the peer is down.

## POLICY CHANGE, declared

A userspace-configured data RG with no published dataplane fail-closes in
`checkUserspaceTakeoverReadinessFor`, so **on a cold boot it now stays SECONDARY
where it previously promoted.** It forwards nothing either way; the difference is
that it now says so instead of advertising itself primary for traffic it cannot
carry.

This was not hypothetical — `pkg/daemon` `TestIPMonPublishAllowedAnyPrimary` went
red. Its `ipmonCluster` fixture builds a cluster-mode manager that never reports
readiness and never sees a peer (a cold boot) and relied on the old fail-open to
reach primary. **Fixed by having the fixture establish the readiness the policy
now requires, not by weakening the gate**, so the test goes on being about the
ipmon publish gate rather than quietly depending on election policy.

## Degraded-promotion fallback

After `DefaultDegradedPromoteTimeout` (2 min) of **continuous** not-readiness the
node promotes anyway, reason on the election event and `DegradedPromoted` set, so
a readiness bug can never cost the cluster both nodes. Two properties are
load-bearing and each has its own cell:

- **Gated on NO peer condition** — not `peerAlive`, not `peerEverSeen`, not sync
  connectivity. #110 is the failure mode: `armSyncReadyTimer`'s callback bails on
  `!d.syncPeerConnected`, so its fallback never fires in exactly the peer-absent
  case it was written for. A fallback whose firing depends on the condition it
  compensates for is not a fallback. The test therefore runs with **no peer ever
  seen**.
- **Armed at the DECLINE SITE**, not in `SetRGReady`. A cold-boot RG starts
  not-ready and may never see a readiness *transition*, so arming from the
  transition branch would leave it unarmed in precisely the case it exists for —
  the same shape as #110, one layer up. The decline site runs exactly when the
  fallback is needed, by construction.

Both timer guards mirror `holdTimer`: the #4716 quiesced-manager check and the
#5245 stale-RG identity check, because a timer that has already fired races
config teardown.

2 minutes sits between two failures: shorter defeats the gate on a node
legitimately still coming up (interface enumeration, VRRP settling, dataplane
load are all on the cold-boot path); longer strands a single-node cluster for the
length of an outage. Not exposed as a config leaf in this PR — that needs
`setSchema` plus `docs/config-schema.md` work and can follow; flagging the scope
choice rather than leaving it implicit.

## Tests — three rows, not two

Two rows (peer-alive-not-ready and cold-boot-not-ready, both secondary) are also
satisfied by deleting the peer condition entirely and gating unconditionally,
which loses the fail-open the issue explicitly defends. **Only the middle row
separates the intended change from that total flip** — and M2 below confirms it
empirically.

| cell | asserts |
|---|---|
| `...GateByPeerHistory7161/peer alive` | secondary (unchanged) |
| `...GateByPeerHistory7161/peer LOSS` | **primary** (fail-open preserved) |
| `...GateByPeerHistory7161/COLD BOOT` | **secondary** (the change) |
| `TestDegradedTimeoutPromotesWithNoPeerEverSeen7161` | the fallback fires with no peer ever seen |
| `TestReadyClearsTheDegradedWindow7161` | becoming ready cancels the window |
| `TestDegradedReasonNamesTheReadinessCause7161` | the reason names the cause, not just the timeout |

The fixture uses `Preempt: true` so the separate `!rg.Preempt && !peerEverSeen`
guard cannot mask the cold-boot row, and drives not-readiness through the real
`SetRGReady` with a precondition assert, so no cell can measure a state it failed
to establish.

## Mutation

Full-suite over `./pkg/cluster/ ./pkg/daemon/`, named-failing-test gated,
`git diff --stat` per cell.

| cell | mutation | verdict | named reds |
|---|---|---|---|
| C0 | none | GREEN | — |
| M1 | revert the gate to the shipped `&& m.peerAlive` | **RED** | the COLD BOOT row |
| M2 | total flip: gate unconditionally | **RED** | **the peer LOSS row** + 2 pre-existing |
| M3 | gate the fallback on `m.peerAlive` (the #110 shape) | **RED** | the degraded cell (3.01s) |
| M4 | stop arming the fallback at the decline site | **RED** | the degraded cell |
| M5 | do not clear the window on ready | **RED** | the clear cell |
| M6b | drop the readiness cause from the reason | **RED** | the reason cell |
| M7 | rewrite the constant as `120 * time.Second` (benign) | GREEN | — |

**M2 is the one to read.** Gating unconditionally reds my middle row *and* two
pre-existing guards — `TestElection_PeerLost_BypassesReadinessGate` and
`TestColdBootNeverSeenFloorSuppressesPromotion`. So the peer-loss fail-open was
already owned by an existing test, which corroborates the design position
independently of anything I wrote. My middle row is partly redundant with it; I
kept it because a three-row table read together is what makes the policy legible.

Disclosures: the first M6 attempt was a **BUILD-BREAK** (removing the reason
branch left `strings` unused), correctly classified and re-run as M6b with the
import removed — the original scored nothing. M3 and M4 also co-fired
`TestTimedOutJoinLeavesNoWaiterBehind_6669`,
`TestThirdRequestCoalescesOntoTheLateReclaim_6669` and
`TestStartHeartbeatDoesNotRaceStopHeartbeat7257` (the last at exactly 30.00s);
these are unrelated timing tests of the kind that have flaked under load
throughout this campaign, and I am not claiming a causal link.

## Cluster validation — required for election code

`make test-failover` on the loss userspace cluster, under the #1875 lock:
**17 passed, 0 failed**, rc=0.

I verified both nodes actually ran the build under test rather than assuming the
deploy covered both — the log printed only one "Deploy complete":

```
local xpfd: 4db19e96de5b5378
fw0   xpfd: 4db19e96de5b5378
fw1   xpfd: 4db19e96de5b5378
```

That matters here specifically: the smoke reboots fw0 (which then cold-boots into
the changed path) while fw1 takes over (the peer-loss path), so the result is
only meaningful if both carry the change.

## Validation

`TMPDIR=/var/tmp go test -count=1 ./...` — rc=0, **0** `--- FAIL`, 69 packages
`ok`. Re-ran `./pkg/cluster/ ./pkg/daemon/` green after merging current
`origin/master`. Docs: `docs/ha-failover-status.md` gains the policy, the
declared change and both fallback properties; `docs/log/7161.md` has the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y