### PR TITLE
Bound the pending_neigh retry sweep

### DIFF
--- a/docs/log/7156.md
+++ b/docs/log/7156.md
@@ -1,0 +1,93 @@
+# 7156 — bound the pending_neigh sweep
+
+- **Timestamp**: 2026-08-28
+- **Action**: replaced the O(all-keys)-per-poll `retry_pending_neigh` walk with a
+  deadline-ordered budgeted sweep plus a neighbour-insert generation gate
+- **File(s)**: `userspace-dp/src/afxdp/neigh_schedule.rs` (new),
+  `neighbor_dispatch.rs`, `neighbor_dispatch_mirror_tests.rs` (extracted),
+  `sharded_neighbor.rs`, `worker/mod.rs`, `binding_state/mod.rs`,
+  `binding_state/tests/tx_inbox.rs`, `poll_descriptor/mod.rs`,
+  `docs/userspace-cold-start-resolution.md`
+
+## Measured first
+
+| pending keys | before ns/sweep | after (nothing due) | Vec bytes/sweep |
+|--------------|-----------------|---------------------|-----------------|
+| 0            | 8               | 6                   | 0               |
+| 64           | 2 673           | 24                  | 1 536           |
+| 1 024        | 40 709          | 24                  | 24 576          |
+| 4 096 (cap)  | 182 207         | 24                  | 98 304          |
+
+Healthy = 8 ns (the empty-map early-out works, which is why this never showed in
+profiling). At the cap = ~364 us and ~196 KiB per POLL, since the sweep runs
+twice per poll iteration. Confirmed as a real hot path, not a
+comment-and-bound case. Per-key cost is dominated by `ShardedNeighborMap::get`,
+which takes a shard MUTEX — so it was O(all-keys) lock acquisitions contending
+with the resolver thread, the #1187 constraint arriving through another door.
+
+## The finding the tests forced
+
+A deadline queue ALONE is wrong, and the existing suite proved it: two tests
+went red because a resolved neighbour was no longer dispatched on the next
+sweep. That is not a fixture artifact but a real regression — a key has nothing
+scheduled between its last probe (queued + 260 ms) and its timeout (800 ms–2 s),
+so a neighbour resolving at 300 ms would go unnoticed until the packet was
+DROPPED as never-resolved.
+
+Hence the generation gate: `ShardedNeighborMap` counts inserts, and a sweep that
+sees the count change walks every pending key that sweep. Filling the pending cap
+resolves nothing, so the attack triggers no walks; a legitimate resolution keeps
+its old latency exactly. Both tests then passed UNMODIFIED — the behaviour was
+restored rather than the assertions weakened.
+
+The static `forwarding.neighbors` map has no counter to bump (it is rebuilt on
+commit), so its length is the second half of the signature. A same-size static
+replacement is the one edit that misses, backstopped by the 50 ms recheck against
+a 800 ms–2 s timeout.
+
+## Mutation matrix — full suite, `--test-threads=1`
+
+| cell | edit | verdict | reds |
+|------|------|---------|------|
+| control | none | GREEN 4849 | — |
+| m1 | `resolution_pass = true` (the pre-fix unbounded walk) | RED | nothing-due + budget cells |
+| m2 | `resolution_pass = false` (deadline only, no gate) | RED | resolution cell + the 2 pre-existing guards |
+| m3 | drop the `.max(now+1)` fairness clamp | RED | at-most-once-per-sweep cell |
+| m4 | re-arm during a resolution pass too (duplicates) | RED | no-duplicate-entries cell |
+
+**m3 and m4 were GREEN on the first run.** Both were unbound, and neither was
+visible from the tests I had written:
+
+* the starvation cell cannot reach the clamp, because every key in it is past
+  its timeout and is REMOVED on visit, so nothing re-arms;
+* no cell drove a resolution pass over surviving keys, which is the only shape
+  that duplicates.
+
+Cells were written for both rather than the mutations excused.
+
+The first version of the nothing-due cell was also vacuous: with nothing due, a
+full walk finds nothing to do and leaves identical state, so removals and
+recycles cannot tell it from no walk at all. That is why `pending_neigh_visits`
+exists — a production counter (also the budget-exhaustion telemetry the issue
+asks for), not a test-only seam.
+
+## Layout guards
+
+Adding the counter moved `BindingLiveState` (size 2304 -> 2368, offsets
+2168 -> 2176, 2296 -> 2304), tripping the compile-time asserts AND their runtime
+twin in `tests/tx_inbox.rs`. Re-measured in lockstep, per the #6664/#7054
+precedent, and verified the way those notes require: BOTH build configurations
+green on ONE set of literals, which a `#[cfg(test)]` field could not achieve.
+
+## Modularity
+
+`neighbor_dispatch.rs` was 1493 LOC — seven lines under the 1500 [WATCH] floor,
+so the gate fired as the issue predicted. The deadline queue went in its own
+module and the dispatch test suite was extracted to
+`neighbor_dispatch_mirror_tests.rs`, leaving the sweep at 1136.
+
+## Not done
+
+The optional #1769 §2.3 exponential GET backoff, listed as adjacent-optional on
+the issue. Out of scope for a change already touching the sweep, the neighbour
+map layout and the module split.

--- a/docs/userspace-cold-start-resolution.md
+++ b/docs/userspace-cold-start-resolution.md
@@ -326,6 +326,39 @@ by #1636 (see accuracy note at the top of this file).
    TCP retransmit). Checking the buffer on every poll wake (1ms) is
    critical for sub-10ms cold start.
 
+   **But checking the buffer is not the same as walking it (#7156).**
+   Because this runs on every poll (twice — the RX-empty branch and the
+   post-batch call), the per-sweep cost is multiplied by the poll rate.
+   The sweep used to snapshot every unresolved key into a fresh `Vec`
+   and walk all of them, bounded only by an empty-map early-out:
+
+   | pending keys | ns/sweep | Vec bytes/sweep |
+   |--------------|----------|-----------------|
+   | 0            | 8        | 0               |
+   | 1 024        | 40 709   | 24 576          |
+   | 4 096 (cap)  | 182 207  | 98 304          |
+
+   A healthy binding holds zero pending keys and pays 8 ns, which is why
+   this never showed up in profiling. At the `MAX_PENDING_NEIGH` cap it
+   is ~364 us and ~196 KiB per poll iteration — an idle worker core
+   spent on hops whose packets are already being dropped and negatively
+   cached, and reachable by scanning distinct unresolved next-hops.
+
+   It is now deadline-ordered and budgeted (`afxdp/neigh_schedule.rs`):
+   nothing due costs one heap peek (~20 ns, flat in the population), and
+   at most `PENDING_NEIGH_SWEEP_BUDGET` keys are serviced per sweep.
+
+   Freshness is preserved by a separate mechanism, because deadline
+   order alone would break it: a key has nothing scheduled between its
+   last probe (queued + 260 ms) and its timeout, so a neighbour
+   resolving at 300 ms would go unnoticed until the packet was DROPPED
+   as never-resolved. `ShardedNeighborMap` therefore carries an insert
+   generation, and a sweep that observes it change walks every pending
+   key on that sweep — so a resolved packet dispatches with exactly the
+   latency it always had. Filling the pending cap resolves nothing, so
+   it triggers no walks: the attack path pays the bounded cost, the
+   legitimate path pays none of it.
+
 5. **Create sessions on MissingNeighbor** — without the forward session,
    the reverse direction (SYN-ACK) can't find the NAT match and gets
    policy-denied. The session must exist before the SYN-ACK arrives.

--- a/userspace-dp/src/afxdp/binding_state/mod.rs
+++ b/userspace-dp/src/afxdp/binding_state/mod.rs
@@ -486,6 +486,18 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// `Coordinator::pending_neigh_decap_drops_total()` (Prometheus
     /// `xpf_userspace_pending_neigh_decap_drops_total`).
     pub(super) pending_neigh_decap_drops: AtomicU64,
+    /// #7156: pending-neigh keys VISITED by the retry sweep, cumulative.
+    ///
+    /// The budget-exhaustion / backlog signal. The sweep used to visit every
+    /// unresolved key on every poll, so this would have tracked
+    /// `pending_neigh.len()` x polls; it now tracks actual serviced work, and
+    /// the gap between it and the queue depth gauge is the backlog.
+    ///
+    /// Also the only way to observe that a sweep with nothing due did NO
+    /// per-key work: that state is defined by the ABSENCE of side effects, so
+    /// removals and recycles cannot distinguish "visited every key and found
+    /// nothing to do" from "visited nothing".
+    pub(super) pending_neigh_visits: AtomicU64,
     /// #2375: per-binding count of `pending_neigh` admissions REFUSED
     /// because the map already holds `MAX_PENDING_NEIGH` distinct
     /// unresolved `(egress_ifindex, next_hop)` hops — the capacity-drop
@@ -831,10 +843,23 @@ pub(in crate::afxdp) struct BindingLiveState {
 // for a second u64. Recorded so the next reader does not treat an unchanged
 // 2304 as evidence their field failed to land — check the OFFSETS, which did
 // move.
-const _: [(); 2304] = [(); std::mem::size_of::<BindingLiveState>()];
+// #7156 re-measured all three moving literals (size 2304 -> 2368, offsets
+// 2168 -> 2176 and 2296 -> 2304) when `pending_neigh_visits` joined the
+// cold-counter run. Same legitimate case as #6664 and #7054: the field is
+// UNCONDITIONAL, so the production and test builds shift by the same 8 bytes
+// and one pair of literals makes both green — the guard reporting a real layout
+// change and being answered, not defeated. Verified by building BOTH
+// configurations, since agreement between them is the whole discriminator
+// against the `#[cfg(test)]` hazard above.
+//
+// This is the addition the #6664 note predicted and #7054 found had not yet
+// happened: the tail padding is now full, so `size_of` moved a whole 64-byte
+// alignment unit rather than absorbing the field. An unchanged 2304 would now
+// be the surprising result.
+const _: [(); 2368] = [(); std::mem::size_of::<BindingLiveState>()];
 const _: [(); 64] = [(); std::mem::align_of::<BindingLiveState>()];
-const _: [(); 2168] = [(); std::mem::offset_of!(BindingLiveState, pending_tx_admitted)];
-const _: [(); 2296] = [(); std::mem::offset_of!(BindingLiveState, delta_loss_pending)];
+const _: [(); 2176] = [(); std::mem::offset_of!(BindingLiveState, pending_tx_admitted)];
+const _: [(); 2304] = [(); std::mem::offset_of!(BindingLiveState, delta_loss_pending)];
 
 impl BindingLiveState {
     pub(super) fn new() -> Self {
@@ -956,6 +981,7 @@ impl BindingLiveState {
             neg_neigh_fast_fail: AtomicU64::new(0),
             pending_neigh_duplicate_drops: AtomicU64::new(0),
             pending_neigh_decap_drops: AtomicU64::new(0),
+            pending_neigh_visits: AtomicU64::new(0),
             pending_neigh_capacity_drops: AtomicU64::new(0),
             pending_neigh_keys: AtomicU64::new(0),
             neg_neigh_keys: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs
+++ b/userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs
@@ -148,10 +148,18 @@ fn enqueue_tx_owned_below_cap_does_not_touch_overflow_counter() {
 // one set of literals. An unconditional field shifts both by the same 8 bytes,
 // so re-measuring both is the guard being ANSWERED. `size_of` stays 2304 — the
 // bytes came out of tail padding, again.
+//
+// #7156 re-measured all three moving literals (size 2304 -> 2368, offsets
+// 2168 -> 2176 and 2296 -> 2304) when the unconditional `pending_neigh_visits`
+// counter joined that run. Same lockstep, and verified the way the paragraph
+// above says it must be: BOTH build configurations green on one set of
+// literals, which a `#[cfg(test)]` field could not achieve. Unlike #6664 and
+// #7054, `size_of` DID move this time — the tail padding is now full, so the
+// struct grew a whole 64-byte alignment unit.
 fn admission_attempt_instrument_leaves_four_pinned_layout_values_unchanged_6304() {
     assert_eq!(
         std::mem::size_of::<BindingLiveState>(),
-        2304,
+        2368,
         "#6304: the `cfg(test)` admission-attempt instrument must not change \
          `BindingLiveState`'s SIZE — the same literal is asserted at compile \
          time in `binding_state/mod.rs`, which is where the production build \
@@ -164,14 +172,14 @@ fn admission_attempt_instrument_leaves_four_pinned_layout_values_unchanged_6304(
     );
     assert_eq!(
         std::mem::offset_of!(BindingLiveState, pending_tx_admitted),
-        2168,
+        2176,
         "#6304/#6114: ...nor the OFFSET of the admission counter whose \
          cacheline this is all about. A `cfg(test)` field ahead of it moves \
          this to 2160 while leaving the size assert above satisfied"
     );
     assert_eq!(
         std::mem::offset_of!(BindingLiveState, delta_loss_pending),
-        2296,
+        2304,
         "#6304: ...nor the offset of the last-declared field, which is the \
          sentinel for a `cfg(test)` member appended at the END of the struct — \
          that shape moves this to 2288 and trips nothing else"

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -1302,6 +1302,7 @@ use neighbor_latency::NeighborLatencyTelemetry;
 
 // Issue 67.2: neighbor-dispatch helpers extracted into
 // afxdp/neighbor_dispatch.rs.
+mod neigh_schedule;
 mod neighbor_dispatch;
 use neighbor_dispatch::{
     PendingNeighAdmission, build_missing_neighbor_session_metadata,

--- a/userspace-dp/src/afxdp/neigh_schedule.rs
+++ b/userspace-dp/src/afxdp/neigh_schedule.rs
@@ -1,0 +1,200 @@
+//! #7156: deadline-ordered, budgeted scheduling for the per-worker
+//! `pending_neigh` buffer.
+//!
+//! ## The cost this replaces, measured before it was written
+//!
+//! `retry_pending_neigh` used to snapshot EVERY unresolved key into a fresh
+//! `Vec` and walk all of them, on every sweep, with the only bound an
+//! empty-map early-out — and it runs TWICE per poll iteration
+//! (`worker/lifecycle.rs`, the RX-empty branch and the post-batch call).
+//! Timings on the release build, one binding, keys unresolved and not due:
+//!
+//! | pending keys | ns/sweep | ns/key | Vec bytes/sweep |
+//! |--------------|----------|--------|-----------------|
+//! | 0            | 8        | —      | 0               |
+//! | 64           | 2 673    | 41.8   | 1 536           |
+//! | 1 024        | 40 709   | 39.8   | 24 576          |
+//! | 4 096 (cap)  | 182 207  | 44.5   | 98 304          |
+//!
+//! A healthy binding holds zero pending keys and pays 8 ns, which is why this
+//! never showed up in ordinary profiling. At the `MAX_PENDING_NEIGH` cap it is
+//! ~182 us per sweep, ~364 us per poll iteration, plus ~196 KiB of allocation
+//! per poll — an idle worker core spent entirely on bookkeeping for hops whose
+//! packets are already being dropped and negatively cached. Filling that cap is
+//! attacker-reachable (a scan across distinct unresolved next-hops), and the
+//! cost lands on forwarding for unrelated traffic on the same worker.
+//!
+//! The per-key cost is dominated by the `dynamic_neighbors` lookup, which takes
+//! a SHARD MUTEX (`ShardedNeighborMap::get`) — so the sweep is not merely
+//! O(all-keys) arithmetic, it is O(all-keys) lock acquisitions contending with
+//! the resolver thread that writes those shards. That is the #1187 constraint
+//! `stage_screen_check` documents for the aggregate screen counters, arriving
+//! here through a different door.
+//!
+//! ## Why a plain min-heap is enough, and tombstone-free
+//!
+//! The general worry with lazy-deletion deadline queues is unbounded tombstones
+//! under attacker-driven churn. That cannot arise here, and the reason is a
+//! property of the buffer rather than of this module:
+//!
+//! * There is exactly ONE production insert site
+//!   (`poll_descriptor`'s `MissingNeighbor` arm), and it inserts only on
+//!   `PendingNeighAdmission::Buffer`.
+//! * A second packet for a key already pending is `DuplicateDrop` — recycled,
+//!   NOT inserted. The buffered representative is never REPLACED (keep-oldest,
+//!   #1771 §2.2), so a key cannot acquire a second live deadline.
+//! * Both removals (`neighbor_dispatch.rs`, timeout drop and resolved dispatch)
+//!   happen on a key the sweep has just POPPED, so the entry that named it is
+//!   already gone from the heap.
+//!
+//! So every live map key has exactly one heap entry and every heap entry names
+//! a live map key. The `None` arm on the map lookup after a pop is retained as
+//! a belt-and-braces invariant check rather than an expected path, and
+//! [`PendingNeighSchedule::len`] is asserted against the map in tests.
+//!
+//! ## Freshness: what changed, stated plainly
+//!
+//! The old sweep re-checked EVERY key against both neighbor maps on every
+//! poll, so a resolved packet was dispatched on the next poll. Deadline order
+//! alone would not do that: a key's own schedule has nothing actionable between
+//! its last probe (queued + 260 ms) and its timeout (800 ms–2 s), so a neighbour
+//! that resolved at 300 ms would wait until the timeout deadline to be noticed —
+//! a correctness regression, not just a latency one, since the packet would be
+//! dropped as timed out.
+//!
+//! Hence [`RESOLUTION_RECHECK_INTERVAL_NS`]: a surviving key is re-armed at
+//! `min(next probe slot, timeout instant, now + recheck)`, so it is revisited at
+//! least that often regardless of where it sits in its probe schedule. Worst-case
+//! added dispatch latency for a resolved packet is one recheck interval, against
+//! a 10 ms first probe and a 800 ms–2 s timeout.
+//!
+//! Under a poll rate too low to fund every key's recheck within the budget, the
+//! effective recheck interval stretches. That is the correct degradation: the
+//! budget bounds the work, and because the heap is deadline-ordered the entries
+//! that fall behind are the ones with the LATEST deadlines, so timeouts and
+//! probes — which have earlier deadlines — keep firing on schedule.
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::net::IpAddr;
+
+/// Maximum pending-neigh keys visited per sweep. Bounds worst-case sweep cost
+/// at ~`BUDGET * 45 ns` (~2.9 us here) independent of how many keys are
+/// pending, against ~182 us for the unbounded walk at the 4096 cap.
+///
+/// Not a fairness knob: the heap is deadline-ordered, so a budget cut short
+/// leaves the LATEST-deadline entries unvisited and the earliest — timeouts and
+/// due probes — always win. Raising it trades worst-case poll latency for
+/// recheck throughput at a large pending population.
+pub(super) const PENDING_NEIGH_SWEEP_BUDGET: usize = 64;
+
+/// Backstop bound on how long a key can go unvisited while it has no probe slot
+/// and no timeout due.
+///
+/// This is NOT what keeps resolution prompt — the generation gate in
+/// `retry_pending_neigh` does that, walking every key on the sweep after any
+/// neighbour insert, so a dynamically-resolved hop dispatches with exactly the
+/// pre-#7156 latency. This covers the one case that gate cannot see: the STATIC
+/// `forwarding.neighbors` map, which changes on config apply rather than
+/// through `ShardedNeighborMap`, and so bumps no insert generation.
+///
+/// Sized against that: a config apply is a human-scale event, and 50 ms is far
+/// inside the 800 ms–2 s pending timeout, so a statically-configured neighbour
+/// resolves a buffered packet long before it could be dropped. Cost at the
+/// MAX_PENDING_NEIGH cap is ~4096 x 45 ns per 50 ms, under 0.4% of a core.
+///
+/// Do not shorten it to buy freshness the gate already provides: at 1 ms the
+/// same arithmetic is ~18% of a core at the cap, which is most of the cost this
+/// module exists to remove.
+pub(super) const RESOLUTION_RECHECK_INTERVAL_NS: u64 = 50_000_000; // 50 ms
+
+/// One armed key. Ordered by deadline first so the heap is a deadline queue;
+/// the key breaks ties so ordering is TOTAL and a sweep over same-deadline keys
+/// is deterministic rather than dependent on heap internals.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct Armed {
+    due_ns: u64,
+    key: (i32, IpAddr),
+}
+
+/// Deadline-ordered arming for one binding's `pending_neigh` map.
+///
+/// Holds no packet state: the map remains authoritative and this only decides
+/// WHEN a key is next looked at. Pushes and pops do not allocate once the heap
+/// has grown to its high-water mark, and it is never rebuilt per sweep.
+#[derive(Default, Debug)]
+pub(super) struct PendingNeighSchedule {
+    heap: BinaryHeap<Reverse<Armed>>,
+}
+
+impl PendingNeighSchedule {
+    /// Arm `key` to be visited at `due_ns`. Called at the single insert site
+    /// and again for every key that survives a sweep.
+    #[inline]
+    pub(super) fn arm(&mut self, key: (i32, IpAddr), due_ns: u64) {
+        self.heap.push(Reverse(Armed { due_ns, key }));
+    }
+
+    /// Pop the earliest-deadline key if it is due at `now_ns`, else `None`.
+    ///
+    /// The `None` return is the whole point: with nothing due, a sweep costs one
+    /// heap peek regardless of how many keys are pending.
+    #[inline]
+    pub(super) fn pop_due(&mut self, now_ns: u64) -> Option<(i32, IpAddr)> {
+        match self.heap.peek() {
+            Some(Reverse(top)) if top.due_ns <= now_ns => {
+                self.heap.pop().map(|Reverse(a)| a.key)
+            }
+            _ => None,
+        }
+    }
+
+    /// Number of armed entries. Equal to the map's length by the invariant in
+    /// the module header.
+    #[inline]
+    pub(super) fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    /// Earliest armed deadline, for tests and telemetry.
+    #[cfg(test)]
+    pub(super) fn next_due_ns(&self) -> Option<u64> {
+        self.heap.peek().map(|Reverse(a)| a.due_ns)
+    }
+}
+
+/// When a surviving unresolved key should next be visited.
+///
+/// `min` of three independent clocks:
+/// * its timeout instant, so a timed-out key is popped at the right moment
+///   rather than a recheck tick later;
+/// * its next probe slot, if the schedule has one left;
+/// * `now + recheck`, so resolution is noticed even between slots.
+///
+/// Saturating throughout: `queued_ns + timeout` cannot wrap the sweep into
+/// never visiting a key, which would leak a UMEM frame for the life of the
+/// process.
+#[inline]
+pub(super) fn next_due_for_pending(
+    now_ns: u64,
+    queued_ns: u64,
+    probe_attempts: u8,
+    timeout_ns: u64,
+    probe_schedule_ns: &[u64],
+) -> u64 {
+    // The instant the timeout comparison `elapsed > timeout` first holds.
+    let timeout_at = queued_ns.saturating_add(timeout_ns).saturating_add(1);
+    let mut due = timeout_at;
+    if let Some(&slot) = probe_schedule_ns.get(probe_attempts as usize) {
+        due = due.min(queued_ns.saturating_add(slot));
+    }
+    // Clamp forward of `now`: a sweep uses ONE `now_ns` for all its pops, so a
+    // key re-armed at or before it would be popped again in the same sweep. The
+    // iface-name-miss path does not advance `probe_attempts`, so its next slot
+    // stays in the past and it would re-arm in the past every time -- consuming
+    // the whole budget and starving every other key. Clamping makes each key
+    // visitable at most once per sweep, which is what makes the budget a
+    // fairness bound rather than just a cost bound.
+    due.min(now_ns.saturating_add(RESOLUTION_RECHECK_INTERVAL_NS))
+        .max(now_ns.saturating_add(1))
+}

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -19,6 +19,9 @@
 // Pure relocation. `use super::*;` brings every type, helper,
 // and sibling-submodule item from afxdp.rs into scope.
 
+use crate::afxdp::neigh_schedule::{
+    next_due_for_pending, PENDING_NEIGH_SWEEP_BUDGET,
+};
 use super::*;
 
 /// GEMINI-NEXT.md Section 3 cold-start: re-fire ARP/NDP solicitation
@@ -33,11 +36,30 @@ use super::*;
 /// 260 ms total. The deltas (10, 50, 200 ms) match the cold-start
 /// exponential design in GEMINI-NEXT.md and give the kernel three
 /// retransmits if the first solicitation is dropped.
-const PROBE_SCHEDULE_NS: &[u64] = &[
+pub(super) const PROBE_SCHEDULE_NS: &[u64] = &[
     10_000_000,  // first retry at queued + 10 ms
     60_000_000,  // second retry at queued + 60 ms (delta 50 ms)
     260_000_000, // third retry at queued + 260 ms (delta 200 ms)
 ];
+
+/// #1636 option D: the drop timeout comes per snapshot from the kernel
+/// retrans_time_ms sysctls (800 ms when fast-retrans is confirmed, else
+/// 2000 ms). `0` means a snapshot predating the field (e.g. a test-built
+/// `ForwardingState::default()`) — fall back to the compile-time constant.
+///
+/// #7156: extracted because the deadline-queue ARM site (`poll_descriptor`'s
+/// MissingNeighbor arm) and this sweep must compute the same timeout. If the
+/// arm used a longer one the key would be visited only after it had already
+/// timed out; if shorter, it would be popped, found not-yet-timed-out, and
+/// re-armed — burning budget for nothing.
+#[inline]
+pub(super) fn effective_pending_neigh_timeout_ns(forwarding: &ForwardingState) -> u64 {
+    if forwarding.pending_neigh_timeout_ns != 0 {
+        forwarding.pending_neigh_timeout_ns
+    } else {
+        PENDING_NEIGH_TIMEOUT_NS
+    }
+}
 
 /// Returns true when the next scheduled probe is due. Pure function —
 /// no side effects, easy to unit-test the schedule edges.
@@ -189,24 +211,114 @@ pub(super) fn retry_pending_neigh(
     // confirmed, else 2000ms). `0` means a snapshot that predates the
     // field (e.g. a test-built ForwardingState::default()) — fall back
     // to the compile-time PENDING_NEIGH_TIMEOUT_NS.
-    let pending_neigh_timeout_ns = if forwarding.pending_neigh_timeout_ns != 0 {
-        forwarding.pending_neigh_timeout_ns
-    } else {
-        PENDING_NEIGH_TIMEOUT_NS
-    };
+    let pending_neigh_timeout_ns = effective_pending_neigh_timeout_ns(forwarding);
     // #1771 §2.2: pending_neigh is keyed by (egress_ifindex, next_hop) with
     // ONE representative packet per hop, so the per-sweep probe-dedup
-    // BTreeSet is gone (each hop fires at most one probe naturally) and the
-    // old O(n²) pop_front/push_back rotation is replaced by a key sweep.
-    // Snapshot the keys (Copy; bounded by distinct unresolved next-hops, not
-    // packet count — tiny on this cold path) so the map is not borrowed while
-    // the resolved-dispatch tail needs `&mut binding`.
-    let keys: Vec<(i32, IpAddr)> = binding.pending_neigh.keys().copied().collect();
-    for key in keys {
+    // BTreeSet is gone (each hop fires at most one probe naturally).
+    //
+    // #7156: and the key sweep that replaced the old O(n²) rotation is itself
+    // now deadline-driven and budgeted. It used to collect EVERY unresolved key
+    // into a fresh Vec and walk all of them on every sweep, twice per poll —
+    // measured at ~182 us and ~98 KiB per sweep at the MAX_PENDING_NEIGH cap,
+    // against 8 ns for the empty-map early-out above. See `neigh_schedule` for
+    // the table and for why the heap needs no tombstone handling.
+    //
+    // Nothing due costs one heap peek. The budget bounds the worst case, and
+    // because the heap is deadline-ordered a truncated sweep leaves the
+    // LATEST-deadline keys unvisited: timeouts and due probes always win.
+    // #7156: has any neighbour been INSERTED since this worker last swept?
+    //
+    // This is the whole point. The old sweep's cost was a resolution check per
+    // pending key — a `forwarding.neighbors` hash lookup plus a
+    // `dynamic_neighbors` lookup that takes a shard MUTEX — and it ran whether
+    // or not anything had resolved. One relaxed-Acquire load answers "could any
+    // buffered next-hop have become resolvable?", and when the answer is no the
+    // sweep only services deadline-due keys: timeouts and probes.
+    //
+    // That is exactly the attacker's case. Filling MAX_PENDING_NEIGH with
+    // distinct unresolvable hops produces NO neighbour inserts, so it now buys
+    // no walks at all — where before it bought a full 4096-key walk twice per
+    // poll, ~182 us each.
+    //
+    // And when a neighbour DOES appear, the walk is the old one: every pending
+    // key is re-checked on that very sweep, so a resolved packet is dispatched
+    // with the same latency as before. Deadline order alone could not do that —
+    // a key has nothing scheduled between its last probe (queued + 260 ms) and
+    // its timeout, so a neighbour resolving at 300 ms would go unnoticed until
+    // the key timed out and its packet was DROPPED.
+    //
+    // Known residual, not closed here: an on-link attacker who can force real
+    // neighbour churn (answering ARP/NDP for many addresses) can drive walks.
+    // That is a strictly harder position than the one this issue describes — it
+    // requires answering probes rather than merely being unreachable — and it
+    // is separately bounded by MAX_DYNAMIC_NEIGHBORS_PER_SHARD and the #5673
+    // learn cap.
+    // Two signals, because there are two neighbour maps and the sweep consults
+    // both in `lookup_neighbor_entry` order. `dynamic_neighbors` is the runtime
+    // learn/resolve path and carries a true insert counter. `forwarding.neighbors`
+    // is the STATIC/permanent config-derived map, rebuilt wholesale on commit and
+    // reaching the worker as a fresh snapshot, so it has no counter to bump — its
+    // length stands in, which is exact for the add and remove that a config change
+    // actually performs. A same-size REPLACEMENT is the one static edit this misses,
+    // and RESOLUTION_RECHECK_INTERVAL_NS is the backstop for it: 50 ms, against a
+    // pending timeout of 800 ms-2 s, so such a packet still dispatches rather than
+    // being dropped. Stated rather than papered over — the dynamic path, which is
+    // the one on the packet-latency critical path, is exact.
+    let neigh_generation = (
+        dynamic_neighbors.insert_generation(),
+        forwarding.neighbors.len(),
+    );
+    let resolution_pass = neigh_generation != binding.last_neigh_generation;
+    binding.last_neigh_generation = neigh_generation;
+    if resolution_pass {
+        // Reuse the scratch so the walk allocates nothing steady-state. The old
+        // sweep built a fresh Vec of every key on EVERY sweep (~98 KiB at the
+        // cap, ~196 KiB per poll); this one reuses its capacity and only runs
+        // when a neighbour actually appeared. `mem::take` because the fill
+        // borrows `pending_neigh` while writing `pending_neigh_scan`.
+        let mut scan = std::mem::take(&mut binding.pending_neigh_scan);
+        scan.clear();
+        scan.extend(binding.pending_neigh.keys().copied());
+        binding.pending_neigh_scan = scan;
+    }
+    let mut scan_idx = 0usize;
+    let mut budget = PENDING_NEIGH_SWEEP_BUDGET;
+    loop {
+        let key = if resolution_pass {
+            // A resolution pass covers every key: it is the path that must not
+            // miss a newly-resolvable hop, and it is rare by construction.
+            let next = binding.pending_neigh_scan.get(scan_idx).copied();
+            scan_idx += 1;
+            match next {
+                Some(k) => k,
+                None => break,
+            }
+        } else {
+            if budget == 0 {
+                break;
+            }
+            budget -= 1;
+            match binding.pending_neigh_schedule.pop_due(now_ns) {
+                Some(k) => k,
+                None => break,
+            }
+        };
+        // #7156: count the visit before any early-out, so this measures work
+        // ATTEMPTED per sweep rather than work that happened to find something.
+        binding
+            .live
+            .pending_neigh_visits
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // Peek queued_ns / probe_attempts without holding a borrow across
         // the dispatch tail.
         let (queued_ns, probe_attempts) = match binding.pending_neigh.get(&key) {
             Some(p) => (p.queued_ns, p.probe_attempts),
+            // A removal during a RESOLUTION PASS leaves its heap entry behind,
+            // since that path does not pop. This is where such an entry is
+            // discarded. Self-limiting rather than an unbounded tombstone leak:
+            // at most one entry per removal, and each is reclaimed the first
+            // time its own deadline comes up, which is bounded by the key's
+            // timeout.
             None => continue,
         };
         // Timeout: recycle frame and drop.
@@ -280,6 +392,34 @@ pub(super) fn retry_pending_neigh(
                 }
                 // else: iface lookup miss → no probe fires, probe_attempts
                 // NOT advanced; the key retries this slot next sweep.
+            }
+            // #7156: this is the ONLY path on which the key stays in the map,
+            // so it is the only re-arm. Both removals below drop the key, and
+            // no path in the dispatch tail re-inserts it (every failure there
+            // recycles the frame), so re-arming anywhere else would create the
+            // stale entry this design otherwise cannot produce.
+            //
+            // Re-read probe_attempts rather than reusing the value peeked
+            // above: a probe may have just advanced it, and arming against the
+            // stale count would re-arm on the slot that has already fired.
+            let attempts_now = binding
+                .pending_neigh
+                .get(&key)
+                .map_or(probe_attempts, |p| p.probe_attempts);
+            // Only the deadline path re-arms. A resolution pass reaches keys by
+            // walking the map WITHOUT popping them, so their heap entry is still
+            // live; arming again there would put a second entry on one key and
+            // manufacture exactly the duplicate this design otherwise cannot
+            // produce.
+            if !resolution_pass {
+                let due = next_due_for_pending(
+                    now_ns,
+                    queued_ns,
+                    attempts_now,
+                    pending_neigh_timeout_ns,
+                    PROBE_SCHEDULE_NS,
+                );
+                binding.pending_neigh_schedule.arm(key, due);
             }
             continue;
         };
@@ -670,505 +810,8 @@ pub(super) fn build_missing_neighbor_session_metadata(
 }
 
 #[cfg(test)]
-mod mirror_tests {
-    use super::*;
-    use crate::afxdp::tx::test_support::{build_ipv4_test_packet, test_session_key};
-    use std::sync::atomic::Ordering;
-
-    /// #1771 §2.2: `pending_neigh` is keyed by `(egress_ifindex, next_hop)`.
-    /// Test helper that buffers one packet under its derived key, preserving
-    /// the old `push_back`-one-packet ergonomics for the retry-sweep tests.
-    ///
-    /// NOTE: this is single-entry seeding — it `insert`s (last-write-wins),
-    /// NOT the production admission keep-oldest+recycle-duplicate semantics
-    /// (poll_descriptor). Every test here seeds one packet per distinct key,
-    /// so the distinction never bites; do not reuse this to model duplicate
-    /// admission.
-    fn push_pending(b: &mut BindingWorker, pkt: PendingNeighPacket) {
-        let key = (
-            pkt.decision.resolution.egress_ifindex,
-            pkt.decision
-                .resolution
-                .next_hop
-                .expect("test pending pkt has a next_hop"),
-        );
-        b.pending_neigh.insert(key, pkt);
-    }
-
-    fn resolved_neighbor_decision(next_hop: IpAddr) -> SessionDecision {
-        SessionDecision {
-            resolution: ForwardingResolution {
-                disposition: ForwardingDisposition::MissingNeighbor,
-                local_ifindex: 0,
-                egress_ifindex: 80,
-                tx_ifindex: 22,
-                tunnel_endpoint_id: 0,
-                next_hop: Some(next_hop),
-                neighbor_mac: None,
-                src_mac: Some([0x02, 0xbf, 0x72, 0x16, 0x00, 0x01]),
-                tx_vlan_id: 0,
-            },
-            nat: NatDecision::default(),
-        }
-    }
-
-    fn pending_neighbor_meta(frame_len: usize) -> UserspaceDpMeta {
-        UserspaceDpMeta {
-            ingress_ifindex: 11,
-            l3_offset: 14,
-            l4_offset: 34,
-            pkt_len: frame_len as u16,
-            addr_family: libc::AF_INET as u8,
-            protocol: PROTO_TCP,
-            ..UserspaceDpMeta::default()
-        }
-    }
-
-    #[test]
-    fn retry_pending_neighbor_mirrors_original_frame_before_rewrite() {
-        let mut bindings = vec![
-            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
-            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
-            BindingWorker::new_for_mirror_test(2, 0, 33, 0),
-        ];
-        let original_frame = build_ipv4_test_packet(0);
-        // SAFETY: single-threaded test over a UMEM created just above; no
-        // other borrow into [0, len) exists and the mutable slice is
-        // consumed by the immediate copy_from_slice before anything else
-        // touches the area.
-        unsafe {
-            bindings[0]
-                .umem
-                .area()
-                .slice_mut_unchecked(0, original_frame.len())
-        }
-        .expect("ingress frame")
-        .copy_from_slice(&original_frame);
-
-        let next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
-        let meta = pending_neighbor_meta(original_frame.len());
-        push_pending(
-            &mut bindings[0],
-            PendingNeighPacket {
-                addr: 0,
-                desc: XdpDesc {
-                    addr: 0,
-                    len: original_frame.len() as u32,
-                    options: 0,
-                },
-                meta,
-                decision: resolved_neighbor_decision(next_hop),
-                flow_key: Some(test_session_key(12345, 443)),
-                queued_ns: 0,
-                probe_attempts: 0,
-            },
-        );
-
-        let mut forwarding = ForwardingState::default();
-        forwarding.neighbors.insert(
-            (80, next_hop),
-            NeighborEntry {
-                mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
-            },
-        );
-        forwarding.mirror_configs.insert(
-            11,
-            MirrorRuntimeConfig {
-                output_ifindex: 33,
-                rate: 0,
-            },
-        );
-
-        let lookup = WorkerBindingLookup::from_bindings(&bindings);
-        let mirror_targets = MirrorTargetMap::default();
-        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
-        let mut shared_recycles = Vec::new();
-        let area = bindings[0].umem.area() as *const MmapArea;
-        let (left, rest) = bindings.split_at_mut(0);
-        let (binding, right) = rest.split_first_mut().expect("ingress binding");
-
-        retry_pending_neigh(
-            binding,
-            left,
-            0,
-            right,
-            &lookup,
-            &mirror_targets,
-            &forwarding,
-            &dynamic_neighbors,
-            None,
-            1,
-            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
-            // bindings[0].umem just above; the Rc-backed allocation lives
-            // past this call, the split_at_mut borrows cover disjoint
-            // binding state (not the umem area), and the test is
-            // single-threaded.
-            unsafe { &*area },
-            &mut shared_recycles,
-        );
-
-        assert!(bindings[0].pending_neigh.is_empty());
-        assert_eq!(bindings[0].live.mirrored_packets.load(Ordering::Relaxed), 1);
-        assert_eq!(
-            bindings[0].live.mirrored_bytes.load(Ordering::Relaxed),
-            original_frame.len() as u64
-        );
-
-        let mirror_req = bindings[2]
-            .tx_pipeline
-            .pending_tx_prepared
-            .front()
-            .expect("mirror prepared request");
-        assert!(mirror_req.mirror_clone);
-        assert_eq!(mirror_req.egress_ifindex, 33);
-        assert_eq!(mirror_req.len, original_frame.len() as u32);
-        assert_eq!(
-            bindings[2]
-                .umem
-                .area()
-                .slice(mirror_req.offset as usize, mirror_req.len as usize)
-                .expect("mirrored frame"),
-            original_frame.as_slice(),
-            "deferred neighbor path must mirror pre-rewrite L2 bytes",
-        );
-
-        let forwarded_req = bindings[1]
-            .tx_pipeline
-            .pending_tx_prepared
-            .front()
-            .expect("forwarded prepared request");
-        assert!(
-            !forwarded_req.mirror_clone,
-            "primary forwarding request must not inherit mirror identity",
-        );
-    }
-
-    /// #1651 B3: a never-resolving pending packet that crosses the timeout
-    /// must (a) be dropped (recycled, removed from the queue) and (b) record
-    /// its (egress_ifindex, next_hop) in the binding's negative cache so
-    /// subsequent cold packets to the same dead host fast-fail.
-    #[test]
-    fn timed_out_pending_neighbor_records_negative_cache() {
-        let mut bindings = vec![
-            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
-            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
-        ];
-        let original_frame = build_ipv4_test_packet(0);
-        // SAFETY: single-threaded test over a UMEM created just above; no
-        // other borrow into [0, len) exists and the mutable slice is
-        // consumed by the immediate copy_from_slice before anything else
-        // touches the area.
-        unsafe {
-            bindings[0]
-                .umem
-                .area()
-                .slice_mut_unchecked(0, original_frame.len())
-        }
-        .expect("ingress frame")
-        .copy_from_slice(&original_frame);
-
-        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 137));
-        let meta = pending_neighbor_meta(original_frame.len());
-        push_pending(
-            &mut bindings[0],
-            PendingNeighPacket {
-                addr: 0,
-                desc: XdpDesc {
-                    addr: 0,
-                    len: original_frame.len() as u32,
-                    options: 0,
-                },
-                meta,
-                decision: resolved_neighbor_decision(next_hop),
-                flow_key: Some(test_session_key(12345, 443)),
-                queued_ns: 0,
-                // All probes already fired; the dst never resolved.
-                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
-            },
-        );
-
-        // No neighbor for `next_hop` anywhere → unresolved. Use the
-        // compile-time fallback timeout (default ForwardingState leaves
-        // pending_neigh_timeout_ns == 0).
-        let forwarding = ForwardingState::default();
-        let lookup = WorkerBindingLookup::from_bindings(&bindings);
-        let mirror_targets = MirrorTargetMap::default();
-        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
-        let mut shared_recycles = Vec::new();
-        let area = bindings[0].umem.area() as *const MmapArea;
-        let (left, rest) = bindings.split_at_mut(0);
-        let (binding, right) = rest.split_first_mut().expect("ingress binding");
-
-        // now_ns just past the 2s fallback timeout.
-        let now_ns = PENDING_NEIGH_TIMEOUT_NS + 1;
-        retry_pending_neigh(
-            binding,
-            left,
-            0,
-            right,
-            &lookup,
-            &mirror_targets,
-            &forwarding,
-            &dynamic_neighbors,
-            None,
-            now_ns,
-            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
-            // bindings[0].umem just above; the Rc-backed allocation lives
-            // past this call, the split_at_mut borrows cover disjoint
-            // binding state (not the umem area), and the test is
-            // single-threaded.
-            unsafe { &*area },
-            &mut shared_recycles,
-        );
-
-        // The packet was dropped (recycled to fill ring, queue drained).
-        assert!(
-            bindings[0].pending_neigh.is_empty(),
-            "timed-out pending packet must be dropped",
-        );
-        // The dead-host key was recorded and is active.
-        let key = (80i32, next_hop); // egress_ifindex 80 per resolved_neighbor_decision
-        assert!(
-            crate::afxdp::neg_neigh::neg_neigh_active(
-                &mut bindings[0].neg_neigh_cache,
-                &key,
-                now_ns,
-            ),
-            "timed-out dst must be negatively cached",
-        );
-    }
-
-    // #6710 lives in its own file (neighbor_dispatch/mirror_tests/) so
-    // appending it does not push this one past the 1500 LOC [WATCH] modularity
-    // floor (pkg/refactoraudit). A child module can see this module's private
-    // helpers, so `push_pending`, `resolved_neighbor_decision` and friends are
-    // reachable unchanged via `use super::*`.
-    mod xfrmi_6710_tests;
-
-    /// #1772: build a worker-facing `NeighborResolver` handle wired to a
-    /// fresh latency-telemetry set, so a test can pass it into
-    /// `retry_pending_neigh` and read back the recorded dwell / drop /
-    /// depth. The channel `rx` is returned so the producer end is not
-    /// dropped (which would mark every enqueue Disconnected).
-    fn resolver_with_latency() -> (
-        Arc<NeighborResolver>,
-        std::sync::mpsc::Receiver<crate::afxdp::neighbor_resolver::ResolveItem>,
-        Arc<crate::afxdp::neighbor_latency::NeighborLatencyHist>,
-        Arc<AtomicU64>,
-        Arc<AtomicU64>,
-    ) {
-        let (tx, rx) = std::sync::mpsc::sync_channel::<crate::afxdp::neighbor_resolver::ResolveItem>(
-            crate::afxdp::neighbor_resolver::RESOLVER_QUEUE_DEPTH,
-        );
-        let dwell = Arc::new(crate::afxdp::neighbor_latency::NeighborLatencyHist::default());
-        let drops = Arc::new(AtomicU64::new(0));
-        let depth = Arc::new(AtomicU64::new(0));
-        let resolver = Arc::new(NeighborResolver::new(
-            tx,
-            Arc::new(crate::afxdp::neighbor_resolver::ResolverCounters::default()),
-            Arc::new(AtomicU64::new(0)),
-            dwell.clone(),
-            drops.clone(),
-            depth.clone(),
-        ));
-        (resolver, rx, dwell, drops, depth)
-    }
-
-    /// #1772 acceptance: a buffered packet with a known `queued_ns` that
-    /// resolves at a later `now_ns` records its dwell into the histogram
-    /// (correct bucket + count) AND the max-depth high-water gauge is set.
-    #[test]
-    fn resolved_pending_neighbor_records_dwell_and_depth() {
-        let mut bindings = vec![
-            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
-            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
-        ];
-        let original_frame = build_ipv4_test_packet(0);
-        // SAFETY: single-threaded test over a UMEM created just above; no
-        // other borrow into [0, len) exists and the mutable slice is
-        // consumed by the immediate copy_from_slice before anything else
-        // touches the area.
-        unsafe {
-            bindings[0]
-                .umem
-                .area()
-                .slice_mut_unchecked(0, original_frame.len())
-        }
-        .expect("ingress frame")
-        .copy_from_slice(&original_frame);
-
-        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
-        let meta = pending_neighbor_meta(original_frame.len());
-        // Buffered at queued_ns = 1_000_000 ns; resolves at a now_ns that
-        // gives a 500 ms dwell — well under the 2 s PENDING_NEIGH_TIMEOUT
-        // so the packet DISPATCHES (and records its dwell) rather than
-        // timing out. The 3 s → tail-bucket mapping is covered by the
-        // neighbor_latency unit tests; here we verify the record fires on
-        // the real dispatch path with the correct sum + bucket.
-        let queued_ns = 1_000_000u64;
-        let dwell_ns = 500_000_000u64; // 500 ms
-        push_pending(
-            &mut bindings[0],
-            PendingNeighPacket {
-                addr: 0,
-                desc: XdpDesc {
-                    addr: 0,
-                    len: original_frame.len() as u32,
-                    options: 0,
-                },
-                meta,
-                decision: resolved_neighbor_decision(next_hop),
-                flow_key: Some(test_session_key(12345, 443)),
-                queued_ns,
-                probe_attempts: 0,
-            },
-        );
-
-        let mut forwarding = ForwardingState::default();
-        // Neighbor IS resolved now → the retry sweep dispatches it and
-        // records the dwell.
-        forwarding.neighbors.insert(
-            (80, next_hop),
-            NeighborEntry {
-                mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
-            },
-        );
-
-        let lookup = WorkerBindingLookup::from_bindings(&bindings);
-        let mirror_targets = MirrorTargetMap::default();
-        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
-        let mut shared_recycles = Vec::new();
-        let (resolver, _rx, dwell, _drops, depth) = resolver_with_latency();
-        let area = bindings[0].umem.area() as *const MmapArea;
-        let (left, rest) = bindings.split_at_mut(0);
-        let (binding, right) = rest.split_first_mut().expect("ingress binding");
-
-        let now_ns = queued_ns + dwell_ns;
-        retry_pending_neigh(
-            binding,
-            left,
-            0,
-            right,
-            &lookup,
-            &mirror_targets,
-            &forwarding,
-            &dynamic_neighbors,
-            Some(&resolver),
-            now_ns,
-            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
-            // bindings[0].umem just above; the Rc-backed allocation lives
-            // past this call, the split_at_mut borrows cover disjoint
-            // binding state (not the umem area), and the test is
-            // single-threaded.
-            unsafe { &*area },
-            &mut shared_recycles,
-        );
-
-        assert!(bindings[0].pending_neigh.is_empty(), "packet must dispatch");
-        let snap = dwell.snapshot();
-        assert_eq!(snap.count, 1, "exactly one dwell sample recorded");
-        assert_eq!(snap.sum_ns, dwell_ns, "sum is the recorded dwell");
-        let expect_bucket = crate::afxdp::neighbor_latency::neigh_latency_bucket_index(dwell_ns);
-        assert_eq!(
-            snap.buckets[expect_bucket], 1,
-            "500 ms dwell recorded into its pow2-ns bucket",
-        );
-        assert_eq!(
-            depth.load(Ordering::Relaxed),
-            1,
-            "max-depth high-water must reflect the 1 queued packet",
-        );
-    }
-
-    /// #1772: a never-resolving packet that crosses the timeout records a
-    /// timeout-drop and records NO dwell sample.
-    #[test]
-    fn timed_out_pending_neighbor_records_timeout_drop_not_dwell() {
-        let mut bindings = vec![
-            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
-            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
-        ];
-        let original_frame = build_ipv4_test_packet(0);
-        // SAFETY: single-threaded test over a UMEM created just above; no
-        // other borrow into [0, len) exists and the mutable slice is
-        // consumed by the immediate copy_from_slice before anything else
-        // touches the area.
-        unsafe {
-            bindings[0]
-                .umem
-                .area()
-                .slice_mut_unchecked(0, original_frame.len())
-        }
-        .expect("ingress frame")
-        .copy_from_slice(&original_frame);
-
-        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 138));
-        let meta = pending_neighbor_meta(original_frame.len());
-        push_pending(
-            &mut bindings[0],
-            PendingNeighPacket {
-                addr: 0,
-                desc: XdpDesc {
-                    addr: 0,
-                    len: original_frame.len() as u32,
-                    options: 0,
-                },
-                meta,
-                decision: resolved_neighbor_decision(next_hop),
-                flow_key: Some(test_session_key(12345, 443)),
-                queued_ns: 0,
-                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
-            },
-        );
-
-        // No neighbor anywhere → never resolves → timeout drop.
-        let forwarding = ForwardingState::default();
-        let lookup = WorkerBindingLookup::from_bindings(&bindings);
-        let mirror_targets = MirrorTargetMap::default();
-        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
-        let mut shared_recycles = Vec::new();
-        let (resolver, _rx, dwell, drops, _depth) = resolver_with_latency();
-        let area = bindings[0].umem.area() as *const MmapArea;
-        let (left, rest) = bindings.split_at_mut(0);
-        let (binding, right) = rest.split_first_mut().expect("ingress binding");
-
-        let now_ns = PENDING_NEIGH_TIMEOUT_NS + 1;
-        retry_pending_neigh(
-            binding,
-            left,
-            0,
-            right,
-            &lookup,
-            &mirror_targets,
-            &forwarding,
-            &dynamic_neighbors,
-            Some(&resolver),
-            now_ns,
-            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
-            // bindings[0].umem just above; the Rc-backed allocation lives
-            // past this call, the split_at_mut borrows cover disjoint
-            // binding state (not the umem area), and the test is
-            // single-threaded.
-            unsafe { &*area },
-            &mut shared_recycles,
-        );
-
-        assert!(
-            bindings[0].pending_neigh.is_empty(),
-            "timed-out pkt dropped"
-        );
-        assert_eq!(
-            drops.load(Ordering::Relaxed),
-            1,
-            "one timeout-drop must be counted",
-        );
-        assert_eq!(
-            dwell.snapshot().count,
-            0,
-            "a timed-out (never-resolved) packet must NOT record a dwell sample",
-        );
-    }
-}
+#[path = "neighbor_dispatch_mirror_tests.rs"]
+mod mirror_tests;
 
 #[cfg(test)]
 mod cold_start_probe_schedule_tests {

--- a/userspace-dp/src/afxdp/neighbor_dispatch_mirror_tests.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch_mirror_tests.rs
@@ -1,0 +1,980 @@
+//! #7156: the `retry_pending_neigh` dispatch/mirror test suite, extracted from
+//! `neighbor_dispatch.rs`.
+//!
+//! Moved rather than grown in place: that file sat at 1493 LOC, seven lines
+//! under the 1500 [WATCH] modularity floor, so the #7156 sweep tests could not
+//! be added to it without crossing. Extracting the tests leaves the production
+//! sweep at ~1100 LOC with room to be read.
+//!
+//! Included with `#[path]` from its parent, so `super::` still resolves to
+//! `neighbor_dispatch` and every existing import is unchanged by the move.
+    use super::*;
+    use crate::afxdp::tx::test_support::{build_ipv4_test_packet, test_session_key};
+    use std::sync::atomic::Ordering;
+
+    /// #1771 §2.2: `pending_neigh` is keyed by `(egress_ifindex, next_hop)`.
+    /// Test helper that buffers one packet under its derived key, preserving
+    /// the old `push_back`-one-packet ergonomics for the retry-sweep tests.
+    ///
+    /// NOTE: this is single-entry seeding — it `insert`s (last-write-wins),
+    /// NOT the production admission keep-oldest+recycle-duplicate semantics
+    /// (poll_descriptor). Every test here seeds one packet per distinct key,
+    /// so the distinction never bites; do not reuse this to model duplicate
+    /// admission.
+    fn push_pending(b: &mut BindingWorker, pkt: PendingNeighPacket) {
+        let key = (
+            pkt.decision.resolution.egress_ifindex,
+            pkt.decision
+                .resolution
+                .next_hop
+                .expect("test pending pkt has a next_hop"),
+        );
+        let due = next_due_for_pending(pkt.queued_ns, pkt.queued_ns, pkt.probe_attempts,
+            PENDING_NEIGH_TIMEOUT_NS, PROBE_SCHEDULE_NS);
+        b.pending_neigh.insert(key, pkt);
+        b.pending_neigh_schedule.arm(key, due);
+    }
+
+    fn resolved_neighbor_decision(next_hop: IpAddr) -> SessionDecision {
+        SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::MissingNeighbor,
+                local_ifindex: 0,
+                egress_ifindex: 80,
+                tx_ifindex: 22,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(next_hop),
+                neighbor_mac: None,
+                src_mac: Some([0x02, 0xbf, 0x72, 0x16, 0x00, 0x01]),
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision::default(),
+        }
+    }
+
+    fn pending_neighbor_meta(frame_len: usize) -> UserspaceDpMeta {
+        UserspaceDpMeta {
+            ingress_ifindex: 11,
+            l3_offset: 14,
+            l4_offset: 34,
+            pkt_len: frame_len as u16,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            ..UserspaceDpMeta::default()
+        }
+    }
+
+    /// #7156 fixture: `n` distinct unresolved next-hops on one binding, all
+    /// queued at `queued_ns`. Returns the bindings so the caller drives the
+    /// sweep against them.
+    ///
+    /// Uses the map's own length as the visit counter: every key here is past
+    /// its timeout when swept at a late `now_ns`, so a visited key is REMOVED.
+    /// That counts visits through production-visible state rather than a
+    /// test-only counter wired into the sweep.
+    fn pending_neigh_fixture_7156(n: usize, queued_ns: u64) -> Vec<BindingWorker> {
+        let mut bindings = vec![BindingWorker::new_for_mirror_test(0, 0, 11, 0)];
+        let frame = build_ipv4_test_packet(0);
+        let meta = pending_neighbor_meta(frame.len());
+        for i in 0..n {
+            let nh = IpAddr::V4(Ipv4Addr::new(
+                10,
+                ((i >> 16) & 0xff) as u8,
+                ((i >> 8) & 0xff) as u8,
+                (i & 0xff) as u8,
+            ));
+            push_pending(
+                &mut bindings[0],
+                PendingNeighPacket {
+                    addr: 0,
+                    desc: XdpDesc { addr: 0, len: frame.len() as u32, options: 0 },
+                    meta,
+                    decision: resolved_neighbor_decision(nh),
+                    flow_key: None,
+                    queued_ns,
+                    probe_attempts: 0,
+                },
+            );
+        }
+        assert_eq!(bindings[0].pending_neigh.len(), n, "fixture must hold n keys");
+        bindings
+    }
+
+    /// Drive one sweep against `bindings[0]` at `now_ns`, with an optional
+    /// pre-populated dynamic neighbor map.
+    fn sweep_7156(
+        bindings: &mut [BindingWorker],
+        dynamic_neighbors: &Arc<ShardedNeighborMap>,
+        now_ns: u64,
+    ) {
+        let forwarding = ForwardingState::default();
+        let lookup = WorkerBindingLookup::from_bindings(bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let mut shared_recycles = Vec::new();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("binding");
+        retry_pending_neigh(
+            binding, left, 0, right, &lookup, &mirror_targets, &forwarding,
+            dynamic_neighbors, None, now_ns,
+            // SAFETY: `area` was cast from the &MmapArea borrowed out of
+            // bindings[0].umem above; the allocation outlives this call, the
+            // split borrows cover disjoint binding state, and this is
+            // single-threaded.
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+    }
+
+    /// #7156 acceptance 1: with a full pending map and NOTHING due, a sweep must
+    /// do no per-key work.
+    ///
+    /// This is the regime the issue is about — an idle binding holding stale
+    /// next-hops — and the one the old sweep paid ~182 us for, twice per poll,
+    /// walking all 4096 keys and allocating ~98 KiB. Asserted through state
+    /// rather than timing: no key may be touched, so nothing is removed and
+    /// nothing is recycled.
+    ///
+    /// FAIL-ON-REVERT: restore the `binding.pending_neigh.keys().collect()` walk
+    /// and every key is visited; with `now_ns` before any timeout they survive,
+    /// but the probe-attempt and recycle assertions below still bind the visit.
+    #[test]
+    fn a_sweep_with_nothing_due_touches_no_pending_key_7156() {
+        const N: usize = 4096;
+        const QUEUED: u64 = 1_000_000_000;
+        let mut bindings = pending_neigh_fixture_7156(N, QUEUED);
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        // 100 ns after queueing: first probe slot (10 ms), the 50 ms recheck and
+        // the 2 s timeout are all in the future, so no key is due.
+        sweep_7156(&mut bindings, &dynamic_neighbors, QUEUED + 100);
+
+        // THE assertion. The removal/recycle checks below cannot see this
+        // defect: with nothing due, walking all 4096 keys finds nothing to do
+        // and leaves exactly the same state as walking none. Only the visit
+        // counter distinguishes "did no work" from "did 4096 lookups, each
+        // taking a neighbor shard mutex, and found nothing".
+        assert_eq!(
+            bindings[0]
+                .live
+                .pending_neigh_visits
+                .load(Ordering::Relaxed),
+            0,
+            "a sweep with nothing due must touch NO pending key. {N} visits \
+             here is the pre-#7156 full-map walk: ~182 us and ~98 KiB per \
+             sweep, twice per poll, on a binding that has nothing to do"
+        );
+        assert_eq!(
+            bindings[0].pending_neigh.len(),
+            N,
+            "no key is due, so none may be removed"
+        );
+        assert!(
+            bindings[0].tx_pipeline.pending_fill_frames.is_empty(),
+            "no key is due, so no frame may be recycled"
+        );
+        assert!(
+            bindings[0].pending_neigh.values().all(|p| p.probe_attempts == 0),
+            "no key is due, so no probe may have been attempted"
+        );
+    }
+
+    /// #7156 acceptance 2: when MORE keys are due than the budget allows, a
+    /// sweep makes bounded progress, and successive sweeps drain the backlog
+    /// without starving anyone.
+    ///
+    /// Exactly `PENDING_NEIGH_SWEEP_BUDGET` keys are serviced per sweep — the
+    /// bound — and the count keeps falling by that step until the map empties,
+    /// which is the no-starvation half: a key deferred by the budget is not
+    /// deferred for ever, and no key is serviced twice while another waits (the
+    /// step would be short if it were).
+    #[test]
+    fn due_keys_beyond_the_budget_drain_without_starvation_7156() {
+        const N: usize = 4096;
+        const QUEUED: u64 = 1_000_000_000;
+        let mut bindings = pending_neigh_fixture_7156(N, QUEUED);
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        // Well past the 2 s timeout: every key is due, and a visited key is
+        // removed, so the map length counts exactly the keys not yet serviced.
+        let now = QUEUED + PENDING_NEIGH_TIMEOUT_NS + 1_000_000_000;
+
+        sweep_7156(&mut bindings, &dynamic_neighbors, now);
+        assert_eq!(
+            bindings[0].pending_neigh.len(),
+            N - PENDING_NEIGH_SWEEP_BUDGET,
+            "one sweep must service exactly the budget, not all {N} due keys — \
+             an unbounded sweep empties the map here"
+        );
+        assert_eq!(
+            bindings[0]
+                .live
+                .pending_neigh_visits
+                .load(Ordering::Relaxed),
+            PENDING_NEIGH_SWEEP_BUDGET as u64,
+            "the budget must bound VISITS, not just removals — a sweep that \
+             looked at every key and only acted on the budget would leave the \
+             per-key cost exactly where #7156 found it"
+        );
+
+        let mut sweeps = 1;
+        while !bindings[0].pending_neigh.is_empty() {
+            let before = bindings[0].pending_neigh.len();
+            sweep_7156(&mut bindings, &dynamic_neighbors, now);
+            let after = bindings[0].pending_neigh.len();
+            assert_eq!(
+                before - after,
+                PENDING_NEIGH_SWEEP_BUDGET.min(before),
+                "sweep {sweeps}: each sweep must service a full budget of DUE \
+                 keys. A short step means budget was spent re-visiting a key \
+                 already serviced while others still waited"
+            );
+            sweeps += 1;
+            assert!(sweeps <= N / PENDING_NEIGH_SWEEP_BUDGET + 2, "must terminate");
+        }
+        assert_eq!(
+            sweeps,
+            N / PENDING_NEIGH_SWEEP_BUDGET,
+            "the backlog must drain in exactly ceil(N/budget) sweeps"
+        );
+    }
+
+    /// #7156: a key may be visited at most ONCE per sweep, so the budget bounds
+    /// distinct keys and not merely iterations.
+    ///
+    /// The path that makes this non-trivial is the iface-name miss: `probe_due`
+    /// is true but `forwarding.ifindex_to_name` has no entry, so no probe fires
+    /// and `probe_attempts` is deliberately NOT advanced — the existing contract
+    /// is that the key retries this slot next sweep. Its next deadline is
+    /// therefore its probe slot, which is already in the PAST, so without the
+    /// clamp in `next_due_for_pending` it re-arms as due, returns to the head of
+    /// the heap, and is popped again inside the same sweep. One key would then
+    /// consume the whole budget while 4095 others waited — the starvation the
+    /// budget is supposed to prevent, reintroduced by the fix.
+    ///
+    /// Asserted as drainage at a FIXED `now`: if each sweep takes `budget`
+    /// distinct keys, ceil(N/budget) sweeps exhaust everything due and one more
+    /// does nothing. If keys re-arm into the past, sweeps never stop finding
+    /// work at that same instant.
+    ///
+    /// This is the cell the starvation test above CANNOT provide: there every
+    /// key is past its timeout and is removed on its visit, so nothing re-arms
+    /// and the clamp is never reached. Deleting the clamp leaves that test green.
+    #[test]
+    fn a_key_is_visited_at_most_once_per_sweep_7156() {
+        const N: usize = 256;
+        const QUEUED: u64 = 1_000_000_000;
+        let mut bindings = pending_neigh_fixture_7156(N, QUEUED);
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        // Past the first probe slot, far short of the timeout. The fixture's
+        // ForwardingState::default() has an empty ifindex_to_name, so this is
+        // exactly the probe-due / name-miss state.
+        let now = QUEUED + PROBE_SCHEDULE_NS[0] + 1;
+
+        let sweeps = N / PENDING_NEIGH_SWEEP_BUDGET;
+        for _ in 0..sweeps {
+            sweep_7156(&mut bindings, &dynamic_neighbors, now);
+        }
+        assert_eq!(
+            bindings[0].live.pending_neigh_visits.load(Ordering::Relaxed),
+            N as u64,
+            "after ceil(N/budget) sweeps every key must have been visited \
+             exactly once. More than {N} means a key was re-visited while \
+             another still waited"
+        );
+        assert_eq!(
+            bindings[0].pending_neigh.len(),
+            N,
+            "none of these keys is resolved or timed out, so all must survive"
+        );
+
+        // The discriminator: everything due has now been serviced, so a further
+        // sweep at the SAME instant must find nothing.
+        let before = bindings[0].live.pending_neigh_visits.load(Ordering::Relaxed);
+        sweep_7156(&mut bindings, &dynamic_neighbors, now);
+        assert_eq!(
+            bindings[0].live.pending_neigh_visits.load(Ordering::Relaxed),
+            before,
+            "a sweep after the backlog is drained must do NOTHING at the same \
+             instant. Work here means keys re-armed into the past and are being \
+             serviced repeatedly within one instant, starving the rest"
+        );
+    }
+
+    /// #7156: the deadline queue must hold at most ONE entry per live pending
+    /// key, across any number of resolution passes.
+    ///
+    /// This is the issue's "must not admit attacker-driven unbounded tombstones"
+    /// requirement, arriving by the other door — duplicates rather than
+    /// tombstones. A resolution pass reaches keys by walking the MAP without
+    /// popping them, so their heap entry is still live; re-arming there adds a
+    /// second entry for the same key. Every subsequent pass adds another, so the
+    /// heap grows by the pending population per pass and never shrinks, and each
+    /// duplicate is a wasted budget slot at some future sweep.
+    ///
+    /// Driven with a neighbour that resolves NOTHING pending, so the pass
+    /// happens and every key survives it — the shape that duplicates. A pass
+    /// that dispatched its keys would hide the defect by removing them.
+    #[test]
+    fn resolution_passes_do_not_duplicate_schedule_entries_7156() {
+        const N: usize = 64;
+        const QUEUED: u64 = 1_000_000_000;
+        let mut bindings = pending_neigh_fixture_7156(N, QUEUED);
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        assert_eq!(
+            bindings[0].pending_neigh_schedule.len(),
+            N,
+            "precondition: one armed entry per key at insert"
+        );
+
+        for pass in 1..=3u16 {
+            // A neighbour on an ifindex nothing is waiting on: it bumps the
+            // insert generation, so the sweep takes the resolution path, but
+            // resolves no pending key, so all N survive the walk.
+            dynamic_neighbors.insert(
+                (9_000 + pass as i32, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))),
+                NeighborEntry { mac: [2, 2, 2, 2, 2, pass as u8] },
+            );
+            sweep_7156(&mut bindings, &dynamic_neighbors, QUEUED + 100);
+
+            assert_eq!(
+                bindings[0].pending_neigh.len(),
+                N,
+                "pass {pass}: nothing resolvable and nothing due, so every key \
+                 must survive — otherwise this fixture is not exercising the \
+                 duplicating shape"
+            );
+            assert_eq!(
+                bindings[0].pending_neigh_schedule.len(),
+                N,
+                "pass {pass}: the schedule must still hold exactly one entry \
+                 per live key. {} entries for {N} keys means each resolution \
+                 pass re-armed keys it never popped, so the queue grows by the \
+                 pending population every time a neighbour appears and never \
+                 shrinks (#7156)",
+                bindings[0].pending_neigh_schedule.len()
+            );
+        }
+    }
+
+    /// #7156 acceptance 3: a neighbour that resolves is dispatched on the NEXT
+    /// sweep, not when the key's own deadline happens to come round.
+    ///
+    /// This is the property deadline ordering alone destroys, and the reason the
+    /// generation gate exists. A key has nothing scheduled between its last
+    /// probe (queued + 260 ms) and its timeout (2 s here), so a neighbour that
+    /// appears at 300 ms would go unseen until the key TIMED OUT and its packet
+    /// was dropped — a correctness regression, not a latency one.
+    ///
+    /// The resolved key is deliberately the LAST one inserted, so it sits behind
+    /// 4095 others: "promptly, not queued behind thousands of future deadlines".
+    ///
+    /// FAIL-ON-REVERT: delete the `resolution_pass` gate (leave only the
+    /// deadline path) and the key is still pending after the sweep.
+    #[test]
+    fn a_neighbour_that_resolves_is_dispatched_on_the_next_sweep_7156() {
+        const N: usize = 4096;
+        const QUEUED: u64 = 1_000_000_000;
+        let mut bindings = pending_neigh_fixture_7156(N, QUEUED);
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+
+        // The tail key, and the egress its decision resolved to.
+        let tail = IpAddr::V4(Ipv4Addr::new(10, 0, 15, 255));
+        let key = (
+            resolved_neighbor_decision(tail).resolution.egress_ifindex,
+            tail,
+        );
+        assert!(
+            bindings[0].pending_neigh.contains_key(&key),
+            "precondition: the tail key must be pending"
+        );
+
+        // Control: with nothing resolved, a sweep at this time leaves it alone —
+        // so the dispatch below is the resolution being noticed, not the key
+        // simply being due.
+        sweep_7156(&mut bindings, &dynamic_neighbors, QUEUED + 100);
+        assert_eq!(
+            bindings[0].pending_neigh.len(),
+            N,
+            "control: nothing resolved and nothing due, so nothing moves"
+        );
+
+        // The neighbour appears, mid-schedule: past every probe slot, far short
+        // of the timeout — precisely the window with no deadline of its own.
+        dynamic_neighbors.insert(key, NeighborEntry { mac: [1, 2, 3, 4, 5, 6] });
+        sweep_7156(&mut bindings, &dynamic_neighbors, QUEUED + 300_000_000);
+
+        assert!(
+            !bindings[0].pending_neigh.contains_key(&key),
+            "a resolved next-hop must leave pending_neigh on the very next \
+             sweep. Still pending here means the packet waits for its timeout \
+             and is then DROPPED as never-resolved (#7156)"
+        );
+        assert_eq!(
+            bindings[0].pending_neigh.len(),
+            N - 1,
+            "only the resolved key may be consumed; the rest are neither \
+             resolved nor timed out"
+        );
+    }
+
+    /// #7156 MEASUREMENT (not a fix): what does the O(all-keys) sweep
+    /// actually cost at a realistic and at a worst-case pending population?
+    ///
+    /// Steady state per key on the "still unresolved" path is: one
+    /// `pending_neigh` hash lookup, a timeout compare, one `forwarding.neighbors`
+    /// hash lookup, one `dynamic_neighbors` lookup which takes a SHARD MUTEX,
+    /// and a `probe_due` evaluation. Plus one fresh `Vec<(i32, IpAddr)>` of the
+    /// whole key set per sweep, and the sweep runs TWICE per poll iteration.
+    #[test]
+    #[ignore = "measurement, not an assertion; run with --ignored --nocapture"]
+    fn measure_pending_neigh_sweep_cost_7156() {
+        use std::time::Instant;
+        let key_bytes = std::mem::size_of::<(i32, IpAddr)>();
+        println!("\nsize_of::<(i32, IpAddr)>() = {key_bytes} bytes");
+        // Read the columns knowing what each is: "nothing-due" is a warm
+        // steady-state average over many reps and is the regime an idle worker
+        // holding a backlog actually pays, twice per poll. "all-due" is ONE
+        // COLD sweep, so it carries first-touch misses over the whole map and is
+        // noisy and pessimistic; it rises with n despite `visited` being capped
+        // because a larger map gives worse locality per random-key lookup, not
+        // because the sweep does more work. The load-bearing column is
+        // `visited`: it is the budget, flat at 64, where the pre-fix sweep
+        // visited every one of n.
+        println!(" N     nothing-due    all-due  visited   pre-fix Vec/sweep");
+        for n in [0usize, 1, 64, 1024, 4096] {
+            let mut bindings = vec![BindingWorker::new_for_mirror_test(0, 0, 11, 0)];
+            let frame = build_ipv4_test_packet(0);
+            let meta = pending_neighbor_meta(frame.len());
+            for i in 0..n {
+                // Distinct next-hops => distinct keys, so the map really holds n.
+                let nh = IpAddr::V4(Ipv4Addr::new(
+                    10,
+                    ((i >> 16) & 0xff) as u8,
+                    ((i >> 8) & 0xff) as u8,
+                    (i & 0xff) as u8,
+                ));
+                push_pending(
+                    &mut bindings[0],
+                    PendingNeighPacket {
+                        addr: 0,
+                        desc: XdpDesc { addr: 0, len: frame.len() as u32, options: 0 },
+                        meta,
+                        decision: resolved_neighbor_decision(nh),
+                        flow_key: None,
+                        // queued "now" so nothing times out during the run.
+                        queued_ns: 1_000_000_000,
+                        probe_attempts: 0,
+                    },
+                );
+            }
+            assert_eq!(bindings[0].pending_neigh.len(), n, "fixture must hold n keys");
+            // Empty forwarding: every key misses both neighbor maps, which is
+            // the UNRESOLVED steady state the issue is about. ifindex_to_name is
+            // empty too, so no probe ever fires and the loop body is the pure
+            // per-key scheduler cost.
+            let forwarding = ForwardingState::default();
+            let lookup = WorkerBindingLookup::from_bindings(&bindings);
+            let mirror_targets = MirrorTargetMap::default();
+            let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+            let mut shared_recycles = Vec::new();
+            let area = bindings[0].umem.area() as *const MmapArea;
+
+            let reps = if n > 512 { 200 } else { 5_000 };
+            let (left, rest) = bindings.split_at_mut(0);
+            let (binding, right) = rest.split_first_mut().expect("binding");
+            // Warm.
+            for _ in 0..(reps / 10).max(1) {
+                retry_pending_neigh(
+                    binding, left, 0, right, &lookup, &mirror_targets, &forwarding,
+                    &dynamic_neighbors, None, 1_000_000_100, unsafe { &*area },
+                    &mut shared_recycles,
+                );
+            }
+            let t0 = Instant::now();
+            for _ in 0..reps {
+                retry_pending_neigh(
+                    binding, left, 0, right, &lookup, &mirror_targets, &forwarding,
+                    &dynamic_neighbors, None, 1_000_000_100, unsafe { &*area },
+                    &mut shared_recycles,
+                );
+            }
+            let per = t0.elapsed().as_nanos() as f64 / reps as f64;
+            assert_eq!(
+                binding.pending_neigh.len(), n,
+                "the sweep must not have drained the fixture (would void the timing)"
+            );
+            // ALL-DUE: advance past the first probe slot so every key is due.
+            // This is the worst case the BUDGET has to bound; reporting only the
+            // nothing-due column would be a flattering measurement.
+            //
+            // Timed as a SINGLE sweep on a fresh backlog, deliberately. Looping
+            // it measures the wrong thing: the first sweep drains `budget` keys
+            // and re-arms them past `now_ns`, so after ceil(n/budget) sweeps at
+            // one fixed `now_ns` the queue is drained and every later rep
+            // measures the nothing-due path again. The average over a loop is
+            // then a blend of the two regimes that belongs to neither, and it
+            // gets cheaper as n grows, which is exactly backwards.
+            let due_now = 1_000_000_000 + PROBE_SCHEDULE_NS[0] + 5_000_000;
+            let t1 = Instant::now();
+            retry_pending_neigh(
+                binding, left, 0, right, &lookup, &mirror_targets, &forwarding,
+                &dynamic_neighbors, None, due_now, unsafe { &*area },
+                &mut shared_recycles,
+            );
+            let per_due = t1.elapsed().as_nanos() as f64;
+            let visited = n.min(PENDING_NEIGH_SWEEP_BUDGET);
+            println!(
+                "{n:5}  {per:11.0}  {per_due:11.0}  {visited:7}   {:>12}",
+                n * key_bytes
+            );
+        }
+    }
+
+    #[test]
+    fn retry_pending_neighbor_mirrors_original_frame_before_rewrite() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+            BindingWorker::new_for_mirror_test(2, 0, 33, 0),
+        ];
+        let original_frame = build_ipv4_test_packet(0);
+        // SAFETY: single-threaded test over a UMEM created just above; no
+        // other borrow into [0, len) exists and the mutable slice is
+        // consumed by the immediate copy_from_slice before anything else
+        // touches the area.
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(0, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+
+        let next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let meta = pending_neighbor_meta(original_frame.len());
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
+                addr: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                probe_attempts: 0,
+            },
+        );
+
+        let mut forwarding = ForwardingState::default();
+        forwarding.neighbors.insert(
+            (80, next_hop),
+            NeighborEntry {
+                mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+            },
+        );
+        forwarding.mirror_configs.insert(
+            11,
+            MirrorRuntimeConfig {
+                output_ifindex: 33,
+                rate: 0,
+            },
+        );
+
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        let mut shared_recycles = Vec::new();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("ingress binding");
+
+        retry_pending_neigh(
+            binding,
+            left,
+            0,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            &dynamic_neighbors,
+            None,
+            1,
+            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
+            // bindings[0].umem just above; the Rc-backed allocation lives
+            // past this call, the split_at_mut borrows cover disjoint
+            // binding state (not the umem area), and the test is
+            // single-threaded.
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+
+        assert!(bindings[0].pending_neigh.is_empty());
+        assert_eq!(bindings[0].live.mirrored_packets.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            bindings[0].live.mirrored_bytes.load(Ordering::Relaxed),
+            original_frame.len() as u64
+        );
+
+        let mirror_req = bindings[2]
+            .tx_pipeline
+            .pending_tx_prepared
+            .front()
+            .expect("mirror prepared request");
+        assert!(mirror_req.mirror_clone);
+        assert_eq!(mirror_req.egress_ifindex, 33);
+        assert_eq!(mirror_req.len, original_frame.len() as u32);
+        assert_eq!(
+            bindings[2]
+                .umem
+                .area()
+                .slice(mirror_req.offset as usize, mirror_req.len as usize)
+                .expect("mirrored frame"),
+            original_frame.as_slice(),
+            "deferred neighbor path must mirror pre-rewrite L2 bytes",
+        );
+
+        let forwarded_req = bindings[1]
+            .tx_pipeline
+            .pending_tx_prepared
+            .front()
+            .expect("forwarded prepared request");
+        assert!(
+            !forwarded_req.mirror_clone,
+            "primary forwarding request must not inherit mirror identity",
+        );
+    }
+
+    /// #1651 B3: a never-resolving pending packet that crosses the timeout
+    /// must (a) be dropped (recycled, removed from the queue) and (b) record
+    /// its (egress_ifindex, next_hop) in the binding's negative cache so
+    /// subsequent cold packets to the same dead host fast-fail.
+    #[test]
+    fn timed_out_pending_neighbor_records_negative_cache() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let original_frame = build_ipv4_test_packet(0);
+        // SAFETY: single-threaded test over a UMEM created just above; no
+        // other borrow into [0, len) exists and the mutable slice is
+        // consumed by the immediate copy_from_slice before anything else
+        // touches the area.
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(0, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+
+        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 137));
+        let meta = pending_neighbor_meta(original_frame.len());
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
+                addr: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                // All probes already fired; the dst never resolved.
+                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
+            },
+        );
+
+        // No neighbor for `next_hop` anywhere → unresolved. Use the
+        // compile-time fallback timeout (default ForwardingState leaves
+        // pending_neigh_timeout_ns == 0).
+        let forwarding = ForwardingState::default();
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        let mut shared_recycles = Vec::new();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("ingress binding");
+
+        // now_ns just past the 2s fallback timeout.
+        let now_ns = PENDING_NEIGH_TIMEOUT_NS + 1;
+        retry_pending_neigh(
+            binding,
+            left,
+            0,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            &dynamic_neighbors,
+            None,
+            now_ns,
+            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
+            // bindings[0].umem just above; the Rc-backed allocation lives
+            // past this call, the split_at_mut borrows cover disjoint
+            // binding state (not the umem area), and the test is
+            // single-threaded.
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+
+        // The packet was dropped (recycled to fill ring, queue drained).
+        assert!(
+            bindings[0].pending_neigh.is_empty(),
+            "timed-out pending packet must be dropped",
+        );
+        // The dead-host key was recorded and is active.
+        let key = (80i32, next_hop); // egress_ifindex 80 per resolved_neighbor_decision
+        assert!(
+            crate::afxdp::neg_neigh::neg_neigh_active(
+                &mut bindings[0].neg_neigh_cache,
+                &key,
+                now_ns,
+            ),
+            "timed-out dst must be negatively cached",
+        );
+    }
+
+    // #6710 lives in its own file (neighbor_dispatch/mirror_tests/) so
+    // appending it does not push this one past the 1500 LOC [WATCH] modularity
+    // floor (pkg/refactoraudit). A child module can see this module's private
+    // helpers, so `push_pending`, `resolved_neighbor_decision` and friends are
+    // reachable unchanged via `use super::*`.
+    // #7156: explicit path — this module's parent moved out of
+    // `neighbor_dispatch.rs` into a `#[path]`-loaded sibling file, so the
+    // implicit `neighbor_dispatch/mirror_tests/` directory lookup no longer
+    // applies. The child file itself is unmoved.
+    #[path = "neighbor_dispatch/mirror_tests/xfrmi_6710_tests.rs"]
+    mod xfrmi_6710_tests;
+
+    /// #1772: build a worker-facing `NeighborResolver` handle wired to a
+    /// fresh latency-telemetry set, so a test can pass it into
+    /// `retry_pending_neigh` and read back the recorded dwell / drop /
+    /// depth. The channel `rx` is returned so the producer end is not
+    /// dropped (which would mark every enqueue Disconnected).
+    fn resolver_with_latency() -> (
+        Arc<NeighborResolver>,
+        std::sync::mpsc::Receiver<crate::afxdp::neighbor_resolver::ResolveItem>,
+        Arc<crate::afxdp::neighbor_latency::NeighborLatencyHist>,
+        Arc<AtomicU64>,
+        Arc<AtomicU64>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<crate::afxdp::neighbor_resolver::ResolveItem>(
+            crate::afxdp::neighbor_resolver::RESOLVER_QUEUE_DEPTH,
+        );
+        let dwell = Arc::new(crate::afxdp::neighbor_latency::NeighborLatencyHist::default());
+        let drops = Arc::new(AtomicU64::new(0));
+        let depth = Arc::new(AtomicU64::new(0));
+        let resolver = Arc::new(NeighborResolver::new(
+            tx,
+            Arc::new(crate::afxdp::neighbor_resolver::ResolverCounters::default()),
+            Arc::new(AtomicU64::new(0)),
+            dwell.clone(),
+            drops.clone(),
+            depth.clone(),
+        ));
+        (resolver, rx, dwell, drops, depth)
+    }
+
+    /// #1772 acceptance: a buffered packet with a known `queued_ns` that
+    /// resolves at a later `now_ns` records its dwell into the histogram
+    /// (correct bucket + count) AND the max-depth high-water gauge is set.
+    #[test]
+    fn resolved_pending_neighbor_records_dwell_and_depth() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let original_frame = build_ipv4_test_packet(0);
+        // SAFETY: single-threaded test over a UMEM created just above; no
+        // other borrow into [0, len) exists and the mutable slice is
+        // consumed by the immediate copy_from_slice before anything else
+        // touches the area.
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(0, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+
+        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+        let meta = pending_neighbor_meta(original_frame.len());
+        // Buffered at queued_ns = 1_000_000 ns; resolves at a now_ns that
+        // gives a 500 ms dwell — well under the 2 s PENDING_NEIGH_TIMEOUT
+        // so the packet DISPATCHES (and records its dwell) rather than
+        // timing out. The 3 s → tail-bucket mapping is covered by the
+        // neighbor_latency unit tests; here we verify the record fires on
+        // the real dispatch path with the correct sum + bucket.
+        let queued_ns = 1_000_000u64;
+        let dwell_ns = 500_000_000u64; // 500 ms
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
+                addr: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns,
+                probe_attempts: 0,
+            },
+        );
+
+        let mut forwarding = ForwardingState::default();
+        // Neighbor IS resolved now → the retry sweep dispatches it and
+        // records the dwell.
+        forwarding.neighbors.insert(
+            (80, next_hop),
+            NeighborEntry {
+                mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+            },
+        );
+
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        let mut shared_recycles = Vec::new();
+        let (resolver, _rx, dwell, _drops, depth) = resolver_with_latency();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("ingress binding");
+
+        let now_ns = queued_ns + dwell_ns;
+        retry_pending_neigh(
+            binding,
+            left,
+            0,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            &dynamic_neighbors,
+            Some(&resolver),
+            now_ns,
+            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
+            // bindings[0].umem just above; the Rc-backed allocation lives
+            // past this call, the split_at_mut borrows cover disjoint
+            // binding state (not the umem area), and the test is
+            // single-threaded.
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+
+        assert!(bindings[0].pending_neigh.is_empty(), "packet must dispatch");
+        let snap = dwell.snapshot();
+        assert_eq!(snap.count, 1, "exactly one dwell sample recorded");
+        assert_eq!(snap.sum_ns, dwell_ns, "sum is the recorded dwell");
+        let expect_bucket = crate::afxdp::neighbor_latency::neigh_latency_bucket_index(dwell_ns);
+        assert_eq!(
+            snap.buckets[expect_bucket], 1,
+            "500 ms dwell recorded into its pow2-ns bucket",
+        );
+        assert_eq!(
+            depth.load(Ordering::Relaxed),
+            1,
+            "max-depth high-water must reflect the 1 queued packet",
+        );
+    }
+
+    /// #1772: a never-resolving packet that crosses the timeout records a
+    /// timeout-drop and records NO dwell sample.
+    #[test]
+    fn timed_out_pending_neighbor_records_timeout_drop_not_dwell() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let original_frame = build_ipv4_test_packet(0);
+        // SAFETY: single-threaded test over a UMEM created just above; no
+        // other borrow into [0, len) exists and the mutable slice is
+        // consumed by the immediate copy_from_slice before anything else
+        // touches the area.
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(0, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+
+        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 138));
+        let meta = pending_neighbor_meta(original_frame.len());
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
+                addr: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
+            },
+        );
+
+        // No neighbor anywhere → never resolves → timeout drop.
+        let forwarding = ForwardingState::default();
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        let mut shared_recycles = Vec::new();
+        let (resolver, _rx, dwell, drops, _depth) = resolver_with_latency();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("ingress binding");
+
+        let now_ns = PENDING_NEIGH_TIMEOUT_NS + 1;
+        retry_pending_neigh(
+            binding,
+            left,
+            0,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            &dynamic_neighbors,
+            Some(&resolver),
+            now_ns,
+            // SAFETY: `area` was cast from `&MmapArea` borrowed out of
+            // bindings[0].umem just above; the Rc-backed allocation lives
+            // past this call, the split_at_mut borrows cover disjoint
+            // binding state (not the umem area), and the test is
+            // single-threaded.
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+
+        assert!(
+            bindings[0].pending_neigh.is_empty(),
+            "timed-out pkt dropped"
+        );
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            1,
+            "one timeout-drop must be counted",
+        );
+        assert_eq!(
+            dwell.snapshot().count,
+            0,
+            "a timed-out (never-resolved) packet must NOT record a dwell sample",
+        );
+    }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -5523,6 +5523,27 @@ pub(super) fn poll_binding_process_descriptor(
                                                     probe_attempts: 0,
                                                 },
                                             );
+                                            // #7156: arm the deadline queue in
+                                            // the SAME branch that inserts. This
+                                            // is the only production insert, and
+                                            // an insert that skipped the arm
+                                            // would strand the key: nothing else
+                                            // ever visits it, so its UMEM frame
+                                            // would never be recycled and its
+                                            // packet never dispatched or timed
+                                            // out.
+                                            binding.pending_neigh_schedule.arm(
+                                                pending_key,
+                                                crate::afxdp::neigh_schedule::next_due_for_pending(
+                                                    now_ns,
+                                                    now_ns,
+                                                    0,
+                                                    crate::afxdp::neighbor_dispatch::effective_pending_neigh_timeout_ns(
+                                                        worker_ctx.forwarding,
+                                                    ),
+                                                    crate::afxdp::neighbor_dispatch::PROBE_SCHEDULE_NS,
+                                                ),
+                                            );
                                             recycle_now = false;
                                         }
                                         PendingNeighAdmission::CapacityDrop => {

--- a/userspace-dp/src/afxdp/sharded_neighbor.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor.rs
@@ -103,6 +103,24 @@ impl PaddedShard {
 /// 64-shard mutex map for the dynamic neighbor cache.
 pub(crate) struct ShardedNeighborMap {
     shards: [PaddedShard; NUM_SHARDS],
+    /// #7156: monotonic count of neighbour INSERTS across all shards.
+    ///
+    /// Read by each worker's `pending_neigh` sweep to answer one question in a
+    /// single relaxed load: "could any buffered next-hop have become resolvable
+    /// since I last looked?" If not, the sweep skips the resolution walk over
+    /// every pending key -- which is where its whole O(all-keys) cost lived,
+    /// one shard MUTEX per key.
+    ///
+    /// Deliberately a COUNTER over the whole map, not a per-shard epoch. It is
+    /// read once per sweep and never keyed, so per-shard resolution would buy
+    /// nothing: a worker cannot know which shard a pending key hashes to
+    /// without walking its keys, which is the walk being avoided.
+    ///
+    /// Distinct from the per-shard `mac_change_epoch` above, which fires only
+    /// when an EXISTING neighbour's hwaddr is replaced. That is the wrong
+    /// signal here: a pending key is waiting for its neighbour to APPEAR, and
+    /// a first insert changes no existing hwaddr, so it bumps no epoch.
+    insert_generation: AtomicU64,
     /// #5147: PER-SHARD monotonic MAC-change epochs. Bumped ONLY when a
     /// kernel ARP/NDP update REPLACES an existing neighbor's hwaddr with a
     /// different MAC (gateway VRRP failover, host NIC swap, upstream MAC
@@ -172,6 +190,7 @@ impl ShardedNeighborMap {
             shards: std::array::from_fn(|_| PaddedShard::new()),
             shard_mac_epochs: std::array::from_fn(|_| AtomicU32::new(0)),
             learn_cap_drops: AtomicU64::new(0),
+            insert_generation: AtomicU64::new(0),
         }
     }
 
@@ -278,8 +297,18 @@ impl ShardedNeighborMap {
     }
 
     /// Insert (or overwrite) `key → val`. Unit-returning.
+    /// #7156: read the map-wide insert generation. One relaxed load; see the
+    /// field for why the pending-neigh sweep gates its resolution walk on it.
+    #[inline]
+    pub(crate) fn insert_generation(&self) -> u64 {
+        self.insert_generation.load(Ordering::Acquire)
+    }
+
     pub(crate) fn insert(&self, key: (i32, IpAddr), val: NeighborEntry) {
         self.lock_shard(shard_idx(&key)).insert(key, val);
+        // #7156: AFTER the map write, Release-ordered — a worker that observes
+        // this generation is guaranteed to see the entry it announces.
+        self.insert_generation.fetch_add(1, Ordering::Release);
     }
 
     /// Remove `key` if present. Unit-returning.
@@ -332,6 +361,9 @@ impl ShardedNeighborMap {
             self.bump_shard_epoch(idx);
         }
         shard.insert(key, val);
+        // #7156: AFTER the map write, Release-ordered — a worker that observes
+        // this generation is guaranteed to see the entry it announces.
+        self.insert_generation.fetch_add(1, Ordering::Release);
         true
     }
 
@@ -375,6 +407,9 @@ impl ShardedNeighborMap {
             self.bump_shard_epoch(idx);
         }
         shard.insert(key, val);
+        // #7156: AFTER the map write, Release-ordered — a worker that observes
+        // this generation is guaranteed to see the entry it announces.
+        self.insert_generation.fetch_add(1, Ordering::Release);
         true
     }
 

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -151,6 +151,21 @@ pub(crate) struct BindingWorker {
     /// cross-core sync; lazy allocation.
     pub(crate) pending_neigh:
         super::types::FastMap<(i32, std::net::IpAddr), PendingNeighPacket>,
+    /// #7156: deadline-ordered arming for `pending_neigh`. The map above stays
+    /// authoritative for packet state; this only decides WHEN each key is next
+    /// looked at, so a sweep with nothing due costs one heap peek instead of a
+    /// walk of every unresolved key. Exactly one entry per live map key --
+    /// see `neigh_schedule`'s header for why no tombstone can arise.
+    pub(crate) pending_neigh_schedule: crate::afxdp::neigh_schedule::PendingNeighSchedule,
+    /// #7156: last `ShardedNeighborMap::insert_generation` this worker acted on.
+    /// When it still matches, no neighbour has been inserted since the last
+    /// sweep, so no buffered key can have become resolvable and the sweep skips
+    /// the walk over every pending key entirely.
+    pub(crate) last_neigh_generation: (u64, usize),
+    /// #7156: reused key scratch for the resolution walk, so the walk that does
+    /// happen still allocates nothing steady-state (the old sweep built a fresh
+    /// Vec of every key on EVERY sweep — ~98 KiB per sweep at the cap).
+    pub(crate) pending_neigh_scan: Vec<(i32, std::net::IpAddr)>,
     /// #1651 B3: dead-host negative neighbor cache. Key
     /// `(egress_ifindex, next_hop)`; value = insertion `now_ns`. A dst is
     /// recorded when it times out in `pending_neigh` without resolving;
@@ -579,6 +594,9 @@ impl BindingWorker {
             // idle. Start at 0 capacity and let VecDeque grow on push as
             // packets actually queue up.
             pending_neigh: super::types::FastMap::default(),
+            pending_neigh_schedule: Default::default(),
+            last_neigh_generation: (0, 0),
+            pending_neigh_scan: Vec::new(),
             // #1651 B3: lazy-grow (empty until first dead-host drop).
             neg_neigh_cache: super::neg_neigh::NegNeighCache::default(),
             resolver_enqueue_throttle: super::types::FastMap::default(),
@@ -724,6 +742,9 @@ impl BindingWorker {
                 scratch_rst_teardowns: Vec::with_capacity(16),
             },
             pending_neigh: super::types::FastMap::default(),
+            pending_neigh_schedule: Default::default(),
+            last_neigh_generation: (0, 0),
+            pending_neigh_scan: Vec::new(),
             // #1651 B3: lazy-grow (empty until first dead-host drop).
             neg_neigh_cache: super::neg_neigh::NegNeighCache::default(),
             resolver_enqueue_throttle: super::types::FastMap::default(),
@@ -848,6 +869,9 @@ impl BindingWorker {
                 scratch_rst_teardowns: Vec::with_capacity(16),
             },
             pending_neigh: super::types::FastMap::default(),
+            pending_neigh_schedule: Default::default(),
+            last_neigh_generation: (0, 0),
+            pending_neigh_scan: Vec::new(),
             // #1651 B3: lazy-grow (empty until first dead-host drop).
             neg_neigh_cache: super::neg_neigh::NegNeighCache::default(),
             resolver_enqueue_throttle: super::types::FastMap::default(),


### PR DESCRIPTION
## Measured before optimising

`retry_pending_neigh` snapshotted **every** unresolved next-hop into a fresh
`Vec` and walked all of them, the only bound an empty-map early-out — and it runs
**twice per poll iteration**. Release build, keys unresolved and not due:

| pending keys | ns/sweep | ns/key | Vec bytes/sweep |
|--------------|----------|--------|-----------------|
| 0            | 8        | —      | 0               |
| 64           | 2 673    | 41.8   | 1 536           |
| 1 024        | 40 709   | 39.8   | 24 576          |
| 4 096 (cap)  | 182 207  | 44.5   | 98 304          |

A healthy binding holds **zero** pending keys and pays 8 ns — which is why this
never showed up in profiling, and why it needed measuring rather than assuming.
At the `MAX_PENDING_NEIGH` cap it is **~364 µs and ~196 KiB per poll iteration**:
a worker core spent on hops whose packets are already being dropped and
negatively cached, reachable by scanning distinct unresolved next-hops. So: a
genuinely hot path, not a bound-and-comment case.

The per-key cost is dominated by `ShardedNeighborMap::get`, which takes a **shard
mutex** — this was O(all-keys) *lock acquisitions* contending with the resolver
thread that writes those shards, the #1187 constraint arriving through another
door.

**After:** ~20 ns with nothing due, flat in the pending population, zero
allocation, and at most `PENDING_NEIGH_SWEEP_BUDGET` (64) keys serviced per
sweep where the old sweep visited all 4096.

## The finding: a deadline queue alone is wrong, and the suite proved it

Two existing tests went red: a resolved neighbour was no longer dispatched on the
next sweep. That is **not** a fixture artifact. A key has nothing scheduled
between its last probe (queued + 260 ms) and its timeout (800 ms–2 s), so a
neighbour resolving at 300 ms goes unnoticed until the packet is **DROPPED as
never-resolved** — a correctness regression, not a latency one.

So `ShardedNeighborMap` now carries an insert generation, and a sweep that
observes it change walks every pending key on that sweep. The asymmetry is the
point: **filling the pending cap resolves nothing, so the attack triggers no
walks at all**, while a legitimate resolution keeps exactly the latency it had.
Both tests then passed **unmodified** — behaviour restored, not assertions
weakened.

The static `forwarding.neighbors` map is rebuilt on commit and has no counter to
bump, so its length is the second half of the signature. A same-size static
replacement is the one edit that misses; the 50 ms recheck backstops it against a
800 ms–2 s timeout. Stated at the site rather than papered over — the dynamic
path, the one on the packet-latency critical path, is exact.

## No tombstones, by a property of the buffer

There is one production insert site; a duplicate for a pending key is
`DuplicateDrop`ped rather than replacing the representative; and both removals
happen on a key the sweep has just **popped**. So each live key has exactly one
heap entry and no tombstone can arise. The one exception is a removal during a
resolution pass (which does not pop); those are discarded when their own deadline
comes up, bounded by the key's timeout.

## Mutation matrix

Full suite, no `-run` filter, `--test-threads=1`.

| cell | edit | verdict | reds |
|------|------|---------|------|
| control | none | GREEN 4849 | — |
| m1 | `resolution_pass = true` (the pre-fix unbounded walk) | RED | nothing-due + budget cells |
| m2 | `resolution_pass = false` (deadline only, no gate) | RED | resolution cell + the 2 pre-existing guards |
| m3 | drop the `.max(now+1)` fairness clamp | RED | at-most-once-per-sweep cell |
| m4 | re-arm during a resolution pass too (duplicates) | RED | no-duplicate-entries cell |

**m3 and m4 were GREEN on the first run**, and neither was visible from the tests
I had already written:

- the starvation cell **cannot** reach the clamp — every key in it is past its
  timeout and is *removed* on visit, so nothing re-arms;
- nothing drove a resolution pass over *surviving* keys, the only shape that
  duplicates.

Cells were written for both rather than the mutations excused.

The first nothing-due cell was also **vacuous**: with nothing due, a full walk
finds nothing to do and leaves identical state, so removals and recycles cannot
distinguish it from no walk at all. That is why `pending_neigh_visits` exists — a
production counter (and the budget-exhaustion telemetry the issue asks for), not
a test-only seam.

## Layout guards

The counter moved `BindingLiveState` (size 2304 → 2368, offsets 2168 → 2176 and
2296 → 2304), tripping the compile-time asserts **and** their runtime twin in
`tests/tx_inbox.rs`. Re-measured in lockstep per the #6664/#7054 precedent, and
verified the way those notes require: **both** build configurations green on
**one** set of literals, which a `#[cfg(test)]` field could not achieve.

## Modularity

`neighbor_dispatch.rs` was 1493 LOC — seven lines under the [WATCH] floor, so the
gate fired exactly as the issue predicted. The deadline queue went in its own
module and the dispatch test suite was extracted to
`neighbor_dispatch_mirror_tests.rs` (`#[path]`, so `super::` and every import is
unchanged by the move). The sweep is now 1136 LOC; gate green.

## Not done

The optional #1769 §2.3 exponential GET backoff listed as adjacent-optional on
the issue — out of scope for a change already touching the sweep, the neighbour
map layout and the module split.

Docs: `docs/userspace-cold-start-resolution.md` note 4 said checking the buffer
every poll is critical for cold start and gave no cost — now carries the
measurement and the distinction between *checking* and *walking*. Reasoning in
`docs/log/7156.md`.

Closes #7156