### PR TITLE
cluster: reject a truncated session-sync record instead of installing it

### DIFF
--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -293,6 +293,52 @@ deterministic side initiates per fabric. `TCP_NODELAY` is enabled.
 [8:12]  Payload length (uint32, little-endian)
 ```
 
+### Decode Contract: which short reads are legitimate (#7175)
+
+A session payload may legitimately be SHORT — that is how the wire is extended.
+Every field appended since the original format is length-gated, so a newer peer's
+record decodes on an older node, which stops after the last field it knows:
+`Generation` (#2170), `AppTimeout`/`PolicyCounterIdx` (#3301), `ConfigEpoch`
+(#5274), `RTFlowSessionID` (#5212), `IngressIfaceFold` (#7095). An absent
+extension reads as 0, meaning "legacy peer", and that is not an error.
+
+**But a short read is only legitimate PAST the forwarding-semantic block.**
+`SessionID`, `PolicyID`, both zone ids and the NAT fields are not extensions —
+no encoder version has ever omitted them — so a payload that stops before them
+is malformed, not old. Before #7175 the decoder accepted one anyway, returning
+`ok=true` with every one of those fields left at **zero**.
+
+Zero is not "missing" here, it is a *value the standby forwards against*, and
+zone id 0 against zone id 0 is matched by a `from-zone any to-zone any permit`
+rule with no zone guard (#6682). So a truncated frame did not degrade to "no
+session" — it seeded one that a wildcard rule affirmatively permits, carrying no
+NAT and no policy attribution, which became live forwarding state on the next
+failover. The precondition is a malformed frame no legitimate encoder emits
+(fabric corruption, a version-skewed or buggy peer, a compromised peer), which is
+narrow — and is exactly the case where fail-open decoding is worst, because the
+receiving node has no other check.
+
+`decodeSessionV4Payload` / `decodeSessionV6Payload` now return `ok=false` for a
+payload truncated before that block; v6 has TWO such blocks because its 16-byte
+NAT addresses are carried separately. Everything from the counters block onward
+remains length-gated. Rejections increment `SyncStats.MalformedRecordsDropped`
+and log — a silently skipped install is how corruption hides.
+
+The same contract applies to the DHCP full-set push
+(`decodeDHCPLeasePayload`), which returns an `ok` flag. It matters more there
+than it looks: a full-set push **replaces** the peer lease set, so returning a
+truncated prefix deletes every lease past the cut on the standby. Two cases are
+distinguished deliberately:
+
+| frame | disposition | why |
+|---|---|---|
+| a record CUT mid-stream (declared length overruns the buffer) | **reject**, retain prior set | part of a lease is gone |
+| count over-declared, every shipped record whole | accept | no data lost, only the count is wrong |
+| trailing bytes after the last record | accept | the #5073 full-set seq trailer is appended exactly so old decoders ignore it |
+
+The retain-prior-set disposition mirrors the stale-sequence guard in the same
+switch ("standby retains newer set").
+
 ### Message Types
 
 | Type | Name | Direction | Purpose |

--- a/pkg/cluster/fullset_seq_test.go
+++ b/pkg/cluster/fullset_seq_test.go
@@ -61,7 +61,10 @@ func TestFullSetSeqDHCPTrailerIgnoredByOldDecoder(t *testing.T) {
 	stamped := appendFullSetSeq(encodeDHCPLeasePayload(leases), 999, 7)
 	// An OLD receiver calls decodeDHCPLeasePayload on the WHOLE frame (it does
 	// not know to strip a trailer). It must still recover exactly the 2 leases.
-	got := decodeDHCPLeasePayload(stamped)
+	got, okDecode := decodeDHCPLeasePayload(stamped)
+	if !okDecode {
+		t.Fatal("a well-formed stamped frame must decode completely (#7175)")
+	}
 	if len(got) != 2 {
 		t.Fatalf("old decoder on stamped DHCP frame: got %d leases, want 2 (trailer must be ignored)", len(got))
 	}
@@ -383,7 +386,7 @@ func TestFullSetSeqDHCPBaseEndingInMagicSafe(t *testing.T) {
 	if !bytes.Equal(gotBase, base) {
 		t.Fatalf("DHCP base must round-trip byte-exact through one stamp/strip; got %d bytes want %d", len(gotBase), len(base))
 	}
-	if got := decodeDHCPLeasePayload(gotBase); len(got) != 1 || got[0].Address != "10.0.0.5" {
+	if got, ok := decodeDHCPLeasePayload(gotBase); !ok || len(got) != 1 || got[0].Address != "10.0.0.5" {
 		t.Fatalf("recovered base must decode to the original lease set, got %+v", got)
 	}
 

--- a/pkg/cluster/lease_sync_wire_test.go
+++ b/pkg/cluster/lease_sync_wire_test.go
@@ -81,7 +81,10 @@ func TestDHCPLeaseEncode_OversizedFieldFailsClosed(t *testing.T) {
 		ValidLife: 7200, Remaining: 6000, Hostname: "host-2", FQDNRev: true,
 	}
 	payload := encodeDHCPLeasePayload([]dhcpserver.SyncLease{normal1, oversized, normal2})
-	out := decodeDHCPLeasePayload(payload)
+	out, okDecode := decodeDHCPLeasePayload(payload)
+	if !okDecode {
+		t.Fatalf("decodeDHCPLeasePayload reported an incomplete decode (#7175)")
+	}
 	if len(out) != 2 {
 		t.Fatalf("payload decoded %d leases, want 2 (the oversized lease must be dropped, "+
 			"not emitted misframed): %+v", len(out), out)
@@ -118,7 +121,10 @@ func TestDHCPLeasePayload_RoundTrip(t *testing.T) {
 		},
 	}
 	payload := encodeDHCPLeasePayload(in)
-	out := decodeDHCPLeasePayload(payload)
+	out, okDecode := decodeDHCPLeasePayload(payload)
+	if !okDecode {
+		t.Fatalf("decodeDHCPLeasePayload reported an incomplete decode (#7175)")
+	}
 	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("round-trip mismatch:\n in=%+v\nout=%+v", in, out)
 	}
@@ -131,7 +137,10 @@ func TestDHCPLeasePayload_Empty(t *testing.T) {
 	if len(payload) != 4 {
 		t.Fatalf("empty payload len = %d, want 4", len(payload))
 	}
-	out := decodeDHCPLeasePayload(payload)
+	out, okDecode := decodeDHCPLeasePayload(payload)
+	if !okDecode {
+		t.Fatalf("decodeDHCPLeasePayload reported an incomplete decode (#7175)")
+	}
 	if len(out) != 0 {
 		t.Fatalf("decoded empty payload to %d leases", len(out))
 	}
@@ -193,7 +202,10 @@ func TestDHCPLeasePayload_TruncatedStream(t *testing.T) {
 	// Lie about the count to 5 but only ship the real 2 records: the decoder
 	// must stop at the end of the buffer, returning the 2 complete records.
 	binary.LittleEndian.PutUint32(payload[:4], 5)
-	out := decodeDHCPLeasePayload(payload)
+	out, okDecode := decodeDHCPLeasePayload(payload)
+	if !okDecode {
+		t.Fatalf("decodeDHCPLeasePayload reported an incomplete decode (#7175)")
+	}
 	if len(out) != 2 {
 		t.Fatalf("over-counted truncated stream decoded %d, want 2", len(out))
 	}
@@ -296,7 +308,11 @@ func TestDHCPLeasePayload_HugeCountDoesNotOverAllocate(t *testing.T) {
 	}()
 	payload := make([]byte, 4)
 	binary.LittleEndian.PutUint32(payload, 0xFFFFFFFF)
-	out := decodeDHCPLeasePayload(payload)
+	out, okDecode := decodeDHCPLeasePayload(payload)
+	if okDecode {
+		t.Error("#7175: a count exceeding what the payload can hold must be reported " +
+			"as malformed, not silently clamped to a short valid set")
+	}
 	if len(out) != 0 {
 		t.Errorf("huge-count empty-body frame: got %d leases, want 0", len(out))
 	}
@@ -332,7 +348,10 @@ func TestDHCPLease_PreferredRemaining_RoundTrip(t *testing.T) {
 			ValidLife: 3600, Remaining: 3000, PreferredRemaining: 3000,
 		},
 	}
-	out := decodeDHCPLeasePayload(encodeDHCPLeasePayload(in))
+	out, okDecode := decodeDHCPLeasePayload(encodeDHCPLeasePayload(in))
+	if !okDecode {
+		t.Fatalf("decodeDHCPLeasePayload reported an incomplete decode (#7175)")
+	}
 	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("PreferredRemaining round-trip mismatch:\n in=%+v\nout=%+v", in, out)
 	}
@@ -403,7 +422,10 @@ func TestDHCPLease_FramingSkipsNewerLongerRecord(t *testing.T) {
 		HWAddress: "aa:bb", ValidLife: 600, Remaining: 500, PreferredRemaining: 500,
 		Hostname: "second",
 	}
-	out := decodeDHCPLeasePayload(encodeDHCPLeasePayload([]dhcpserver.SyncLease{first, second}))
+	out, okDecode := decodeDHCPLeasePayload(encodeDHCPLeasePayload([]dhcpserver.SyncLease{first, second}))
+	if !okDecode {
+		t.Fatalf("decodeDHCPLeasePayload reported an incomplete decode (#7175)")
+	}
 	if len(out) != 2 {
 		t.Fatalf("got %d leases, want 2 (recLen framing must step past the longer first record)", len(out))
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -215,14 +215,24 @@ const syncPeerSilenceTimeout = 30 * time.Second
 
 // SyncStats tracks session synchronization statistics.
 type SyncStats struct {
-	SessionsSent      atomic.Uint64
-	SessionsReceived  atomic.Uint64
-	SessionsInstalled atomic.Uint64
-	DeletesSent       atomic.Uint64
-	DeletesReceived   atomic.Uint64
-	BulkSyncs         atomic.Uint64
-	ConfigsSent       atomic.Uint64
-	ConfigsReceived   atomic.Uint64
+	SessionsSent     atomic.Uint64
+	SessionsReceived atomic.Uint64
+	// MalformedRecordsDropped counts sync records REJECTED by the #7175 decode
+	// contract: a session record truncated before its policy/zone/NAT block, or
+	// a DHCP full-set push that did not decode completely. Before #7175 these
+	// decoded ok=true and installed partial state — a session with PolicyID 0
+	// and zone ids (0,0), which a `from-zone any to-zone any permit` rule
+	// matches with no zone guard (#6682), or a lease set silently truncated to
+	// a prefix. The rejection is now countable because the failure mode it
+	// replaces was invisible: nothing distinguished a corrupt frame from a
+	// legitimately small one.
+	MalformedRecordsDropped atomic.Uint64
+	SessionsInstalled       atomic.Uint64
+	DeletesSent             atomic.Uint64
+	DeletesReceived         atomic.Uint64
+	BulkSyncs               atomic.Uint64
+	ConfigsSent             atomic.Uint64
+	ConfigsReceived         atomic.Uint64
 	// ConfigsStaleIgnored counts config-sync messages dropped by the #3931
 	// config-generation ordering guard: an incoming config whose monotonic
 	// generation was NOT strictly newer than the last-applied one (an

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -107,7 +107,16 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 			}
 		}
 		if s.sessions != nil {
-			if key, val, ok := decodeSessionV4Payload(payload); ok {
+			key, val, ok := decodeSessionV4Payload(payload)
+			if !ok {
+				// #7175: a truncated record used to decode ok=true with PolicyID,
+				// both zone ids and the NAT fields left at zero. It is now
+				// rejected — and counted, because a silently skipped install is
+				// how fabric corruption or a version-skewed peer hides.
+				s.stats.MalformedRecordsDropped.Add(1)
+				slog.Warn("cluster sync: dropping malformed v4 session record — no session installed",
+					"bytes", len(payload))
+			} else {
 				if val.IsReverse == 0 {
 					s.bulkMu.Lock()
 					if s.bulkInProgress {
@@ -133,7 +142,16 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 			}
 		}
 		if s.sessions != nil {
-			if key, val, ok := decodeSessionV6Payload(payload); ok {
+			key, val, ok := decodeSessionV6Payload(payload)
+			if !ok {
+				// #7175: a truncated record used to decode ok=true with PolicyID,
+				// both zone ids and the NAT fields left at zero. It is now
+				// rejected — and counted, because a silently skipped install is
+				// how fabric corruption or a version-skewed peer hides.
+				s.stats.MalformedRecordsDropped.Add(1)
+				slog.Warn("cluster sync: dropping malformed v6 session record — no session installed",
+					"bytes", len(payload))
+			} else {
 				if val.IsReverse == 0 {
 					s.bulkMu.Lock()
 					if s.bulkInProgress {
@@ -479,7 +497,16 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 				"incarnation", incarnation, "seq", seq)
 			return
 		}
-		leases := decodeDHCPLeasePayload(base)
+		leases, ok := decodeDHCPLeasePayload(base)
+		if !ok {
+			// #7175: a full-set push REPLACES the set, so storing a truncated
+			// prefix would delete every lease past the truncation point. Retain
+			// the prior set, exactly as the stale-sequence guard above does.
+			s.stats.MalformedRecordsDropped.Add(1)
+			slog.Warn("cluster sync: dropping malformed DHCP v4 lease set — standby retains previous set",
+				"incarnation", incarnation, "seq", seq, "bytes", len(base))
+			return
+		}
 		s.storePeerDHCPLeases(4, leases)
 		slog.Debug("cluster sync: received DHCP v4 lease set", "count", len(leases), "incarnation", incarnation, "seq", seq)
 		if s.OnDHCPLeasesReceived != nil {
@@ -497,7 +524,16 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 				"incarnation", incarnation, "seq", seq)
 			return
 		}
-		leases := decodeDHCPLeasePayload(base)
+		leases, ok := decodeDHCPLeasePayload(base)
+		if !ok {
+			// #7175: a full-set push REPLACES the set, so storing a truncated
+			// prefix would delete every lease past the truncation point. Retain
+			// the prior set, exactly as the stale-sequence guard above does.
+			s.stats.MalformedRecordsDropped.Add(1)
+			slog.Warn("cluster sync: dropping malformed DHCP v6 lease set — standby retains previous set",
+				"incarnation", incarnation, "seq", seq, "bytes", len(base))
+			return
+		}
 		s.storePeerDHCPLeases(6, leases)
 		slog.Debug("cluster sync: received DHCP v6 lease set", "count", len(leases), "incarnation", incarnation, "seq", seq)
 		if s.OnDHCPLeasesReceived != nil {

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -422,8 +422,19 @@ func decodeSessionV4Payload(payload []byte) (dataplane.SessionKey, dataplane.Ses
 	off++
 	val.IsReverse = payload[off]
 	off += 5
+	// #7175: a payload that stops here is MALFORMED, not a legacy peer. This
+	// block carries SessionID, PolicyID, both zone ids and all four NAT fields
+	// — the values the session MEANS — and no encoder version has ever omitted
+	// them (every length-gated extension sits after the counters block; see
+	// encodeSessionV4Payload). Accepting a short read here returned ok=true with
+	// all of them left at ZERO, and zero is not "missing": zone id 0 against
+	// zone id 0 is matched by a `from-zone any to-zone any permit` rule with no
+	// zone guard (#6682). So a truncated frame did not degrade to "no session" —
+	// it seeded one a wildcard rule affirmatively permits, carrying no NAT and
+	// no policy attribution, which became live forwarding state on the next
+	// failover.
 	if off+48 > len(payload) {
-		return key, val, true
+		return key, val, false
 	}
 	val.SessionID = binary.LittleEndian.Uint64(payload[off:])
 	off += 8
@@ -557,8 +568,11 @@ func decodeSessionV6Payload(payload []byte) (dataplane.SessionKeyV6, dataplane.S
 	off++
 	val.IsReverse = payload[off]
 	off += 5
+	// #7175: mandatory — see decodeSessionV4Payload for the reasoning. SessionID,
+	// PolicyID and both zone ids; a short read here zeroed every one of them and
+	// still reported success.
 	if off+48 > len(payload) {
-		return key, val, true
+		return key, val, false
 	}
 	val.SessionID = binary.LittleEndian.Uint64(payload[off:])
 	off += 8
@@ -574,8 +588,12 @@ func decodeSessionV6Payload(payload []byte) (dataplane.SessionKeyV6, dataplane.S
 	off += 2
 	val.EgressZone = binary.LittleEndian.Uint16(payload[off:])
 	off += 2
+	// #7175: mandatory. v6 gives NAT its own block because the addresses are 16
+	// bytes; it is the same forwarding-semantic data the v4 48-byte block carries
+	// inline, so it gets the same treatment. A short read here left the session
+	// with no NAT translation while reporting success.
 	if off+36 > len(payload) {
-		return key, val, true
+		return key, val, false
 	}
 	copy(val.NATSrcIP[:], payload[off:off+16])
 	off += 16
@@ -1087,12 +1105,19 @@ func encodeDHCPLeasePayload(leases []dhcpserver.SyncLease) []byte {
 // decodeDHCPLeasePayload parses a full-set lease push. A truncated payload
 // stops decoding at the last complete record (fail-safe: a partial message
 // yields the leases that fully arrived rather than erroring the whole push).
-func decodeDHCPLeasePayload(payload []byte) []dhcpserver.SyncLease {
+// #7175 (C179-075): the bool reports whether the payload decoded COMPLETELY.
+// A full-set push REPLACES the peer lease set, so returning a truncated prefix
+// silently deleted every lease past the truncation point on the standby. The
+// caller must retain its prior set when this is false rather than storing a
+// partial one — the same disposition the stale-sequence guard already applies
+// one branch above ("standby retains newer set").
+func decodeDHCPLeasePayload(payload []byte) ([]dhcpserver.SyncLease, bool) {
 	if len(payload) < 4 {
-		return nil
+		return nil, false
 	}
 	count := int(binary.LittleEndian.Uint32(payload[:4]))
 	off := 4
+	malformed := false
 	// Clamp the preallocation to what the payload can physically hold: count
 	// is untrusted on-wire data, and each record consumes at least its 4-byte
 	// length prefix, so there can be at most len(payload)/4 records. Without
@@ -1100,21 +1125,42 @@ func decodeDHCPLeasePayload(payload []byte) []dhcpserver.SyncLease {
 	// a ~hundreds-of-GB make() (SyncLease is ~160 bytes) and panic before the
 	// loop's truncation guard fires. Valid payloads are unaffected (a real
 	// count is always <= len(payload)/4). Clamping count also bounds the loop.
+	// #7175: a count exceeding what the payload can physically hold is not a
+	// short valid set — no encoder produces it. The clamp still bounds the
+	// allocation, and the frame is now reported as malformed rather than
+	// silently reduced to whatever fit.
 	if maxRecords := len(payload) / 4; count > maxRecords {
 		count = maxRecords
+		malformed = true
 	}
 	out := make([]dhcpserver.SyncLease, 0, count)
 	for i := 0; i < count; i++ {
 		if off+4 > len(payload) {
+			// The buffer ended while the count still expected records. Every
+			// record that DID arrive is whole — only the sender's count was
+			// wrong — so this stays recoverable, which is the contract
+			// TestDHCPLeasePayload_TruncatedStream pins. Deliberately NOT
+			// promoted to malformed: nothing was lost mid-record.
 			break
 		}
 		recLen := int(binary.LittleEndian.Uint32(payload[off:]))
 		off += 4
 		if recLen < 0 || off+recLen > len(payload) {
+			// A record is CUT: its declared length runs past the buffer, so
+			// part of a lease is gone. This is the C179-075 case — the full-set
+			// push REPLACES the peer set, so returning the prefix would delete
+			// every lease after the cut on the standby.
+			malformed = true
 			break
 		}
 		out = append(out, decodeOneLease(payload[off:off+recLen]))
 		off += recLen
 	}
-	return out
+	// NOTE: trailing bytes after the last record are NOT malformed. The #5073
+	// full-set seq trailer is appended exactly so an old decoder walks its
+	// records and ignores the remainder (TestFullSetSeqDHCPTrailerIgnoredByOldDecoder).
+	if malformed {
+		return nil, false
+	}
+	return out, true
 }

--- a/pkg/cluster/sync_truncated_record_7175_test.go
+++ b/pkg/cluster/sync_truncated_record_7175_test.go
@@ -1,0 +1,197 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/dhcpserver"
+)
+
+// #7175: a truncated-but-framed session-sync record must not decode ok=true
+// with its policy/zone/NAT fields left at zero.
+//
+// WHY ZERO IS NOT "MISSING". A zeroed PolicyID and zone ids are not absent
+// values, they are VALUES the standby forwards against, and zone id 0 against
+// zone id 0 is matched by a `from-zone any to-zone any permit` rule with no zone
+// guard (#6682). So the pre-fix behaviour did not degrade a truncated frame to
+// "no session" — it seeded one that a wildcard rule affirmatively permits,
+// carrying no NAT and no policy attribution, which became live forwarding state
+// on the next failover.
+//
+// WHY A FULL PREFIX SWEEP RATHER THAN A FEW BOUNDARY CASES. The property is not
+// "these particular lengths are rejected", it is "no accepted length yields
+// zeroed forwarding fields". Sweeping every prefix and asserting the INVARIANT
+// at each one covers the interiors of blocks as well as their boundaries, and it
+// keeps holding if a future field moves a boundary — a boundary-listing test
+// would silently stop covering the interior it was written for.
+//
+// WHAT IS DELIBERATELY STILL TOLERATED. Everything from the counters block
+// onward stays length-gated, because those are genuine append-only wire
+// extensions that older peers legitimately omit (#2170 Generation, #3301
+// AppTimeout/PolicyCounterIdx, #5274 ConfigEpoch, #5212 RTFlowSessionID, #7095
+// IngressIfaceFold). TestCrossVersionShortPayloadDecode and the #7095 truncation
+// case pin that tolerance and must keep passing: the fix draws the line at
+// forwarding semantics, not at "any short read".
+
+func fullV4Record(t *testing.T) (dataplane.SessionKey, dataplane.SessionValue, []byte) {
+	t.Helper()
+	// Every field the assertion reads is NON-ZERO and distinct, so a decode that
+	// silently substitutes a zero is caught. A fixture using the value the bug
+	// falls back to would go green against the very defect it is written for.
+	key := dataplane.SessionKey{
+		SrcIP: [4]byte{10, 1, 2, 3}, DstIP: [4]byte{10, 4, 5, 6},
+		SrcPort: 1111, DstPort: 2222, Protocol: 6,
+	}
+	val := dataplane.SessionValue{
+		State: dataplane.SessStateEstablished,
+		// The forwarding-semantic block that truncation used to zero.
+		SessionID: 0x1122334455667788, PolicyID: 0xABCD,
+		IngressZone: 0x0101, EgressZone: 0x0202,
+		NATSrcIP: 0x0A0B0C0D, NATDstIP: 0x0E0F1011,
+		NATSrcPort: 3333, NATDstPort: 4444,
+	}
+	return key, val, encodeSessionV4Payload(key, val)
+}
+
+func TestTruncatedV4RecordNeverDecodesWithZeroedForwardingFields7175(t *testing.T) {
+	_, val, full := fullV4Record(t)
+
+	accepted := 0
+	for n := 0; n <= len(full); n++ {
+		_, got, ok := decodeSessionV4Payload(full[:n])
+		if !ok {
+			continue
+		}
+		accepted++
+		// The invariant: anything ACCEPTED must carry the real forwarding
+		// fields, never the zero the truncation used to substitute.
+		if got.PolicyID != val.PolicyID {
+			t.Fatalf("prefix of %d bytes decoded ok=true with PolicyID=%d, want %d — a truncated "+
+				"record must not be accepted with a zeroed policy id (#7175)", n, got.PolicyID, val.PolicyID)
+		}
+		if got.IngressZone != val.IngressZone || got.EgressZone != val.EgressZone {
+			t.Fatalf("prefix of %d bytes decoded ok=true with zones (%d,%d), want (%d,%d) — zone id 0 "+
+				"is matched by a from-zone any to-zone any permit rule with no zone guard (#6682)",
+				n, got.IngressZone, got.EgressZone, val.IngressZone, val.EgressZone)
+		}
+		if got.NATSrcIP != val.NATSrcIP || got.NATDstIP != val.NATDstIP ||
+			got.NATSrcPort != val.NATSrcPort || got.NATDstPort != val.NATDstPort {
+			t.Fatalf("prefix of %d bytes decoded ok=true with NAT (%d,%d,%d,%d), want (%d,%d,%d,%d) — "+
+				"a session installed with no translation misforwards (#7175)",
+				n, got.NATSrcIP, got.NATDstIP, got.NATSrcPort, got.NATDstPort,
+				val.NATSrcIP, val.NATDstIP, val.NATSrcPort, val.NATDstPort)
+		}
+	}
+	// Negative control. Without it "no accepted prefix violated the invariant"
+	// is also what a decoder that rejects EVERYTHING reports — including the
+	// complete record, which would break session sync entirely while this test
+	// stayed green.
+	if accepted == 0 {
+		t.Fatal("no prefix decoded at all, so the sweep above asserted nothing: a decoder that " +
+			"rejects every input would pass it. The complete record must still decode")
+	}
+	t.Logf("%d of %d prefix lengths accepted, all carrying intact forwarding fields", accepted, len(full)+1)
+}
+
+// The complete record must round-trip unchanged — the other half of the control:
+// the fix must reject partial state without disturbing the valid path.
+func TestCompleteV4RecordStillRoundTrips7175(t *testing.T) {
+	key, val, full := fullV4Record(t)
+	gotKey, got, ok := decodeSessionV4Payload(full)
+	if !ok {
+		t.Fatal("the complete record must decode")
+	}
+	if gotKey != key {
+		t.Errorf("key round-trip: got %+v want %+v", gotKey, key)
+	}
+	if got.PolicyID != val.PolicyID || got.IngressZone != val.IngressZone ||
+		got.EgressZone != val.EgressZone || got.SessionID != val.SessionID {
+		t.Errorf("forwarding fields round-trip: got policy=%d zones=(%d,%d) id=%d",
+			got.PolicyID, got.IngressZone, got.EgressZone, got.SessionID)
+	}
+}
+
+func TestTruncatedV6RecordNeverDecodesWithZeroedForwardingFields7175(t *testing.T) {
+	key := dataplane.SessionKeyV6{SrcPort: 1111, DstPort: 2222, Protocol: 6}
+	key.SrcIP[0], key.DstIP[0] = 0x20, 0x30
+	val := dataplane.SessionValueV6{
+		State: dataplane.SessStateEstablished,
+		// v6 splits NAT into its own block; both blocks are asserted.
+		SessionID: 0x99AABBCC, PolicyID: 0x4321,
+		IngressZone: 0x0303, EgressZone: 0x0404,
+		NATSrcPort: 5555, NATDstPort: 6666,
+	}
+	val.NATSrcIP[0], val.NATDstIP[0] = 0x40, 0x50
+	full := encodeSessionV6Payload(key, val)
+
+	accepted := 0
+	for n := 0; n <= len(full); n++ {
+		_, got, ok := decodeSessionV6Payload(full[:n])
+		if !ok {
+			continue
+		}
+		accepted++
+		if got.PolicyID != val.PolicyID || got.IngressZone != val.IngressZone || got.EgressZone != val.EgressZone {
+			t.Fatalf("v6 prefix of %d bytes decoded ok=true with policy=%d zones=(%d,%d) (#7175)",
+				n, got.PolicyID, got.IngressZone, got.EgressZone)
+		}
+		if got.NATSrcIP != val.NATSrcIP || got.NATDstIP != val.NATDstIP ||
+			got.NATSrcPort != val.NATSrcPort || got.NATDstPort != val.NATDstPort {
+			t.Fatalf("v6 prefix of %d bytes decoded ok=true with zeroed/incorrect NAT — v6 carries NAT "+
+				"in its own 36-byte block, which was separately fail-open (#7175)", n)
+		}
+	}
+	if accepted == 0 {
+		t.Fatal("no v6 prefix decoded at all — the sweep asserted nothing")
+	}
+}
+
+// C179-075, the sibling on the DHCP full-set path. A full-set push REPLACES the
+// peer lease set, so accepting a prefix DELETES every lease past the cut on the
+// standby.
+func TestDHCPFullSetRejectsARecordCutMidStream7175(t *testing.T) {
+	in := []dhcpserver.SyncLease{
+		{Family: 4, Address: "10.0.0.1", SubnetID: 1, Remaining: 10, ValidLife: 10},
+		{Family: 4, Address: "10.0.0.2", SubnetID: 1, Remaining: 20, ValidLife: 20},
+	}
+	full := encodeDHCPLeasePayload(in)
+
+	// Positive control FIRST: without it, a decoder that rejects everything
+	// passes the rejection cell below.
+	if out, ok := decodeDHCPLeasePayload(full); !ok || len(out) != 2 {
+		t.Fatalf("control: the complete lease set must decode (ok=%v, %d leases)", ok, len(out))
+	}
+
+	// Cut the LAST record in half. Its length prefix still claims the full
+	// length, so the frame is framed-but-truncated — the exact shape that used
+	// to return a silently shortened set.
+	cut := full[:len(full)-6]
+	out, ok := decodeDHCPLeasePayload(cut)
+	if ok {
+		t.Errorf("a lease record cut mid-stream decoded ok=true with %d of %d leases — a full-set "+
+			"push replaces the set, so the standby would silently drop the rest (C179-075)", len(out), len(in))
+	}
+	if len(out) != 0 {
+		t.Errorf("a rejected decode must yield no leases, got %d — the caller stores what it is "+
+			"handed, so a non-empty prefix here still replaces the set", len(out))
+	}
+}
+
+// The deliberately TOLERATED case, pinned so the rejection above cannot quietly
+// widen into it. An over-declared count whose records all arrived WHOLE loses no
+// data — only the sender's count was wrong — and this is the contract
+// TestDHCPLeasePayload_TruncatedStream already documents.
+func TestDHCPFullSetStillToleratesAnOverDeclaredCount7175(t *testing.T) {
+	in := []dhcpserver.SyncLease{
+		{Family: 4, Address: "10.0.0.1", SubnetID: 1, Remaining: 10, ValidLife: 10},
+		{Family: 4, Address: "10.0.0.2", SubnetID: 1, Remaining: 20, ValidLife: 20},
+	}
+	payload := encodeDHCPLeasePayload(in)
+	binary.LittleEndian.PutUint32(payload[:4], 5) // claim 5, ship 2 complete records
+	out, ok := decodeDHCPLeasePayload(payload)
+	if !ok || len(out) != 2 {
+		t.Fatalf("an over-declared count with every record whole must still decode "+
+			"(ok=%v, %d leases, want true/2). #7175 rejects data LOSS, not a wrong count", ok, len(out))
+	}
+}


### PR DESCRIPTION
`decodeSessionV4Payload` / `decodeSessionV6Payload` returned **`ok=true`** for a record that was framed correctly but truncated before its forwarding-semantic block, leaving `SessionID`, `PolicyID`, both zone ids and the NAT fields at **zero**. The partial session was then installed on the receiving node.

Measured at master: a full v4 record is **180 bytes**, and **a 24-byte prefix decoded `ok=true`** with PolicyID, both zones and SessionID all zero.

Zero is not "missing" for those fields — it is a value the standby forwards against, and zone id 0 against zone id 0 is matched by a `from-zone any to-zone any permit` rule with no zone guard (#6682). So a truncated frame did not degrade to "no session": it seeded one a wildcard rule affirmatively **permits**, with no NAT and no policy attribution, which became live forwarding state on the next failover.

## The line is drawn at forwarding semantics, not at "any short read"

This matters, because **a short read is how this wire is extended**. `Generation` (#2170), `AppTimeout`/`PolicyCounterIdx` (#3301), `ConfigEpoch` (#5274), `RTFlowSessionID` (#5212) and `IngressIfaceFold` (#7095) are all length-gated so a newer peer's record decodes on an older node.

The issue proposed *"enumerate the valid complete record lengths and require an exact match"*. **That would have rejected every legacy-peer record** — `TestCrossVersionShortPayloadDecode` (truncates 36 bytes) and the #7095 v6 case (truncates 4) both pin that tolerance, and both still pass here. Only the block no encoder has ever omitted became mandatory. v6 needed **two** sites, because its 16-byte NAT addresses sit in a separate block that was independently fail-open.

## The DHCP sibling (C179-075)

Same shape, and it matters more than it looks: a full-set push **replaces** the peer lease set, so a truncated prefix silently deleted every lease past the cut. `decodeDHCPLeasePayload` now reports completeness and the caller retains its prior set — mirroring the stale-sequence guard in the same switch (*"standby retains newer set"*).

Two cases are deliberately kept apart:

| frame | disposition | why |
|---|---|---|
| record **cut** mid-stream | reject | part of a lease is gone |
| count over-declared, records all whole | accept | no data lost, only the count is wrong |
| trailing bytes after the last record | accept | the #5073 seq trailer is appended so old decoders ignore it |

An earlier revision of this branch also rejected trailing bytes. **That broke #5073**, and `TestFullSetSeqDHCPTrailerIgnoredByOldDecoder` caught it — an existing test catching my over-reach, which is why the M6 cell below exists.

Rejections increment a new `SyncStats.MalformedRecordsDropped` and log: a silently skipped install is how corruption or a version-skewed peer hides, and nothing previously distinguished a corrupt frame from a legitimately small one.

## Tests

The sweep walks **every prefix length** rather than listing block boundaries, asserting the invariant that matters — *no accepted length may yield zeroed forwarding fields*. That covers block interiors as well as boundaries and keeps holding if a future field moves one. Both sweeps carry a control asserting at least one prefix **was** accepted; without it, a decoder that rejected everything — breaking session sync entirely — would pass them.

## Mutation matrix (998 collected in every cell, full package, unfiltered)

| cell | change | result |
|---|---|---|
| C0 | control | 998 collected, 0 failed |
| M1 | v4 forwarding block back to fail-open | **RED** — v4 sweep, `prefix of 24 bytes ... PolicyID=0` |
| M2 | v6 policy/zone block back to fail-open | **RED** — v6 sweep line 136, `policy=0 zones=(0,0)` |
| M3 | v6 NAT block back to fail-open | **RED** — v6 sweep line 141, zeroed NAT |
| M4 | DHCP cut-record back to a silent break | **RED** — `1 of 2 leases` |
| M5 | over-reach: also reject the over-declared count | **RED** ×2 — incl. the pre-existing `TestDHCPLeasePayload_TruncatedStream` |
| M6 | over-reach: reject trailing bytes | **RED** — `TestFullSetSeqDHCPTrailerIgnoredByOldDecoder` |

M5/M6 are the ones I care about most: they prove the narrowing is **guarded in both directions**, so the rejection cannot quietly widen into a case that is legitimate.

## Gate

Full Go suite: **rc=0, 69 packages, 0 FAIL**.

A first run showed one failure in `pkg/eventengine` (`TestQueue_ConcurrentProbesSerialize`). Isolated: 5/5 pass on this branch, 3/3 on clean master, **0.026s vs the 3.93s failing run** — a load-contention flake against a wall-clock bound, unrelated to `pkg/cluster`. Filed as #7931; the re-run of the full gate was clean.

Docs: `docs/session-sync-architecture.md` gains a **Decode Contract** section stating which short reads are legitimate and why, with the DHCP disposition table.

`make test-failover` is owed on this (cluster/session-sync) and is queued behind the shared-cluster lock.

Closes #7175