### PR TITLE
cli: stream the remote pipe filter instead of buffering the output

### DIFF
--- a/cmd/cli/pipe_filter_case_4968_test.go
+++ b/cmd/cli/pipe_filter_case_4968_test.go
@@ -3,12 +3,28 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/cliterm"
 )
 
-// TestApplyPipeFilterCaseSensitive pins the remote CLI pipe filter to the same
-// case-SENSITIVE semantics as the local CLI's pkg/cli.filterStream. Junos
-// `| match` never case-folds; the earlier remote implementation lowercased both
-// operands, so `| match Foo` matched `foo` on remote but not local (#4968).
+// TestApplyPipeFilterCaseSensitive pins the remote CLI pipe filter to
+// case-SENSITIVE semantics. Junos `| match` never case-folds; the earlier remote
+// implementation lowercased both operands, so `| match Foo` matched `foo` on
+// remote but not local (#4968).
+//
+// #7210 changed what this test can fail on, so read the change before trusting
+// it. The remote surface no longer has its own filter: it calls
+// cliterm.FilterStream, the same implementation pkg/cli uses. The specific
+// divergence #4968 found is therefore structurally impossible now rather than
+// merely tested against.
+//
+// The test is KEPT and pointed at the shared function rather than deleted,
+// because the property it pins — these semantics are case-sensitive — is still
+// worth a guard, and the assertions are unchanged. What it no longer proves on
+// its own is that the two surfaces AGREE; that is now carried by
+// TestRemotePipeUsesTheSharedFilter7210, which pins the delegation itself. A
+// test that outlives the structure it was written for should say which half of
+// its original claim it still carries.
 func TestApplyPipeFilterCaseSensitive(t *testing.T) {
 	lines := []string{
 		"Foo matches exactly",
@@ -52,10 +68,11 @@ func TestApplyPipeFilterCaseSensitive(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf strings.Builder
-			applyPipeFilter(lines, &buf, tc.pipeType, tc.pipeArg)
+			cliterm.FilterStream(strings.NewReader(strings.Join(lines, "\n")+"\n"),
+				&buf, tc.pipeType, tc.pipeArg)
 			got := splitNonEmptyLines(buf.String())
 			if !equalStringSlices(got, tc.want) {
-				t.Fatalf("applyPipeFilter(%q, %q) = %#v, want %#v",
+				t.Fatalf("FilterStream(%q, %q) = %#v, want %#v",
 					tc.pipeType, tc.pipeArg, got, tc.want)
 			}
 		})

--- a/cmd/cli/pipe_stream_7210_test.go
+++ b/cmd/cli/pipe_stream_7210_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/cliterm"
+)
+
+// #7210: the remote CLI's pipe filter must consume its input INCREMENTALLY.
+//
+// WHY OUTPUT CORRECTNESS CANNOT TEST THIS. A streaming filter and a
+// buffer-everything-then-filter one produce byte-identical output for every
+// finite input. So no assertion over the result distinguishes them, and the
+// property being fixed — bounded memory on huge output — is invisible to the
+// obvious test. The instrument has to be TIME: feed a reader that yields some
+// lines and then BLOCKS, and assert that filtered output appears while it is
+// still blocked. A buffering implementation emits nothing until EOF, which
+// never comes.
+
+// blockingReader yields payload, then blocks until release is closed, then EOF.
+type blockingReader struct {
+	payload []byte
+	off     int
+	release chan struct{}
+	done    bool
+}
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	if b.off < len(b.payload) {
+		n := copy(p, b.payload[b.off:])
+		b.off += n
+		return n, nil
+	}
+	if !b.done {
+		<-b.release // hold the stream open with no further data
+		b.done = true
+	}
+	return 0, io.EOF
+}
+
+// syncBuf is written by the filter goroutine and read by the test goroutine.
+type syncBuf struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func TestRemotePipeFilterStreamsBeforeEOF7210(t *testing.T) {
+	// Several matching lines up front, then the stream stalls. A buffering
+	// implementation cannot emit any of them until EOF.
+	var head strings.Builder
+	for i := 0; i < 64; i++ {
+		head.WriteString("hit line\n")
+	}
+	r := &blockingReader{payload: []byte(head.String()), release: make(chan struct{})}
+	out := &syncBuf{}
+
+	filterDone := make(chan struct{})
+	go func() {
+		cliterm.FilterStream(r, out, "match", "hit")
+		close(filterDone)
+	}()
+
+	// Poll for output while the reader is still blocked. The deadline is
+	// generous on purpose: it is a "did anything come out at all" bound, not a
+	// latency assertion, so a loaded box does not turn this into a flake.
+	deadline := time.Now().Add(10 * time.Second)
+	got := ""
+	for time.Now().Before(deadline) {
+		if got = out.String(); strings.Contains(got, "hit line") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !strings.Contains(got, "hit line") {
+		close(r.release)
+		<-filterDone
+		t.Fatal("no filtered output was produced while the input stream was still open, so the " +
+			"filter is buffering to EOF before filtering. That is the #7210 defect: a large " +
+			"`show ... | match ...` materializes the whole output in the cli process first")
+	}
+
+	// Release and confirm it terminates and produced everything.
+	close(r.release)
+	select {
+	case <-filterDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the filter did not finish after the reader reached EOF")
+	}
+	if n := strings.Count(out.String(), "hit line"); n != 64 {
+		t.Errorf("streamed output lost lines: got %d, want 64", n)
+	}
+}
+
+// Control for the cell above: the same harness against a reader that blocks
+// with NOTHING buffered must NOT produce output. Without this, "output appeared"
+// could be explained by the harness emitting something on its own, and the
+// streaming cell would pass for a reason unrelated to streaming.
+func TestRemotePipeFilterProducesNothingWithoutInput7210(t *testing.T) {
+	r := &blockingReader{payload: nil, release: make(chan struct{})}
+	out := &syncBuf{}
+	filterDone := make(chan struct{})
+	go func() {
+		cliterm.FilterStream(r, out, "match", "hit")
+		close(filterDone)
+	}()
+	time.Sleep(200 * time.Millisecond)
+	if s := out.String(); s != "" {
+		t.Errorf("control: filter emitted %q with no input available — the streaming cell's "+
+			"output would not prove streaming", s)
+	}
+	close(r.release)
+	<-filterDone
+}
+
+// Acceptance 2: `| last N` for a huge N must clamp rather than allocate from N.
+func TestRemotePipeLastClampsHugeN7210(t *testing.T) {
+	if got := cliterm.ParseLastCount("2000000000"); got != cliterm.MaxTailLines {
+		t.Errorf("| last 2000000000 parsed to %d, want the %d cap — an unclamped N is a "+
+			"~32 GiB up-front allocation from an untrusted operand (#5037)", got, cliterm.MaxTailLines)
+	}
+	// The tail itself must still be correct for a normal N.
+	var in strings.Builder
+	for i := 0; i < 100; i++ {
+		in.WriteString("line\n")
+	}
+	var out strings.Builder
+	cliterm.FilterStream(strings.NewReader(in.String()), &out, "last", "3")
+	if n := strings.Count(out.String(), "line"); n != 3 {
+		t.Errorf("| last 3 emitted %d lines, want 3", n)
+	}
+}
+
+// Binds the DELEGATION, not just the behaviour. If cmd/cli reintroduced its own
+// filter, every behavioural test above would still pass — they exercise
+// cliterm directly — so the thing that actually prevents a re-fork is that
+// dispatchWithPipe calls the shared function. That is a fact about this
+// package's source, so the source is what is asserted, via go/parser rather
+// than a textual scan (the doc comments here and on dispatchWithPipe both
+// mention the old buffering shape, which a grep would match).
+func TestRemotePipeUsesTheSharedFilter7210(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "shared.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing shared.go: %v", err)
+	}
+	var body *ast.BlockStmt
+	for _, decl := range f.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "dispatchWithPipe" {
+			body = fn.Body
+			break
+		}
+	}
+	if body == nil {
+		t.Fatal("dispatchWithPipe not found in shared.go — if it was renamed, move this test " +
+			"with it; a missing function must not read as a passing delegation check")
+	}
+
+	callsShared, readsAll := false, false
+	ast.Inspect(body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if pkg.Name == "cliterm" && sel.Sel.Name == "FilterStream" {
+			callsShared = true
+		}
+		if pkg.Name == "io" && sel.Sel.Name == "ReadAll" {
+			readsAll = true
+		}
+		return true
+	})
+
+	if !callsShared {
+		t.Error("dispatchWithPipe does not call cliterm.FilterStream. The remote CLI must not " +
+			"carry its own filter: the copy it used to have drifted into the #4968 case-folding " +
+			"divergence, where `| match Foo` matched `foo` on remote but not local")
+	}
+	if readsAll {
+		t.Error("dispatchWithPipe calls io.ReadAll — that is the #7210 defect verbatim, " +
+			"materializing the command's entire output before the filter runs")
+	}
+}

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/chzyer/readline"
+	"github.com/psaab/xpf/pkg/cliterm"
 	"github.com/psaab/xpf/pkg/cmdtree"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
@@ -137,6 +137,21 @@ func extractPipe(line string) (string, string, string, bool) {
 }
 
 // dispatchWithPipe runs the command and applies the pipe filter.
+//
+// #7210: the filter runs CONCURRENTLY with the command, reading its output from
+// r as it is produced and writing the filtered result straight to the real
+// stdout. Previously this did io.ReadAll into a []byte and then
+// strings.Split into a []string — materializing the entire output TWICE before
+// the filter ran, so `show log messages | match error` against a large syslog
+// buffer, or `show route | count` on a big table, could OOM the operator's own
+// cli process on a memory-constrained jump host. (Client-side only: the daemon
+// streams normally and was never affected.)
+//
+// The filter itself is pkg/cliterm.FilterStream, the SAME implementation the
+// in-process CLI uses. That is the other half of the fix: the remote surface
+// used to carry its own copy, and it drifted (#4968). Every filter reads to EOF
+// — which arrives when w is closed — so no early-return drain is needed to
+// unblock the writer.
 func (c *ctl) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 	origStdout := os.Stdout
 	r, w, err := os.Pipe()
@@ -145,90 +160,19 @@ func (c *ctl) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 	}
 	os.Stdout = w
 
-	outputCh := make(chan []byte, 1)
+	done := make(chan struct{})
 	go func() {
-		output, _ := io.ReadAll(r)
+		cliterm.FilterStream(r, origStdout, pipeType, pipeArg)
 		r.Close()
-		outputCh <- output
+		close(done)
 	}()
 
 	cmdErr := c.dispatch(cmd)
 	w.Close()
 	os.Stdout = origStdout
+	<-done
 
-	output := <-outputCh
-
-	lines := strings.Split(string(output), "\n")
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
-		lines = lines[:len(lines)-1]
-	}
-
-	applyPipeFilter(lines, origStdout, pipeType, pipeArg)
 	return cmdErr
-}
-
-// applyPipeFilter applies a Junos-style output filter (| match/grep/except/find/
-// count/last/no-more) to lines, writing the filtered result to out.
-//
-// match/grep/except/find are CASE-SENSITIVE, matching the local CLI's
-// pkg/cli.filterStream (which uses a bare strings.Contains(line, pipeArg)).
-// Junos `| match` never case-folds, so the remote and local surfaces must
-// agree — the earlier strings.ToLower on both operands made `| match Foo`
-// match `foo` on remote but not local, a silent semantic divergence (#4968).
-func applyPipeFilter(lines []string, out io.Writer, pipeType, pipeArg string) {
-	switch pipeType {
-	case "match", "grep":
-		for _, line := range lines {
-			if strings.Contains(line, pipeArg) {
-				fmt.Fprintln(out, line)
-			}
-		}
-	case "except":
-		for _, line := range lines {
-			if !strings.Contains(line, pipeArg) {
-				fmt.Fprintln(out, line)
-			}
-		}
-	case "find":
-		found := false
-		for _, line := range lines {
-			if !found && strings.Contains(line, pipeArg) {
-				found = true
-			}
-			if found {
-				fmt.Fprintln(out, line)
-			}
-		}
-	case "count":
-		fmt.Fprintf(out, "Count: %d lines\n", len(lines))
-	case "last":
-		// Clamp N to the same cap the local CLI enforces
-		// (pkg/cli.maxTailLines, #5037) so `| last N` behaves identically on
-		// both surfaces (#4968 local/remote harmony). This branch slices
-		// lines[start:] rather than pre-allocating from N, so it is not the
-		// OOM vector the local filterStream was — the clamp is for parity.
-		const maxTailLines = 100_000
-		n := 10
-		if pipeArg != "" {
-			if v, err := strconv.Atoi(pipeArg); err == nil && v > 0 {
-				n = v
-			}
-		}
-		if n > maxTailLines {
-			n = maxTailLines
-		}
-		start := len(lines) - n
-		if start < 0 {
-			start = 0
-		}
-		for _, line := range lines[start:] {
-			fmt.Fprintln(out, line)
-		}
-	case "no-more":
-		for _, line := range lines {
-			fmt.Fprintln(out, line)
-		}
-	}
 }
 
 func (c *ctl) dispatchOperational(line string) error {

--- a/pkg/cli/cli_dispatch.go
+++ b/pkg/cli/cli_dispatch.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +8,8 @@ import (
 	"strings"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/psaab/xpf/pkg/cliterm"
 )
 
 var errExit = fmt.Errorf("exit")
@@ -86,107 +87,32 @@ func (c *CLI) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 	return cmdErr
 }
 
-// filterStream reads newline-delimited output from src and applies a Junos-style
-// output filter, writing the result to out as each line is read. It reuses the
-// #4709 lineSource line splitting so the emitted lines are byte-identical to the
-// previous strings.Split(output, "\n")-with-trailing-empty-dropped path for any
-// input. match/except/find/no-more hold at most one line at a time; count keeps
-// only a running tally; last keeps a bounded ring buffer of the last n lines —
-// none buffers the full output (#4731).
-// maxTailLines bounds the ring the `| last N` filter retains and grows,
-// independent of the operator-supplied N (#5037). `show` is a read-only
-// (PermView) command, so without a bound a viewer could run
-// `show ... | last 2000000000` and force a ~32 GiB up-front []string
-// allocation, OOM-killing the in-process xpfd before any output is produced.
-// 100,000 lines is far more tail than any operator needs, yet caps the ring's
-// worst-case slice header at ~1.6 MiB (64-bit) plus the retained line strings.
-const maxTailLines = 100_000
-
-// parseLastCount parses the `| last N` operand. It defaults to 10, ignores a
-// non-positive or unparseable N (Junos-compatible leniency), and clamps N to
-// maxTailLines so the retained/grown ring is bounded by a fixed operator cap
-// rather than an untrusted operand (#5037).
-func parseLastCount(arg string) int {
-	n := 10
-	if arg != "" {
-		if v, err := strconv.Atoi(arg); err == nil && v > 0 {
-			n = v
-		}
-	}
-	if n > maxTailLines {
-		n = maxTailLines
-	}
-	return n
+// filterStream applies a Junos-style output filter to src, writing to out as
+// each line is read.
+//
+// #7210: the implementation now lives in pkg/cliterm and is SHARED with the
+// remote CLI client (cmd/cli). It used to live here, and the remote surface
+// carried its own copy — which drifted, producing the #4968 case-folding
+// divergence where `| match Foo` matched `foo` on remote but not local. A
+// divergence between the two surfaces is always a bug, never a legitimate
+// difference, so there is now one implementation rather than an agreement to
+// maintain between two.
+//
+// This wrapper is kept deliberately: it preserves this package's call sites and
+// keeps the #4731 / #5037 / #5069 regression tests exercising the real code path
+// rather than being decommissioned by the move.
+func filterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
+	cliterm.FilterStream(src, out, pipeType, pipeArg)
 }
 
-func filterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
-	ls := &lineSource{r: bufio.NewReader(src)}
+// maxTailLines is an ALIAS for the shared cap, not a second copy of the number.
+// Pinning the literal again here would let the two drift silently, which is the
+// failure this consolidation exists to remove.
+const maxTailLines = cliterm.MaxTailLines
 
-	switch pipeType {
-	case "match", "grep":
-		for ls.hasMore() {
-			line, _ := ls.next()
-			if strings.Contains(line, pipeArg) {
-				fmt.Fprintln(out, line)
-			}
-		}
-	case "except":
-		for ls.hasMore() {
-			line, _ := ls.next()
-			if !strings.Contains(line, pipeArg) {
-				fmt.Fprintln(out, line)
-			}
-		}
-	case "find":
-		found := false
-		for ls.hasMore() {
-			line, _ := ls.next()
-			if !found && strings.Contains(line, pipeArg) {
-				found = true
-			}
-			if found {
-				fmt.Fprintln(out, line)
-			}
-		}
-	case "count":
-		count := 0
-		for ls.hasMore() {
-			ls.next()
-			count++
-		}
-		fmt.Fprintf(out, "Count: %d lines\n", count)
-	case "last":
-		n := parseLastCount(pipeArg)
-		// Circular buffer of the last n lines: slot i%n holds the i-th
-		// line, overwriting the oldest once more than n have arrived. The
-		// ring GROWS LAZILY (append until it holds n lines, then overwrite)
-		// so its memory is O(min(n, lines produced)) — never O(operand),
-		// never pre-allocated from an untrusted N (#5037). Only n lines are
-		// ever retained, not the whole output.
-		ring := make([]string, 0)
-		count := 0
-		for ls.hasMore() {
-			line, _ := ls.next()
-			if len(ring) < n {
-				ring = append(ring, line)
-			} else {
-				ring[count%n] = line
-			}
-			count++
-		}
-		total := count
-		if total > n {
-			total = n
-		}
-		for i := count - total; i < count; i++ {
-			fmt.Fprintln(out, ring[i%n])
-		}
-	case "no-more":
-		for ls.hasMore() {
-			line, _ := ls.next()
-			fmt.Fprintln(out, line)
-		}
-	}
+// parseLastCount delegates to the shared parser (see filterStream).
+func parseLastCount(arg string) int {
+	return cliterm.ParseLastCount(arg)
 }
 
 // dispatchWithPager runs a "show" command and pages its output. The command
@@ -259,12 +185,12 @@ func pageStream(src io.Reader, out io.Writer, keys io.Reader, pageSize int) {
 	if pageSize < 1 {
 		pageSize = 1
 	}
-	ls := &lineSource{r: bufio.NewReader(src)}
+	ls := cliterm.NewLineSource(src)
 
-	for ls.hasMore() {
+	for ls.HasMore() {
 		printed := 0
 		for printed < pageSize {
-			l, ok := ls.next()
+			l, ok := ls.Next()
 			if !ok {
 				break
 			}
@@ -272,7 +198,7 @@ func pageStream(src io.Reader, out io.Writer, keys io.Reader, pageSize int) {
 			printed++
 		}
 
-		if !ls.hasMore() {
+		if !ls.HasMore() {
 			break
 		}
 
@@ -287,7 +213,7 @@ func pageStream(src io.Reader, out io.Writer, keys io.Reader, pageSize int) {
 			io.Copy(io.Discard, src)
 			return
 		case '\n', '\r':
-			if l, ok := ls.next(); ok {
+			if l, ok := ls.Next(); ok {
 				fmt.Fprintln(out, l)
 			}
 			continue
@@ -302,53 +228,6 @@ func pageStream(src io.Reader, out io.Writer, keys io.Reader, pageSize int) {
 // produce a phantom empty line, while an unterminated final line is returned as
 // its own line. Only "\n" is treated as the delimiter, so a trailing "\r" stays
 // on the line exactly as the previous strings.Split did.
-type lineSource struct {
-	r       *bufio.Reader
-	peeked  string
-	hasPeek bool
-	done    bool
-}
-
-// read pulls the next line directly from the underlying reader.
-func (ls *lineSource) read() (string, bool) {
-	line, err := ls.r.ReadString('\n')
-	if len(line) == 0 && err != nil {
-		ls.done = true
-		return "", false
-	}
-	if err != nil {
-		ls.done = true
-	}
-	return strings.TrimSuffix(line, "\n"), true
-}
-
-// next returns the next line, or ("", false) at end of input.
-func (ls *lineSource) next() (string, bool) {
-	if ls.hasPeek {
-		ls.hasPeek = false
-		return ls.peeked, true
-	}
-	return ls.read()
-}
-
-// hasMore reports whether another line is available, buffering it for the next
-// next() call.
-func (ls *lineSource) hasMore() bool {
-	if ls.hasPeek {
-		return true
-	}
-	if ls.done {
-		return false
-	}
-	l, ok := ls.read()
-	if !ok {
-		return false
-	}
-	ls.peeked = l
-	ls.hasPeek = true
-	return true
-}
-
 var operationalCommands = []string{
 	"configure", "show", "clear", "ping", "test", "traceroute",
 	"monitor", "request", "quit", "exit",

--- a/pkg/cli/cli_dispatch_pager_stream_4709_test.go
+++ b/pkg/cli/cli_dispatch_pager_stream_4709_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/cliterm"
 )
 
 func bufioReader(s string) *bufio.Reader {
@@ -205,10 +207,14 @@ func TestLineSourceSemantics(t *testing.T) {
 		{"a\r\nb\r\n", []string{"a\r", "b\r"}}, // only "\n" is the delimiter
 	}
 	for _, tc := range cases {
-		ls := &lineSource{r: bufioReader(tc.in)}
+		// #7210: LineSource moved to pkg/cliterm and is now shared with the
+		// remote CLI. This test moved with it rather than being left pointing
+		// at a name that no longer exists — the splitting contract it pins is
+		// unchanged and now covers BOTH surfaces.
+		ls := cliterm.NewLineSource(strings.NewReader(tc.in))
 		var got []string
-		for ls.hasMore() {
-			l, ok := ls.next()
+		for ls.HasMore() {
+			l, ok := ls.Next()
 			if !ok {
 				t.Fatalf("hasMore/next disagreed for %q", tc.in)
 			}

--- a/pkg/cli/pipe_filter_single_source_7210_test.go
+++ b/pkg/cli/pipe_filter_single_source_7210_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cliterm"
+)
+
+// #7210: pkg/cli must DELEGATE its pipe filtering to pkg/cliterm rather than
+// keeping a second copy, because the local and remote CLI surfaces must not be
+// able to drift apart (#4968 is what drifting looks like).
+//
+// WHY A VALUE COMPARISON CANNOT TEST THE CAP. `maxTailLines == cliterm.MaxTailLines`
+// is true whether maxTailLines is an alias for it or a second literal 100_000.
+// The two states are indistinguishable by value TODAY, and only become
+// distinguishable on the day someone changes one of them — which is exactly the
+// day the test is needed and the day it would not fire. So the assertion has to
+// be about how the constant is DECLARED, which is a fact about the source.
+//
+// A mutation matrix found this gap: restoring `const maxTailLines = 100_000`
+// left the entire suite green. The delegation comment claimed "an ALIAS, not a
+// second copy of the number" and nothing enforced it.
+//
+// go/parser rather than grep: the surrounding doc comments name the literal and
+// the shared constant, so a textual scan matches whichever one it looks for.
+
+func constValueExpr(t *testing.T, file, name string) ast.Expr {
+	t.Helper()
+	f, err := parser.ParseFile(token.NewFileSet(), file, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, id := range vs.Names {
+				if id.Name == name && i < len(vs.Values) {
+					return vs.Values[i]
+				}
+			}
+		}
+	}
+	t.Fatalf("const %s not found in %s — if it moved, move this test with it; a missing "+
+		"declaration must not read as a passing delegation check", name, file)
+	return nil
+}
+
+func TestLocalMaxTailLinesIsAnAliasNotACopy7210(t *testing.T) {
+	expr := constValueExpr(t, "cli_dispatch.go", "maxTailLines")
+
+	referencesShared := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "cliterm" && sel.Sel.Name == "MaxTailLines" {
+			referencesShared = true
+		}
+		return true
+	})
+
+	if !referencesShared {
+		t.Error("maxTailLines is not declared as cliterm.MaxTailLines, so the local and remote " +
+			"CLI now hold two independent copies of the tail cap. They are equal today, which is " +
+			"why no value assertion can catch this — the copies only diverge on the day someone " +
+			"changes one, and that is the day a value assertion still passes (#7210)")
+	}
+
+	// Positive control: the walker must actually detect a shared reference,
+	// otherwise "no reference found" would be reported for a delegating
+	// declaration too and the assertion above would be vacuous.
+	ctl, err := parser.ParseExpr("cliterm.MaxTailLines")
+	if err != nil {
+		t.Fatalf("parsing the control expression: %v", err)
+	}
+	found := false
+	ast.Inspect(ctl, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "cliterm" && sel.Sel.Name == "MaxTailLines" {
+				found = true
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("the walker failed to find cliterm.MaxTailLines in a literal reference to it; " +
+			"until it does, a clean result above means nothing")
+	}
+}
+
+// The behavioural half: whatever the declaration says, the two must agree.
+// Kept alongside the structural check because they fail for different reasons —
+// this one catches a wrong value, the one above catches a re-forked declaration
+// that happens to still hold the right value.
+func TestLocalAndSharedTailCapsAgree7210(t *testing.T) {
+	if maxTailLines != cliterm.MaxTailLines {
+		t.Errorf("local cap %d != shared cap %d", maxTailLines, cliterm.MaxTailLines)
+	}
+	if got := parseLastCount("2000000000"); got != cliterm.MaxTailLines {
+		t.Errorf("local parseLastCount did not clamp to the shared cap: got %d, want %d",
+			got, cliterm.MaxTailLines)
+	}
+}

--- a/pkg/cliterm/pipefilter.go
+++ b/pkg/cliterm/pipefilter.go
@@ -1,0 +1,189 @@
+package cliterm
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Junos-style output pipe filtering, shared by BOTH CLI surfaces: the
+// in-process interactive CLI (pkg/cli) and the remote gRPC client (cmd/cli).
+//
+// WHY THIS LIVES HERE RATHER THAN BEING DUPLICATED. The two surfaces must agree
+// on filter semantics, and a divergence between them is ALWAYS a bug, never a
+// legitimate difference — #4968 is the proof: the remote copy lowercased both
+// operands, so `| match Foo` matched `foo` on remote and not on local. Two
+// copies can drift; one cannot. cliterm was already the established home for
+// exactly this (the readline loop moved here "so there is one"), and it adds no
+// dependency edge — both surfaces already import it, while cmd/cli deliberately
+// does NOT import pkg/cli, which would drag the whole in-process CLI into the
+// thin remote client.
+//
+// Everything here streams. match/except/find/no-more hold at most one line at a
+// time; count keeps only a running tally; last keeps a bounded ring. None
+// buffers the full output (#4731, #7210).
+
+// MaxTailLines bounds the ring the `| last N` filter retains and grows,
+// independent of the operator-supplied N (#5037). `show` is a read-only
+// (PermView) command, so without a bound a viewer could run
+// `show ... | last 2000000000` and force a ~32 GiB up-front []string
+// allocation. 100,000 lines is far more tail than any operator needs, yet caps
+// the ring's worst-case slice header at ~1.6 MiB (64-bit) plus the retained
+// line strings.
+const MaxTailLines = 100_000
+
+// ParseLastCount parses the `| last N` operand. It defaults to 10, ignores a
+// non-positive or unparseable N (Junos-compatible leniency), and clamps N to
+// MaxTailLines so the retained/grown ring is bounded by a fixed operator cap
+// rather than an untrusted operand (#5037).
+func ParseLastCount(arg string) int {
+	n := 10
+	if arg != "" {
+		if v, err := strconv.Atoi(arg); err == nil && v > 0 {
+			n = v
+		}
+	}
+	if n > MaxTailLines {
+		n = MaxTailLines
+	}
+	return n
+}
+
+// LineSource is a one-line-lookahead reader. The lookahead is what lets a
+// filter ask "is there more?" without reading the rest of the stream, which is
+// what keeps the filters streaming rather than buffering.
+// NewLineSource wraps src with the one-line lookahead the streaming filters
+// and the pager both rely on.
+func NewLineSource(src io.Reader) *LineSource {
+	return &LineSource{r: bufio.NewReader(src)}
+}
+
+type LineSource struct {
+	r       *bufio.Reader
+	peeked  string
+	hasPeek bool
+	done    bool
+}
+
+// read pulls the next line directly from the underlying reader.
+func (ls *LineSource) read() (string, bool) {
+	line, err := ls.r.ReadString('\n')
+	if len(line) == 0 && err != nil {
+		ls.done = true
+		return "", false
+	}
+	if err != nil {
+		ls.done = true
+	}
+	return strings.TrimSuffix(line, "\n"), true
+}
+
+// Next returns the next line, or ("", false) at end of input.
+func (ls *LineSource) Next() (string, bool) {
+	if ls.hasPeek {
+		ls.hasPeek = false
+		return ls.peeked, true
+	}
+	return ls.read()
+}
+
+// HasMore reports whether another line is available, buffering it for the next
+// next() call.
+func (ls *LineSource) HasMore() bool {
+	if ls.hasPeek {
+		return true
+	}
+	if ls.done {
+		return false
+	}
+	l, ok := ls.read()
+	if !ok {
+		return false
+	}
+	ls.peeked = l
+	ls.hasPeek = true
+	return true
+}
+
+// FilterStream reads newline-delimited output from src and applies a Junos-style
+// output filter (match/grep/except/find/count/last/no-more), writing the result
+// to out as each line is read.
+//
+// match/grep/except/find are CASE-SENSITIVE. Junos `| match` never case-folds
+// (#4968).
+//
+// The line splitting is byte-identical to a
+// strings.Split(output, "\n")-with-trailing-empty-dropped pass over the same
+// input, so replacing a buffer-then-filter implementation with this one changes
+// no output.
+func FilterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
+	ls := NewLineSource(src)
+
+	switch pipeType {
+	case "match", "grep":
+		for ls.HasMore() {
+			line, _ := ls.Next()
+			if strings.Contains(line, pipeArg) {
+				fmt.Fprintln(out, line)
+			}
+		}
+	case "except":
+		for ls.HasMore() {
+			line, _ := ls.Next()
+			if !strings.Contains(line, pipeArg) {
+				fmt.Fprintln(out, line)
+			}
+		}
+	case "find":
+		found := false
+		for ls.HasMore() {
+			line, _ := ls.Next()
+			if !found && strings.Contains(line, pipeArg) {
+				found = true
+			}
+			if found {
+				fmt.Fprintln(out, line)
+			}
+		}
+	case "count":
+		count := 0
+		for ls.HasMore() {
+			ls.Next()
+			count++
+		}
+		fmt.Fprintf(out, "Count: %d lines\n", count)
+	case "last":
+		n := ParseLastCount(pipeArg)
+		// Circular buffer of the last n lines: slot i%n holds the i-th line,
+		// overwriting the oldest once more than n have arrived. The ring GROWS
+		// LAZILY (append until it holds n lines, then overwrite) so its memory
+		// is O(min(n, lines produced)) — never O(operand), never pre-allocated
+		// from an untrusted N (#5037). Only n lines are ever retained, not the
+		// whole output.
+		ring := make([]string, 0)
+		count := 0
+		for ls.HasMore() {
+			line, _ := ls.Next()
+			if len(ring) < n {
+				ring = append(ring, line)
+			} else {
+				ring[count%n] = line
+			}
+			count++
+		}
+		total := count
+		if total > n {
+			total = n
+		}
+		for i := count - total; i < count; i++ {
+			fmt.Fprintln(out, ring[i%n])
+		}
+	case "no-more":
+		for ls.HasMore() {
+			line, _ := ls.Next()
+			fmt.Fprintln(out, line)
+		}
+	}
+}


### PR DESCRIPTION
The remote CLI client buffered a piped command's **entire** output before filtering, materializing it **twice** — once as a `[]byte` from `io.ReadAll`, again as a `[]string` from `strings.Split`. `show log messages | match error` against a big syslog buffer could OOM the operator's own `cli` process.

Client-side only: the daemon streams normally, and neither `xpfd` nor the dataplane is involved.

## Single-sourced rather than ported

The issue explicitly allowed copying `pkg/cli`'s streaming shape into `cmd/cli`, since `extractPipe` is already duplicated. **I did not**, because a divergence between the two surfaces is *always* a bug, never a legitimate difference — and **#4968 is the proof**: the remote copy had drifted into lowercasing both operands, so `| match Foo` matched `foo` on remote but not local. Two copies can drift; one cannot.

`FilterStream` / `LineSource` / `ParseLastCount` / `MaxTailLines` now live in **`pkg/cliterm`**, which was already the established home for exactly this (the readline loop moved there *"so there is one"*) and adds **no dependency edge**: both surfaces already import it, while `cmd/cli` deliberately does *not* import `pkg/cli` (that would drag the whole in-process CLI into the thin remote client).

`pkg/cli` keeps its unexported names as thin delegations, so its #4731 / #5037 / #5069 regression tests keep exercising the real code path instead of being quietly decommissioned by the move. Two tests **moved with the code** rather than being left pointing at names that no longer exist.

## Mutation matrix (1243 collected in every cell)

| cell | change | result |
|---|---|---|
| C0 | control | 1243 collected, 0 failed |
| M1 | revert `cmd/cli` to buffer-then-filter | **RED** — `TestRemotePipeUsesTheSharedFilter7210` |
| M2 | drop the `MaxTailLines` clamp | **RED ×3** — incl. two **pre-existing** tests (`TestParseLastCountCap`, `TestFilterStreamLastCapTruncates`) |
| M3 | re-fold the filter case-insensitively | **RED** — `TestApplyPipeFilterCaseSensitive` |
| M4 | `maxTailLines` back to a pinned literal | **SURVIVED** → then **RED** after adding a binding |

**M2 is the answer to "does single-sourcing decommission the old tests?"** — it reds two tests that came with the moved code, so they are still guarding it.

**M4 is worth reading.** The delegation comment claimed *"an ALIAS, not a second copy of the number"* and **nothing enforced it** — restoring `const maxTailLines = 100_000` left the whole suite green. A value comparison cannot catch it: `maxTailLines == cliterm.MaxTailLines` is true either way, and the two states only become distinguishable on the day someone changes one, which is exactly the day the value assertion still passes. Bound with a `go/parser` check that the declaration *references* the shared constant. M4 reds after the fix.

## One limitation, stated plainly

**M1 reds only on the AST test, not on the streaming test.** `TestRemotePipeFilterStreamsBeforeEOF7210` exercises `cliterm.FilterStream` directly, so it proves *the shared filter streams* — which stays true even if `cmd/cli` buffers before calling it. What actually binds the production path is the AST assertion (`dispatchWithPipe` calls `FilterStream` and does **not** call `io.ReadAll`). A true end-to-end cell would have to drive `dispatchWithPipe` with a live gRPC `*ctl`, which is out of proportion here — but the division of labour should be visible rather than implied.

## Acceptance

1. **No semantic drift** — the six verbs are the same implementation both surfaces already used; #4968 and the #4731/#5037/#5069 tests all still pass.
2. **`| last N` clamps** — `TestRemotePipeLastClampsHugeN7210`, and M2 shows it is load-bearing.
3. **Incremental consumption** — `TestRemotePipeFilterStreamsBeforeEOF7210` feeds a reader that yields lines then **blocks**, asserting output appears while the stream is still open, which a buffering implementation cannot do (it emits nothing until an EOF that never comes). Its control runs the same harness with nothing buffered and asserts no output, so "output appeared" cannot be explained by the harness itself.

Full Go suite: **rc=0, 69 packages, 0 FAIL**. Go-only — no Rust, no shim, no protocol movement, **no cluster smoke owed**.

Closes #7210