### PR TITLE
Accept a DNS hostname as a WireGuard peer endpoint

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -7304,12 +7304,31 @@ reserved for whole-dataplane selection where a rewrite shim
   every compile/load/HA-sync path funnels through. The gate also
   hard-rejects a WG tunnel with zero peers, a duplicate or malformed
   (non-64-hex) peer pubkey, a malformed preshared-key,
-  a peer `endpoint` that is not a concrete `host:port` (IPv6 authored as
-  `[addr]:port`) with a numeric UDP port in `1..65535` and an IP-literal
-  host — the Rust `hydrate_wg_identity` turns it into a `SocketAddr`
-  (`wg_endpoint.parse::<SocketAddr>()`, no DNS), so a port-less/zero-port
-  or hostname endpoint that COMMITTED CLEAN would hydrate the peer
-  RESPONDER-ONLY (unable to initiate handshakes/keepalives). The lexer
+  a peer `endpoint` that is not a `host:port` (IPv6 authored as
+  `[addr]:port`) with a numeric UDP port in `1..65535`. The host may be an
+  IP literal **or a DNS hostname** (#7158): a peer behind a dynamic WAN is
+  reachable only by a DDNS name, and rejecting that made the topology
+  unauthorable. The port half stays strict because it IS knowable at
+  commit — a port-less or zero-port endpoint can never initiate no matter
+  what DNS returns.
+
+  The #5182 invariant is preserved, restated at the time of USE rather
+  than of commit: every accepted endpoint becomes a real `SocketAddr` with
+  the authored port before the peer initiates. A hostname is resolved by
+  the tunnel's endpoint resolver thread, NOT at commit — a lookup in a
+  config transaction would hang commits on a broken resolver, and an
+  answer cached at commit is stale the moment the DDNS name moves, which
+  is the whole reason for using one. Commit therefore validates SHAPE
+  only; `classify_wg_endpoint` in the Rust hydrate decides the same
+  question, and both sides are asserted to agree against the shared
+  fixture `test/fixtures/wg-endpoint-shape.txt`.
+
+  A hostname's family is not knowable at commit, so it does NOT
+  participate in the mixed-family gate below; literals still pin the
+  family between themselves, so every config that gate rejected before it
+  still rejects. The family a name actually resolves to is enforced where
+  it becomes knowable: the resolver keeps only answers matching the
+  interface socket's family and counts the rest. The lexer
   preserves the bracketed `[v6]:port` literal as one scalar (#5182) — it
   previously split it on the address's inner colons and dropped the port,
   so every IPv6 peer silently degraded; the dataplane now DROPS the row

--- a/docs/log/7158.md
+++ b/docs/log/7158.md
@@ -1,0 +1,103 @@
+# 7158 — a DNS hostname as a WireGuard peer endpoint
+
+- **Timestamp**: 2026-08-29
+- **Action**: accepted hostname endpoints at commit; added a per-tunnel endpoint
+  resolver thread with last-good retention and a roam-precedence rule
+- **File(s)**: `pkg/config/compiler_validate_wireguard.go`,
+  `pkg/config/types_routing.go`, `pkg/config/wireguard_endpoint_shape_7158_test.go`,
+  `userspace-dp/src/afxdp/wg/endpoint_resolver{,_tests}.rs` (new),
+  `userspace-dp/src/afxdp/forwarding_build/tunnels.rs`,
+  `userspace-dp/src/afxdp/coordinator/wg_control/mod.rs`,
+  `userspace-dp/src/afxdp/coordinator/tunnel_supervision.rs`,
+  `userspace-dp/src/afxdp/types/forwarding.rs`,
+  `test/fixtures/wg-endpoint-shape.txt` (new), `docs/config-schema.md`
+
+## The three design questions, settled before any parser work
+
+**Where does resolution happen? Not at commit, and not in the control loop.**
+
+Not at commit: a lookup there is a blocking network call inside a config
+transaction, so a broken resolver hangs commits — including the commit that
+would fix the resolver. And an answer cached at commit is correct at commit and
+silently stale a day later, which is precisely what a DDNS name is for. That
+failure is worse than not resolving, because it looks configured.
+
+Not in the WireGuard control loop either, which is the sharper constraint and
+was not obvious until measured against the code: that loop is not control-only.
+It blocks in `poll(2)` over `{UDP socket, TUN}` and carries the tunnel's DATA
+path. A blocking `to_socket_addrs` there would stall every packet on the tunnel
+behind a slow resolver — converting a name-service problem into a forwarding
+outage. There is no DNS anywhere in the helper today, so this is the first, and
+it went on its own thread.
+
+**What happens when a lookup fails? Retain the last-good address.**
+
+A failed lookup changes nothing: same address, same session, counter incremented.
+Clearing on failure looks like correct cache hygiene and would tear down a
+working tunnel because a DNS server blinked, making the tunnel strictly less
+reliable than the name service in front of it. The cost of retaining is a stale
+address after a real DDNS move while lookups fail — the same state the tunnel
+would be in anyway, self-correcting on the next success, and visible in the
+counters.
+
+**What wins, DNS or a learned roam? The roam, for one attempt window.**
+
+An authenticated datagram pins the endpoint for `REKEY_ATTEMPT_TIME` (90 s). The
+authenticated source is where the peer REALLY is, including its NAT; DNS is only
+where it claims to be reachable. After a full attempt window of silence the
+learned address has already failed to produce a handshake, so it has stopped
+being evidence and DNS takes over — which is the case this feature exists for.
+
+Visibility: every outcome counted (`resolve_ok`, `resolve_fail`,
+`family_mismatch`, `endpoint_changed`), last error text retained, and an
+endpoint move logged. Family mismatch is counted separately from failure
+because the operator action differs — the name works and the record is wrong.
+
+## What the agreement test found
+
+`test/fixtures/wg-endpoint-shape.txt` is read by BOTH the Go commit test and the
+Rust hydrate test, so the two gates are asserted to agree rather than each
+restating its own belief about the other. On its first run it failed on
+`203.0.113.7:0`.
+
+Rust's `parse::<SocketAddr>()` **accepts port 0**. Both sides' comments claimed
+the hydrate "rejects a missing/zero port"; the missing-port half is true, the
+zero-port half never was. The strict commit gate does reject it, so this only
+mattered on the TOLERANT load path — exactly the path the fail-closed hydrate
+exists to backstop (#5182). A port-0 peer "can initiate" to nowhere. Closed, and
+both stale comments corrected.
+
+The first version of the test also compared `parse::<SocketAddr>()` directly,
+which is testing the standard library rather than the hydrate's decision — it
+could not see the fix. The decision was extracted into `classify_wg_endpoint`
+and the test bound to that.
+
+## A defect caught in review of my own diff
+
+The family classification sits in the per-peer loop ABOVE the allowed-ips gates.
+The obvious spelling for "a hostname does not constrain the family" is
+`continue` — which continues the PEER loop and exempts every hostname peer from
+the malformed-CIDR and duplicate-prefix checks. Such a peer commits clean and is
+then dropped by the hydrate, with no diagnostic. Scoped to `if fam != nil` and
+guarded by `TestWireguardHostnamePeerStillGetsAllowedIPsValidation_7158`.
+
+## Mutation matrix — Rust full suite `--test-threads=1` + `go test ./pkg/config/`
+
+| cell | edit | verdict | reds |
+|------|------|---------|------|
+| control | none | GREEN (rust 4859, go clean) | — |
+| m1 | restore the pre-#7158 hostname reject | RED | the shared-fixture test + both feature tests |
+| m2 | `continue` instead of the scoped `if` | RED | the allowed-ips guard, alone |
+| m3 | let the hydrate take port 0 | RED | the agreement test, alone |
+| m4 | drop the entry when a lookup fails | RED | the last-good retention test, alone |
+| m5 | let DNS overwrite a live roam | RED | the roam-precedence test, alone |
+
+m2's first attempt was a VOID, not a red: the edit broke the Go build, so
+`rc=1` with zero named failures. Re-done line-anchored.
+
+## Not done
+
+The resolver's counters are not yet on the `ProcessStatus` wire / Prometheus
+surface — they are in-process only. Filed as a follow-up rather than widened
+here; the operator-visible half of visibility (the endpoint-move log line and
+the retained error text) is present.

--- a/pkg/config/compiler_validate_wireguard.go
+++ b/pkg/config/compiler_validate_wireguard.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // validateWireguardPeersStrict enforces the multi-peer WireGuard
@@ -225,14 +226,40 @@ func validateOneWireguardTunnel(tc *TunnelConfig) error {
 		}
 
 		if p.Endpoint != "" {
-			v6, err := endpointIsV6(p.Endpoint)
+			fam, err := endpointFamily(p.Endpoint)
 			if err != nil {
 				return fmt.Errorf("peer %q has an invalid endpoint %q: %w", p.PublicKeyHex, p.Endpoint, err)
 			}
-			if endpointFamilyV6 == nil {
-				endpointFamilyV6 = &v6
-			} else if *endpointFamilyV6 != v6 {
-				return fmt.Errorf("peers declare endpoints of mixed address family; a WireGuard interface binds one UDP socket, so all endpoint-bearing peers must use the same outer family (IPv4 or IPv6)")
+			// #7158: a HOSTNAME endpoint returns nil and does not participate
+			// in this gate. Its family is not knowable at commit, and a guess
+			// would be wrong in both directions: assuming v4 rejects a valid
+			// dual-stack config, and assuming "matches whatever is there"
+			// accepts a config that cannot work.
+			//
+			// This preserves the gate exactly for every config that reached it
+			// before. Hostnames were a hard reject until now, so no previously
+			// ACCEPTED config gains a peer here and no previously REJECTED
+			// mixed-literal config starts passing — the literals still pin the
+			// family between themselves.
+			//
+			// The family a hostname actually resolves to is enforced where it
+			// becomes knowable: the control thread's resolver keeps only
+			// answers matching the interface socket's family, and counts the
+			// ones it discards, so a name that resolves to the wrong family is
+			// visible rather than a silent no-initiate.
+			//
+			// NOT `continue`: this block sits inside the per-peer loop, above
+			// the allowed-ips validation, so skipping the rest of the iteration
+			// would exempt every hostname-endpoint peer from the malformed-CIDR
+			// and duplicate-prefix gates — commit-clean, then dropped at
+			// hydrate, which is the silent-degradation shape this whole
+			// validator exists to prevent.
+			if fam != nil {
+				if endpointFamilyV6 == nil {
+					endpointFamilyV6 = fam
+				} else if *endpointFamilyV6 != *fam {
+					return fmt.Errorf("peers declare endpoints of mixed address family; a WireGuard interface binds one UDP socket, so all endpoint-bearing peers must use the same outer family (IPv4 or IPv6)")
+				}
 			}
 		}
 
@@ -304,31 +331,117 @@ func isWireguardKeyHex(s string) bool {
 	return true
 }
 
-// endpointIsV6 validates a WireGuard peer endpoint and reports whether its
-// address is IPv6. The endpoint MUST be a concrete `host:port` (IPv6 as
-// `[addr]:port`) with a numeric UDP port in 1..65535 and an IP-literal
-// host — exactly what the Rust hydrate can turn into a `SocketAddr`
-// (`wg_endpoint.parse::<SocketAddr>()`; it does NOT resolve DNS and rejects
-// a missing/zero port). Rejecting a port-less, zero-port, or hostname
-// endpoint here upholds the invariant that every non-empty endpoint the
-// strict commit ACCEPTS hydrates to `Some(SocketAddr)` with the authored
-// port and can therefore INITIATE (#5182). Before the lexer preserved the
-// bracketed `[v6]:port` token, a v6 endpoint arrived port-stripped and had
-// to be accepted as a bare IP — that leniency is what silently degraded
-// every IPv6 peer to responder-only. The bool return classifies the outer
-// family for the one-UDP-socket mixed-family gate.
-func endpointIsV6(endpoint string) (bool, error) {
+// endpointFamily validates a WireGuard peer endpoint and classifies its outer
+// address family. The endpoint MUST be a `host:port` (IPv6 as `[addr]:port`)
+// with a numeric UDP port in 1..65535. The host may be an IP literal or a DNS
+// hostname.
+//
+// The return is nil for a hostname, whose family is not knowable at commit —
+// see the mixed-family gate at the call site for why that is the correct
+// answer rather than a guess.
+//
+// # Why the port rules stay strict (#5182)
+//
+// The pre-#7158 gate additionally required an IP LITERAL, to uphold: every
+// endpoint the strict commit ACCEPTS hydrates to a real `SocketAddr` with the
+// authored port and can therefore INITIATE. That invariant is preserved, not
+// relaxed — it is restated in terms of the time of USE rather than the time of
+// commit: an accepted endpoint resolves to a `SocketAddr` when the WireGuard
+// control thread comes to initiate. What is dropped is only the claim that the
+// address is knowable at commit, which was never true for a DDNS peer.
+//
+// The port half is unchanged and still strict, because it IS knowable at
+// commit: a port-less or zero-port endpoint can never initiate no matter what
+// DNS returns. Before the lexer preserved the bracketed `[v6]:port` token, a v6
+// endpoint arrived port-stripped and had to be accepted as a bare IP — that
+// leniency is what silently degraded every IPv6 peer to responder-only.
+//
+// # Why this does NOT resolve
+//
+// Deliberately no DNS lookup here. Two independent reasons, either sufficient:
+//
+//   - A commit is a config transaction. A lookup in it is a blocking network
+//     call whose latency is an unreachable resolver's timeout, so a broken
+//     resolver would hang commits — including the commit that would FIX the
+//     resolver.
+//   - Resolving at commit and caching the answer is wrong even when it works.
+//     A DDNS endpoint changes; that is the entire reason for using one. A
+//     commit-time answer is correct at commit and silently stale a day later,
+//     which is a worse failure than not resolving, because it looks configured.
+//
+// So the address is resolved where it is used, by the WireGuard control
+// thread's resolver, and re-resolved on a bounded schedule.
+func endpointFamily(endpoint string) (*bool, error) {
 	host, portStr, err := net.SplitHostPort(endpoint)
 	if err != nil {
-		return false, fmt.Errorf("must be host:port (IPv6 as [addr]:port): %w", err)
+		return nil, fmt.Errorf("must be host:port (IPv6 as [addr]:port): %w", err)
 	}
 	port, perr := strconv.Atoi(portStr)
 	if perr != nil || port < 1 || port > 65535 {
-		return false, fmt.Errorf("UDP port %q is not a number in 1..65535", portStr)
+		return nil, fmt.Errorf("UDP port %q is not a number in 1..65535", portStr)
 	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false, fmt.Errorf("host %q is not an IP literal (a WireGuard endpoint must be a numeric address, not a hostname; the dataplane does not resolve DNS)", host)
+	if ip := net.ParseIP(host); ip != nil {
+		v6 := ip.To4() == nil
+		return &v6, nil
 	}
-	return ip.To4() == nil, nil
+	if !isDNSHostname(host) {
+		return nil, fmt.Errorf("host %q is neither an IP literal nor a valid DNS hostname", host)
+	}
+	return nil, nil
+}
+
+// isDNSHostname reports whether s is a syntactically valid DNS hostname
+// (RFC 1123): 1..253 characters, dot-separated labels of 1..63 characters,
+// each label alphanumeric-or-hyphen and not starting or ending with a hyphen.
+//
+// Syntax only, on purpose. This must not consult DNS — see endpointFamily.
+// It exists so an obvious typo (an empty label, a space, a stray bracket) is
+// still a commit error rather than a peer that can never initiate and whose
+// only symptom is a resolver counter.
+//
+// A single trailing dot (the fully-qualified form) is accepted and normalized
+// away before the label walk; Go's resolver accepts it, so rejecting it here
+// would refuse a name the dataplane can in fact use.
+func isDNSHostname(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	s = strings.TrimSuffix(s, ".")
+	if s == "" {
+		return false
+	}
+	// A name consisting only of digits and dots is a malformed IP literal, not
+	// a hostname: net.ParseIP already rejected it, and treating it as a name
+	// would accept "10.0.0.999:51820" as a DDNS endpoint and defer a certain
+	// failure to the resolver.
+	allDigitsAndDots := true
+	for i := 0; i < len(s); i++ {
+		if (s[i] < '0' || s[i] > '9') && s[i] != '.' {
+			allDigitsAndDots = false
+			break
+		}
+	}
+	if allDigitsAndDots {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return false
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for i := 0; i < len(label); i++ {
+			c := label[i]
+			switch {
+			case c >= 'a' && c <= 'z':
+			case c >= 'A' && c <= 'Z':
+			case c >= '0' && c <= '9':
+			case c == '-':
+			default:
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -698,12 +698,16 @@ func (tc *TunnelConfig) WgOuterFamilyV6() bool {
 		if p.Endpoint == "" {
 			continue
 		}
-		// The strict commit gate (endpointIsV6) now requires a concrete
+		// The strict commit gate (endpointFamily) requires a concrete
 		// `host:port` (IPv6 as `[addr]:port`), and the lexer preserves the
 		// bracketed literal whole (#5182), so SplitHostPort recovers the
 		// host for classification. The bare-IP fallback is retained as
 		// defense-in-depth for a leniently-loaded config that never went
 		// through the strict gate.
+		//
+		// #7158: the host may now be a DNS HOSTNAME as well as a literal, so
+		// a failed ParseIP below is no longer evidence of a malformed
+		// endpoint.
 		if host, _, err := net.SplitHostPort(p.Endpoint); err == nil {
 			if ip := net.ParseIP(host); ip != nil {
 				return ip.To4() == nil

--- a/pkg/config/wireguard_endpoint_shape_7158_test.go
+++ b/pkg/config/wireguard_endpoint_shape_7158_test.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+)
+
+// wgEndpointShapeCases reads the cross-language agreement fixture. Both this
+// test and the Rust hydrate test in
+// userspace-dp/src/afxdp/forwarding_build/tunnels.rs read the SAME file, so the
+// two implementations are asserted to agree rather than each pinned to its own
+// literal table that can drift.
+func wgEndpointShapeCases(t *testing.T) map[string]string {
+	t.Helper()
+	const path = "../../test/fixtures/wg-endpoint-shape.txt"
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v (the shared #7158 agreement fixture must exist; "+
+			"without it this test silently checks nothing)", path, err)
+	}
+	defer f.Close()
+
+	cases := make(map[string]string)
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) != 2 {
+			t.Fatalf("malformed fixture line %q (want <endpoint>\\t<verdict>)", line)
+		}
+		cases[parts[0]] = parts[1]
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	// Non-vacuity: an empty or comment-only fixture would make every assertion
+	// below pass by never running.
+	if len(cases) < 20 {
+		t.Fatalf("fixture yielded only %d cases; it is supposed to cover "+
+			"literals, hostnames, port rules and malformed hosts", len(cases))
+	}
+	return cases
+}
+
+// TestWireguardEndpointShapeMatchesTheSharedFixture_7158 pins the commit-side
+// half of the agreement.
+//
+// #7158 relaxed the IP-literal requirement so a DDNS peer is authorable. The
+// risk that relaxation introduces is not that a hostname is accepted — that is
+// the feature — but that the two sides disagree about WHICH strings are
+// hostnames. An endpoint Go accepts and Rust drops commits clean and then
+// silently loses the peer.
+func TestWireguardEndpointShapeMatchesTheSharedFixture_7158(t *testing.T) {
+	for endpoint, want := range wgEndpointShapeCases(t) {
+		t.Run(endpoint, func(t *testing.T) {
+			fam, err := endpointFamily(endpoint)
+			switch want {
+			case "reject":
+				if err == nil {
+					t.Fatalf("endpointFamily(%q) accepted an endpoint the shared "+
+						"fixture marks reject; the Rust hydrate drops it, so this "+
+						"config would commit clean and lose the peer", endpoint)
+				}
+			case "v4", "v6":
+				if err != nil {
+					t.Fatalf("endpointFamily(%q) rejected an IP literal: %v", endpoint, err)
+				}
+				if fam == nil {
+					t.Fatalf("endpointFamily(%q) returned an unknown family for an IP "+
+						"literal; a literal MUST constrain the mixed-family gate", endpoint)
+				}
+				if got := map[bool]string{true: "v6", false: "v4"}[*fam]; got != want {
+					t.Fatalf("endpointFamily(%q) = %s, want %s", endpoint, got, want)
+				}
+			case "hostname":
+				if err != nil {
+					t.Fatalf("endpointFamily(%q) rejected a DNS hostname: %v "+
+						"(this is the #7158 feature — the DDNS topology must be "+
+						"authorable)", endpoint, err)
+				}
+				if fam != nil {
+					t.Fatalf("endpointFamily(%q) claimed a family for a hostname; it "+
+						"is not knowable at commit, and a guess is wrong in both "+
+						"directions — see the mixed-family gate", endpoint)
+				}
+			default:
+				t.Fatalf("unknown verdict %q in the shared fixture", want)
+			}
+		})
+	}
+}
+
+// TestWireguardHostnamePeerStillGetsAllowedIPsValidation_7158 guards a defect
+// this change nearly shipped.
+//
+// The family classification sits in the per-peer loop ABOVE the allowed-ips
+// gates. Skipping the rest of the iteration for a hostname peer (the obvious
+// spelling, `continue`, since a hostname does not constrain the family) would
+// exempt every hostname peer from the malformed-CIDR and duplicate-prefix
+// checks. Such a peer would commit clean and then be DROPPED by the Rust
+// hydrate, which parses the same prefixes and fails the row closed — a peer
+// that silently routes nothing.
+//
+// FAIL-ON-REVERT: replace the `if fam != nil { ... }` block with
+// `if fam == nil { continue }` and this test goes RED while every other
+// WireGuard test stays green.
+func TestWireguardHostnamePeerStillGetsAllowedIPsValidation_7158(t *testing.T) {
+	tc := &TunnelConfig{
+		WgListenPort:      51820,
+		WgLocalPrivkeyHex: Secret(strings.Repeat("cd", 32)),
+		WgPeers: []WgPeerConfig{{
+			PublicKeyHex: strings.Repeat("ab", 32),
+			Endpoint:     "ddns.example.com:51820",
+			AllowedIPs:   []string{"this-is-not-a-cidr"},
+		}},
+	}
+	err := validateOneWireguardTunnel(tc)
+	if err == nil {
+		t.Fatal("a hostname-endpoint peer with a malformed allowed-ips prefix " +
+			"must still be rejected at commit; accepting it here means the row " +
+			"is dropped at hydrate instead, with no diagnostic (#7158)")
+	}
+	if !strings.Contains(err.Error(), "allowed-ips") {
+		t.Fatalf("expected the allowed-ips diagnostic, got: %v", err)
+	}
+}
+
+// TestWireguardMixedFamilyGateUnchangedByHostnames_7158 is #7158 acceptance 5:
+// the one-UDP-socket gate must still reject exactly what it rejected before.
+func TestWireguardMixedFamilyGateUnchangedByHostnames_7158(t *testing.T) {
+	peer := func(n byte, endpoint string) WgPeerConfig {
+		return WgPeerConfig{
+			PublicKeyHex: strings.Repeat(string("0123456789abcdef"[n%16]), 64),
+			Endpoint:     endpoint,
+			AllowedIPs:   []string{"10.0.0.0/24"},
+		}
+	}
+	// Mixed LITERALS still reject — unchanged behaviour.
+	mixed := &TunnelConfig{WgListenPort: 51820, WgLocalPrivkeyHex: Secret(strings.Repeat("cd", 32)), WgPeers: []WgPeerConfig{
+		peer(1, "203.0.113.7:51820"),
+		peer(2, "[2001:db8::1]:51820"),
+	}}
+	mixed.WgPeers[1].AllowedIPs = []string{"10.0.1.0/24"}
+	if err := validateOneWireguardTunnel(mixed); err == nil {
+		t.Fatal("mixed-family literal endpoints must still be rejected: a " +
+			"WireGuard interface binds ONE UDP socket")
+	}
+
+	// A hostname alongside a literal does NOT trip the gate: its family is
+	// unknowable at commit, so it neither constrains nor is constrained.
+	withHostname := &TunnelConfig{WgListenPort: 51820, WgLocalPrivkeyHex: Secret(strings.Repeat("cd", 32)), WgPeers: []WgPeerConfig{
+		peer(3, "203.0.113.7:51820"),
+		peer(4, "ddns.example.com:51820"),
+	}}
+	withHostname.WgPeers[1].AllowedIPs = []string{"10.0.1.0/24"}
+	if err := validateOneWireguardTunnel(withHostname); err != nil {
+		t.Fatalf("a hostname peer must not trip the mixed-family gate: %v", err)
+	}
+
+	// And two hostnames are fine together.
+	twoHostnames := &TunnelConfig{WgListenPort: 51820, WgLocalPrivkeyHex: Secret(strings.Repeat("cd", 32)), WgPeers: []WgPeerConfig{
+		peer(5, "a.example.com:51820"),
+		peer(6, "b.example.com:51820"),
+	}}
+	twoHostnames.WgPeers[1].AllowedIPs = []string{"10.0.1.0/24"}
+	if err := validateOneWireguardTunnel(twoHostnames); err != nil {
+		t.Fatalf("two hostname peers must commit clean: %v", err)
+	}
+}

--- a/test/fixtures/wg-endpoint-shape.txt
+++ b/test/fixtures/wg-endpoint-shape.txt
@@ -1,0 +1,59 @@
+# #7158: the ONE source of truth for which WireGuard peer endpoint spellings are
+# accepted, and how each is classified.
+#
+# Two independent implementations must agree on this set:
+#
+#   Go   pkg/config/compiler_validate_wireguard.go  endpointFamily/isDNSHostname
+#          -- decides what COMMITS.
+#   Rust userspace-dp/src/afxdp/forwarding_build/tunnels.rs
+#          -- decides what HYDRATES (SocketAddr parse, else the hostname shape
+#             check, else the row is dropped).
+#
+# They must accept the same set in both directions. An endpoint the Go gate
+# accepts but the Rust hydrate drops is a config that commits clean and then
+# silently loses the peer -- the exact silent degradation #5182 hardened the
+# hydrate against. An endpoint Rust would accept but Go rejects is merely
+# unauthorable, but still a disagreement worth catching.
+#
+# Both sides read THIS file in their tests, so the agreement is asserted rather
+# than restated as two literal tables that can drift apart independently.
+#
+# Format: <endpoint><TAB><verdict>
+#   v4        accepted, IP literal, family IPv4 (constrains the mixed-family gate)
+#   v6        accepted, IP literal, family IPv6 (constrains the mixed-family gate)
+#   hostname  accepted, DNS name, family unknown at commit (does NOT constrain)
+#   reject    rejected at commit AND dropped at hydrate
+
+# --- IP literals: unchanged by #7158 ---
+203.0.113.7:51820	v4
+[2001:db8::1]:51820	v6
+[::1]:1	v6
+127.0.0.1:65535	v4
+
+# --- hostnames: the #7158 addition ---
+unifi.example.ui.com:51820	hostname
+a.b:1	hostname
+host-with-hyphens.example.com:51820	hostname
+UPPER.Example.COM:51820	hostname
+trailing-dot.example.com.:51820	hostname
+xn--bcher-kva.example:51820	hostname
+h1.example.com:65535	hostname
+
+# --- port rules stay strict: knowable at commit, and a bad port can never
+# --- initiate no matter what DNS returns ---
+203.0.113.7	reject
+example.com	reject
+203.0.113.7:0	reject
+example.com:0	reject
+example.com:65536	reject
+example.com:	reject
+example.com:notanumber	reject
+:51820	reject
+
+# --- malformed hosts ---
+-leading.example.com:51820	reject
+trailing-.example.com:51820	reject
+double..dot.example.com:51820	reject
+has space.example.com:51820	reject
+10.0.0.999:51820	reject
+[2001:db8::1:51820	reject

--- a/userspace-dp/src/afxdp/coordinator/tunnel_supervision.rs
+++ b/userspace-dp/src/afxdp/coordinator/tunnel_supervision.rs
@@ -834,6 +834,20 @@ impl super::Coordinator {
         let recent_exceptions = self.recent_exceptions.clone();
         let thread_tunnel_name = tunnel_name.clone();
         let thread_per_peer_outer_mtu = per_peer_outer_mtu.clone();
+        // #7158: peers authored with a DNS hostname endpoint. Empty for a
+        // literal-only tunnel, which then starts no resolver thread — every
+        // tunnel that existed before #7158 is unchanged.
+        let endpoint_hosts: Vec<([u8; 32], String)> = self
+            .forwarding
+            .tunnel_endpoints
+            .get(&id)
+            .map(|e| {
+                e.wg_peers
+                    .iter()
+                    .filter_map(|p| p.endpoint_host.as_ref().map(|h| (p.pubkey, h.clone())))
+                    .collect()
+            })
+            .unwrap_or_default();
         eprintln!(
             "xpf-userspace-dp: spawning WG control thread endpoint={id} tun={tunnel_name} port={listen_port}"
         );
@@ -847,6 +861,7 @@ impl super::Coordinator {
                     listen_port,
                     outer_mtu,
                     thread_per_peer_outer_mtu,
+                    endpoint_hosts,
                     recent_exceptions,
                     stop_clone,
                 );

--- a/userspace-dp/src/afxdp/coordinator/wg_control/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control/mod.rs
@@ -123,6 +123,10 @@ pub(super) fn wg_control_loop(
     listen_port: u16,
     outer_mtu: usize,
     per_peer_outer_mtu: std::collections::HashMap<[u8; 32], usize>,
+    // #7158: peers whose endpoint was authored as a DNS hostname, as
+    // (pubkey, authored `host:port`). Empty for a tunnel of IP literals,
+    // which starts no resolver thread at all.
+    endpoint_hosts: Vec<([u8; 32], String)>,
     recent_exceptions: Arc<Mutex<ExceptionEventRing>>,
     stop: Arc<AtomicBool>,
 ) {
@@ -185,6 +189,19 @@ pub(super) fn wg_control_loop(
         return;
     }
 
+    // #7158: spawn the endpoint resolver HERE rather than at the supervisor,
+    // because it needs `socket_is_v6` to filter answers to the family this
+    // interface's single UDP socket can actually send from — and that is only
+    // known once the bind above has chosen it (the v6 bind falls back to v4).
+    //
+    // Dropped when this function returns, which joins the thread, so the
+    // resolver's lifetime is exactly the control thread's.
+    let endpoint_resolver = crate::afxdp::wg::endpoint_resolver::WgEndpointResolver::spawn(
+        &tunnel_name,
+        endpoint_hosts,
+        socket_is_v6,
+    );
+
     run_wg_control_loop(
         &tunnel_name,
         &engine,
@@ -193,6 +210,7 @@ pub(super) fn wg_control_loop(
         tun,
         outer_mtu,
         &per_peer_outer_mtu,
+        endpoint_resolver.as_ref(),
         &recent_exceptions,
         &stop,
     );
@@ -213,6 +231,7 @@ fn run_wg_control_loop(
     mut tun: std::fs::File,
     outer_mtu: usize,
     per_peer_outer_mtu: &std::collections::HashMap<[u8; 32], usize>,
+    endpoint_resolver: Option<&crate::afxdp::wg::endpoint_resolver::WgEndpointResolver>,
     recent_exceptions: &Arc<Mutex<ExceptionEventRing>>,
     stop: &AtomicBool,
 ) {
@@ -226,6 +245,10 @@ fn run_wg_control_loop(
     // peer drives its own keepalive/rekey timers.
     let peer_pubkeys: Vec<[u8; 32]> = engine.peer_pubkeys();
     let mut effective_endpoints: HashMap<[u8; 32], SocketAddr> = HashMap::new();
+    // #7158: last authenticated inbound datagram per peer, for the DNS/roam
+    // precedence rule. Empty means "never heard from", which is exactly the
+    // state in which a resolved address should be adopted immediately.
+    let mut last_authenticated_rx: HashMap<[u8; 32], u64> = HashMap::new();
     for (pk, ep) in engine.peer_endpoints() {
         if let Some(ep) = ep {
             effective_endpoints.insert(pk, ep);
@@ -315,6 +338,11 @@ fn run_wg_control_loop(
                     // peer's traffic.
                     if let Some(peer) = outcome.peer() {
                         effective_endpoints.insert(peer, canonicalize_endpoint(from));
+                        // #7158: stamp WHEN this peer was last heard from,
+                        // authenticated. The endpoint resolver uses it to stay
+                        // out of the way of a live roam — see
+                        // `apply_resolved_endpoints`.
+                        last_authenticated_rx.insert(peer, monotonic_nanos());
                     }
                     // Completion-site cleanup (plan v9, Codex r5/r6):
                     // a handshake completion obsoletes any request
@@ -470,6 +498,17 @@ fn run_wg_control_loop(
             // Session expiry is engine-wide (sweeps every peer's
             // sessions); run it once per pass, not per peer.
             engine.expire_sessions(now);
+            // #7158: adopt freshly-resolved hostname endpoints before driving
+            // the per-peer timers, so an initiation this pass uses the newest
+            // address rather than the previous one.
+            apply_resolved_endpoints(
+                endpoint_resolver,
+                &peer_pubkeys,
+                &mut effective_endpoints,
+                &last_authenticated_rx,
+                now,
+                tunnel_name,
+            );
             // #1434: drive each peer's keepalive/rekey timers and
             // attempt machine independently. The earliest deadline
             // across ALL peers gates the poll timeout.
@@ -535,3 +574,165 @@ fn run_wg_control_loop(
 #[cfg(test)]
 #[path = "wg_control_tests.rs"]
 mod tests;
+
+/// #7158: how long an authenticated datagram pins a peer's endpoint against a
+/// DNS re-resolution.
+///
+/// One full handshake attempt window (`REKEY_ATTEMPT_TIME`, 90 s). While a peer
+/// is actually talking to us, DNS must not move it: the authenticated source
+/// address is where the peer REALLY is, including whatever NAT it is behind,
+/// whereas a DNS answer is only where it CLAIMS to be reachable. Overwriting a
+/// working roamed endpoint with an A record would break a tunnel that is
+/// carrying traffic, which is the opposite of the point.
+///
+/// Once the peer has been silent for longer than a whole attempt window, the
+/// learned address has stopped being evidence of anything — an attempt window
+/// has already elapsed without it producing a handshake — and the DNS answer
+/// takes over. That is the case this feature exists for: the peer's dynamic WAN
+/// address changed, so the old learned address is dead and the new one is only
+/// discoverable through the name.
+const WG_ENDPOINT_ROAM_HOLD_NS: u64 = crate::afxdp::wg::session::REKEY_ATTEMPT_TIME_NS;
+
+/// Adopt resolver answers into `effective_endpoints`, subject to the roam-hold
+/// rule above. Never blocks: `latest` is a map read, never a lookup.
+fn apply_resolved_endpoints(
+    resolver: Option<&crate::afxdp::wg::endpoint_resolver::WgEndpointResolver>,
+    peer_pubkeys: &[[u8; 32]],
+    effective_endpoints: &mut std::collections::HashMap<[u8; 32], SocketAddr>,
+    last_authenticated_rx: &std::collections::HashMap<[u8; 32], u64>,
+    now_ns: u64,
+    tunnel_name: &str,
+) {
+    let Some(resolver) = resolver else {
+        return;
+    };
+    for pk in peer_pubkeys {
+        let Some(resolved) = resolver.latest(pk) else {
+            continue;
+        };
+        if effective_endpoints.get(pk) == Some(&resolved) {
+            continue;
+        }
+        // Roam hold: a peer heard from recently keeps the address it is
+        // actually reachable at.
+        if let Some(&heard) = last_authenticated_rx.get(pk) {
+            if now_ns.saturating_sub(heard) < WG_ENDPOINT_ROAM_HOLD_NS {
+                continue;
+            }
+        }
+        let prior = effective_endpoints.insert(*pk, resolved);
+        // Rare by construction (a DDNS move, or first resolution at bring-up),
+        // so this is not a hot-path log. It is the operator's account of WHY a
+        // peer's endpoint moved without a commit.
+        eprintln!(
+            "xpf-userspace-dp: wg {tunnel_name}: peer endpoint resolved to {resolved}{}",
+            match prior {
+                Some(p) => format!(" (was {p})"),
+                None => String::new(),
+            }
+        );
+    }
+}
+
+#[cfg(test)]
+mod endpoint_adoption_7158_tests {
+    use super::*;
+    use crate::afxdp::wg::endpoint_resolver::WgEndpointResolver;
+    use std::collections::HashMap;
+
+    const PK: [u8; 32] = [7u8; 32];
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().expect("test address")
+    }
+
+    /// #7158 acceptance 2/3: a resolved address is adopted, so a peer whose
+    /// DDNS name moved is reached without a commit or a daemon restart.
+    #[test]
+    fn a_resolved_endpoint_is_adopted_when_the_peer_is_silent_7158() {
+        let resolver = WgEndpointResolver::with_resolved_for_test(&[(PK, addr("203.0.113.9:51820"))]);
+        let mut effective: HashMap<[u8; 32], SocketAddr> = HashMap::new();
+        effective.insert(PK, addr("198.51.100.1:51820"));
+        // Never heard from: no roam to protect.
+        let heard: HashMap<[u8; 32], u64> = HashMap::new();
+
+        apply_resolved_endpoints(Some(&resolver), &[PK], &mut effective, &heard, 1_000, "wg0");
+
+        assert_eq!(
+            effective.get(&PK).copied(),
+            Some(addr("203.0.113.9:51820")),
+            "a peer we have never heard from must take the resolved address; \
+             this is the DDNS move the feature exists for (#7158)"
+        );
+    }
+
+    /// #7158: a peer we are CURRENTLY hearing from keeps the address it is
+    /// actually reachable at.
+    ///
+    /// The authenticated source is where the peer really is, including whatever
+    /// NAT it sits behind; a DNS answer is only where it claims to be
+    /// reachable. Letting a re-resolve overwrite a live roamed endpoint would
+    /// break a tunnel that is carrying traffic — the feature actively harming
+    /// the case that already worked.
+    ///
+    /// FAIL-ON-REVERT: delete the roam-hold branch in
+    /// `apply_resolved_endpoints` and the roamed address is clobbered.
+    #[test]
+    fn a_live_roam_is_not_clobbered_by_dns_7158() {
+        let resolver = WgEndpointResolver::with_resolved_for_test(&[(PK, addr("203.0.113.9:51820"))]);
+        let mut effective: HashMap<[u8; 32], SocketAddr> = HashMap::new();
+        // The roamed address: learned from an authenticated datagram.
+        effective.insert(PK, addr("198.51.100.77:33445"));
+        let mut heard: HashMap<[u8; 32], u64> = HashMap::new();
+        let now = 10 * WG_ENDPOINT_ROAM_HOLD_NS;
+        // Heard from one nanosecond ago.
+        heard.insert(PK, now - 1);
+
+        apply_resolved_endpoints(Some(&resolver), &[PK], &mut effective, &heard, now, "wg0");
+
+        assert_eq!(
+            effective.get(&PK).copied(),
+            Some(addr("198.51.100.77:33445")),
+            "DNS must not move a peer we are actively hearing from"
+        );
+    }
+
+    /// #7158: once the peer has been silent for longer than a whole handshake
+    /// attempt window, the learned address has stopped being evidence and DNS
+    /// takes over.
+    ///
+    /// This is the boundary that makes the hold a HOLD rather than a permanent
+    /// veto: without it, a peer that ever roamed could never be recovered
+    /// through its name after its dynamic address changed — the exact topology
+    /// #7158 is for.
+    #[test]
+    fn a_stale_roam_yields_to_dns_7158() {
+        let resolver = WgEndpointResolver::with_resolved_for_test(&[(PK, addr("203.0.113.9:51820"))]);
+        let mut effective: HashMap<[u8; 32], SocketAddr> = HashMap::new();
+        effective.insert(PK, addr("198.51.100.77:33445"));
+        let mut heard: HashMap<[u8; 32], u64> = HashMap::new();
+        let now = 10 * WG_ENDPOINT_ROAM_HOLD_NS;
+        // Silent for exactly the hold: the boundary is inclusive-yields.
+        heard.insert(PK, now - WG_ENDPOINT_ROAM_HOLD_NS);
+
+        apply_resolved_endpoints(Some(&resolver), &[PK], &mut effective, &heard, now, "wg0");
+
+        assert_eq!(
+            effective.get(&PK).copied(),
+            Some(addr("203.0.113.9:51820")),
+            "after a full attempt window of silence the learned address has \
+             already failed to produce a handshake; DNS must be allowed to \
+             recover the peer"
+        );
+    }
+
+    /// #7158 acceptance 6: with no resolver — every tunnel of IP literals —
+    /// adoption is a no-op.
+    #[test]
+    fn no_resolver_means_no_change_7158() {
+        let mut effective: HashMap<[u8; 32], SocketAddr> = HashMap::new();
+        effective.insert(PK, addr("198.51.100.1:51820"));
+        let heard: HashMap<[u8; 32], u64> = HashMap::new();
+        apply_resolved_endpoints(None, &[PK], &mut effective, &heard, 1_000, "wg0");
+        assert_eq!(effective.get(&PK).copied(), Some(addr("198.51.100.1:51820")));
+    }
+}

--- a/userspace-dp/src/afxdp/coordinator/wg_control/wg_control_tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control/wg_control_tests.rs
@@ -214,6 +214,10 @@ fn spawn_poll_loop(
             // #5291: no per-peer overrides in the idle poll-loop tests —
             // every peer falls back to the scalar (WG_DEFAULT_OUTER_MTU).
             &std::collections::HashMap::new(),
+            // #7158: no hostname endpoints in these fixtures, so no resolver.
+            // `None` is also the production shape for every literal-only
+            // tunnel, so these tests keep exercising the unchanged path.
+            None,
             &exceptions,
             &stop,
         );
@@ -372,6 +376,10 @@ fn wg_tun_origin_egress_uses_per_peer_outer_mtu_5291() {
             tun,
             outer_mtu,
             &per_peer,
+            // #7158: no hostname endpoints in these fixtures, so no resolver.
+            // `None` is also the production shape for every literal-only
+            // tunnel, so these tests keep exercising the unchanged path.
+            None,
             &exceptions,
             &stop_thread,
         );

--- a/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
@@ -313,6 +313,7 @@ pub(in crate::afxdp) fn hydrate_wg_identity(
             }
         }
         let mut endpoint: Option<SocketAddr> = None;
+        let mut endpoint_host: Option<String> = None;
         if !wire.wg_endpoint.is_empty() {
             // A non-empty endpoint that does not parse to a concrete
             // SocketAddr must fail the ROW closed rather than silently
@@ -322,13 +323,29 @@ pub(in crate::afxdp) fn hydrate_wg_identity(
             // degradation the Go commit gate now rejects; the dataplane
             // keeps defense-in-depth in agreement so a leniently-loaded
             // config fails loudly (drop) instead of quietly.
-            let Ok(parsed) = wire.wg_endpoint.parse::<SocketAddr>() else {
-                return None;
-            };
-            // Canonicalize (unmap ::ffff:a.b.c.d) so a configured
-            // v4-mapped literal gets the same logical-v4 treatment as a
-            // learned endpoint (#1736).
-            endpoint = Some(crate::afxdp::wg::canonicalize_endpoint(parsed));
+            match classify_wg_endpoint(&wire.wg_endpoint) {
+                WgEndpointForm::Literal(addr) => {
+                    // Canonicalize (unmap ::ffff:a.b.c.d) so a configured
+                    // v4-mapped literal gets the same logical-v4 treatment as
+                    // a learned endpoint (#1736).
+                    endpoint = Some(crate::afxdp::wg::canonicalize_endpoint(addr));
+                }
+                // #7158: a well-formed `host:port` with a DNS hostname is now
+                // ACCEPTED and resolved by the tunnel's endpoint resolver; the
+                // peer starts endpoint-less (exactly the learn-only/roaming
+                // state) until an answer arrives.
+                //
+                // The #5182 invariant is preserved, restated at the time of
+                // USE: an accepted endpoint becomes a real SocketAddr with the
+                // authored port before the peer initiates.
+                WgEndpointForm::Hostname => {
+                    endpoint_host = Some(wire.wg_endpoint.clone());
+                }
+                // Neither a usable literal nor a resolvable-shaped host:port:
+                // drop the ROW rather than coercing the peer to
+                // responder-only.
+                WgEndpointForm::Invalid => return None,
+            }
         }
         // PSK is OPTIONAL: an empty hex hydrates to the all-zero key
         // (no PSK). A malformed non-empty PSK drops the row (fail
@@ -343,6 +360,7 @@ pub(in crate::afxdp) fn hydrate_wg_identity(
         peers.push(WgRuntimePeer {
             pubkey: peer_pubkey,
             allowed_ips,
+            endpoint_host,
             endpoint,
             keepalive_secs: wire.wg_keepalive_secs,
             preshared_key,
@@ -376,5 +394,202 @@ fn hex_nibble(c: u8) -> Result<u8, ()> {
         b'a'..=b'f' => Ok(c - b'a' + 10),
         b'A'..=b'F' => Ok(c - b'A' + 10),
         _ => Err(()),
+    }
+}
+
+/// #7158: how the dataplane reads one authored WireGuard peer endpoint.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum WgEndpointForm {
+    /// A usable IP literal with a non-zero port.
+    Literal(SocketAddr),
+    /// A well-formed `host:port` whose host is a DNS name, to be resolved by
+    /// the tunnel's endpoint resolver.
+    Hostname,
+    /// Unusable: the peer row is dropped (fail closed).
+    Invalid,
+}
+
+/// The single endpoint decision, used by the hydrate AND by the cross-language
+/// agreement test. One function, so the test binds what production does rather
+/// than re-deriving it — a test that called `parse::<SocketAddr>()` itself
+/// would be testing the standard library and would have missed the zero-port
+/// hole below.
+pub(super) fn classify_wg_endpoint(s: &str) -> WgEndpointForm {
+    if let Ok(addr) = s.parse::<SocketAddr>() {
+        // `parse::<SocketAddr>()` ACCEPTS port 0 — "1.2.3.4:0" parses fine.
+        // Both this hydrate and the Go commit gate documented that it "rejects
+        // a missing/zero port"; the missing-port half is true, the zero-port
+        // half never was. The strict commit gate does reject port 0, so this
+        // only ever mattered on the TOLERANT load path, which downgrades that
+        // check to a warning — precisely the path this fail-closed hydrate
+        // exists to backstop (#5182). A port-0 peer "can initiate" to nowhere.
+        //
+        // Found by the cross-language agreement test, which is the only thing
+        // that COMPARES the two gates rather than each restating its own
+        // belief about the other.
+        if addr.port() == 0 {
+            return WgEndpointForm::Invalid;
+        }
+        return WgEndpointForm::Literal(addr);
+    }
+    if wg_endpoint_hostname_shape_ok(s) {
+        return WgEndpointForm::Hostname;
+    }
+    WgEndpointForm::Invalid
+}
+
+/// Does `s` look like a `host:port` whose host is a DNS name the
+/// endpoint resolver could plausibly resolve?
+///
+/// This is the dataplane half of a two-sided agreement: `endpointFamily` /
+/// `isDNSHostname` in `pkg/config/compiler_validate_wireguard.go` decide the
+/// same question at commit. The two must accept the same set, or a config
+/// commits clean and then silently drops the peer row here — the exact
+/// silent-degradation shape #5182 hardened this hydrate against.
+///
+/// Syntax only, and deliberately no DNS: this runs on the config-apply path,
+/// where a blocking lookup would stall the apply.
+pub(super) fn wg_endpoint_hostname_shape_ok(s: &str) -> bool {
+    // Reject a bracketed form here: `[..]:port` is the IPv6 literal spelling,
+    // so if it did not parse as a SocketAddr above it is a malformed literal,
+    // not a hostname.
+    if s.starts_with('[') {
+        return false;
+    }
+    let Some((host, port)) = s.rsplit_once(':') else {
+        return false;
+    };
+    match port.parse::<u16>() {
+        Ok(p) if p >= 1 => {}
+        _ => return false,
+    }
+    wg_endpoint_host_is_dns_name(host)
+}
+
+/// RFC 1123 hostname syntax, mirroring `isDNSHostname` on the Go side.
+fn wg_endpoint_host_is_dns_name(host: &str) -> bool {
+    if host.is_empty() || host.len() > 253 {
+        return false;
+    }
+    let host = host.strip_suffix('.').unwrap_or(host);
+    if host.is_empty() {
+        return false;
+    }
+    // All-digits-and-dots is a malformed IP literal, not a name. Accepting it
+    // would defer a certain failure to the resolver.
+    if host.bytes().all(|c| c.is_ascii_digit() || c == b'.') {
+        return false;
+    }
+    host.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|c| c.is_ascii_alphanumeric() || c == b'-')
+    })
+}
+
+#[cfg(test)]
+mod wg_endpoint_shape_7158_tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    /// #7158: the dataplane half of the cross-language agreement.
+    ///
+    /// Reads the SAME fixture as
+    /// `pkg/config`'s `TestWireguardEndpointShapeMatchesTheSharedFixture_7158`.
+    /// Two implementations decide which endpoint spellings are usable — the Go
+    /// commit gate and this hydrate — and they must accept the same set. An
+    /// endpoint Go accepts but this drops commits clean and then silently loses
+    /// the peer, which is the failure #5182 hardened the hydrate against.
+    ///
+    /// Binding both sides to one file is the point: two literal tables would
+    /// pass independently while disagreeing, which is exactly the bug.
+    #[test]
+    fn hydrate_accepts_the_same_endpoints_the_commit_gate_does_7158() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("test")
+            .join("fixtures")
+            .join("wg-endpoint-shape.txt");
+        let text = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!(
+                "the shared #7158 agreement fixture must be readable at {}: {e}. \
+                 Without it this test silently checks nothing",
+                path.display()
+            )
+        });
+
+        let mut checked = 0usize;
+        for line in text.lines() {
+            let line = line.trim_end();
+            if line.trim().is_empty() || line.trim_start().starts_with('#') {
+                continue;
+            }
+            let (endpoint, verdict) = line
+                .split_once('\t')
+                .unwrap_or_else(|| panic!("malformed fixture line {line:?}"));
+            checked += 1;
+
+            // Drive the PRODUCTION decision, not `parse` — see
+            // `classify_wg_endpoint`.
+            let form = classify_wg_endpoint(endpoint);
+            let literal = matches!(form, WgEndpointForm::Literal(_));
+            let hostname = form == WgEndpointForm::Hostname;
+            let accepted = literal || hostname;
+
+            match verdict {
+                "v4" | "v6" => {
+                    assert!(
+                        literal,
+                        "{endpoint:?}: the commit gate classifies this as an IP \
+                         literal of family {verdict}, but the hydrate cannot \
+                         parse it as a SocketAddr — the peer row would be dropped"
+                    );
+                    let WgEndpointForm::Literal(addr) = form else {
+                        unreachable!("checked literal above")
+                    };
+                    let want_v6 = verdict == "v6";
+                    assert_eq!(
+                        addr.is_ipv6(),
+                        want_v6,
+                        "{endpoint:?}: family disagreement between the commit \
+                         gate and the hydrate"
+                    );
+                }
+                "hostname" => {
+                    assert!(
+                        !literal,
+                        "{endpoint:?}: the fixture calls this a hostname but it \
+                         parses as a SocketAddr; the commit gate would classify \
+                         its family and constrain the mixed-family gate"
+                    );
+                    assert!(
+                        hostname,
+                        "{endpoint:?}: the commit gate ACCEPTS this as a DNS \
+                         hostname and the hydrate REJECTS it. That config commits \
+                         clean and then loses the peer with no diagnostic (#7158)"
+                    );
+                }
+                "reject" => {
+                    assert!(
+                        !accepted,
+                        "{endpoint:?}: the commit gate rejects this, but the \
+                         hydrate would accept it — a spelling the dataplane \
+                         honours and the operator cannot author"
+                    );
+                }
+                other => panic!("unknown verdict {other:?} in the shared fixture"),
+            }
+        }
+        // Non-vacuity: a fixture that failed to parse would leave every
+        // assertion above unrun and this test green.
+        assert!(
+            checked >= 20,
+            "only {checked} fixture cases were checked; the file is supposed to \
+             cover literals, hostnames, port rules and malformed hosts"
+        );
     }
 }

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -1048,6 +1048,16 @@ pub(in crate::afxdp) struct WgRuntimePeer {
     pub(in crate::afxdp) pubkey: [u8; 32],
     pub(in crate::afxdp) allowed_ips: Vec<ipnet::IpNet>,
     pub(in crate::afxdp) endpoint: Option<std::net::SocketAddr>,
+    /// #7158: the authored `host:port` when the endpoint is a DNS HOSTNAME
+    /// rather than a literal, so a peer behind a dynamic WAN (DDNS) is
+    /// authorable. `None` for a literal endpoint, which is every peer that
+    /// existed before #7158.
+    ///
+    /// `endpoint` stays `None` for such a peer until the tunnel's resolver
+    /// produces an address — the same state a learn-only/roaming peer is in at
+    /// spawn, which the per-peer outer-MTU resolution already handles by
+    /// falling back to the interface MTU.
+    pub(in crate::afxdp) endpoint_host: Option<String>,
     pub(in crate::afxdp) keepalive_secs: u16,
     /// Per-peer preshared key (#1434 B2), hex-decoded. 32 zero bytes =
     /// no PSK. Zeroized on drop; redacted in the Debug impl. Must never

--- a/userspace-dp/src/afxdp/wg/endpoint_resolver.rs
+++ b/userspace-dp/src/afxdp/wg/endpoint_resolver.rs
@@ -1,0 +1,290 @@
+//! #7158: DNS resolution for WireGuard peer endpoints authored as hostnames.
+//!
+//! A peer behind a dynamic WAN is reachable by a DDNS name, not a literal. The
+//! commit gate used to reject a hostname outright, which made that topology
+//! unauthorable. It is now accepted, and this is where the name becomes an
+//! address.
+//!
+//! ## Why a thread, and not a lookup in the control loop
+//!
+//! The WireGuard control loop is not a control-only loop: it blocks in `poll(2)`
+//! over `{UDP socket, TUN}` and carries the tunnel's DATA path. `to_socket_addrs`
+//! is a blocking call whose worst case is a resolver timeout — seconds. Calling
+//! it from that loop would not merely delay re-resolution, it would stall every
+//! packet on the tunnel behind a slow or unreachable DNS server, converting a
+//! name-service problem into a forwarding outage.
+//!
+//! So lookups happen here, on a thread that may block freely, and the loop reads
+//! the latest answer with an uncontended lock and never waits for one.
+//!
+//! ## Why not at commit either
+//!
+//! Two independent reasons, either sufficient — see `endpointFamily` in
+//! `pkg/config/compiler_validate_wireguard.go`, which is the other half of this
+//! decision:
+//!
+//! * a commit is a config transaction, and a lookup in it hangs commits on a
+//!   broken resolver, including the commit that would fix the resolver;
+//! * an answer cached at commit is correct at commit and silently stale a day
+//!   later, which is precisely what a DDNS name is for. That failure is worse
+//!   than not resolving, because it looks configured.
+//!
+//! ## Failure policy: retain the last good address
+//!
+//! A failed lookup changes nothing. The peer keeps the address that last worked,
+//! the session is untouched, and the failure is counted. The alternative —
+//! clearing the endpoint on a failed lookup — would tear down a working tunnel
+//! because a DNS server blinked, which inverts the dependency: the tunnel would
+//! become less reliable than the name service in front of it.
+//!
+//! The cost of retaining is a stale address after a real DDNS change while
+//! lookups are failing. That is the better failure: it is the same state the
+//! tunnel would be in anyway, it self-corrects on the next successful lookup,
+//! and it is visible in the counters below rather than silent.
+//!
+//! ## Visibility
+//!
+//! An operator whose tunnel is down because DNS is broken must be able to see
+//! that from the box rather than infer it. Every outcome is counted
+//! ([`WgEndpointResolverCounters`]) and the most recent failure text is
+//! retained, including the family-mismatch case — a name that resolves only to
+//! the family the interface socket cannot send from is a configuration error
+//! that would otherwise present as a peer that simply never initiates.
+
+use std::collections::HashMap;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Re-resolve cadence once a peer has an address. DDNS records carry short
+/// TTLs (commonly 60 s); 30 s picks up a change within roughly one TTL without
+/// making the tunnel a meaningful source of query load.
+pub(crate) const WG_ENDPOINT_RESOLVE_INTERVAL_SECS: u64 = 30;
+
+/// Retry cadence for a peer that has NO address yet. Faster than the steady
+/// cadence because this interval is bring-up latency: until the first answer
+/// the peer cannot initiate at all, so a 30 s wait would be 30 s of tunnel
+/// downtime after a resolver outage clears.
+pub(crate) const WG_ENDPOINT_RETRY_INTERVAL_SECS: u64 = 5;
+
+/// Granularity at which the resolver thread notices `stop`. Small enough that
+/// teardown is not perceptibly delayed, large enough not to spin.
+const STOP_POLL_SLICE_MS: u64 = 250;
+
+#[derive(Debug, Default)]
+pub(crate) struct WgEndpointResolverCounters {
+    /// Lookups that returned at least one usable address.
+    pub(crate) resolve_ok: AtomicU64,
+    /// Lookups that returned an error or no addresses at all.
+    pub(crate) resolve_fail: AtomicU64,
+    /// Lookups that SUCCEEDED but yielded no address of the interface socket's
+    /// family. Counted separately from `resolve_fail` because the operator
+    /// action differs: the name works and the record is wrong (or the tunnel is
+    /// bound to the wrong family), rather than the resolver being unreachable.
+    pub(crate) family_mismatch: AtomicU64,
+    /// Times a lookup produced an address DIFFERENT from the one held — the
+    /// DDNS-change signal, and the counter that shows re-resolution is doing
+    /// something rather than merely running.
+    pub(crate) endpoint_changed: AtomicU64,
+}
+
+struct ResolverShared {
+    /// Last good address per peer. A peer absent from this map has never
+    /// resolved; a peer present keeps its entry across failed lookups.
+    resolved: Mutex<HashMap<[u8; 32], SocketAddr>>,
+    /// Most recent failure text, for the operator-facing surface.
+    last_error: Mutex<Option<String>>,
+    counters: WgEndpointResolverCounters,
+    stop: AtomicBool,
+}
+
+/// Handle to one tunnel's endpoint-resolution thread.
+pub(crate) struct WgEndpointResolver {
+    shared: Arc<ResolverShared>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl WgEndpointResolver {
+    /// Start resolving `targets` (peer pubkey -> authored `host:port`).
+    ///
+    /// Returns `None` when there is nothing to resolve, so a tunnel whose peers
+    /// are all IP literals — every tunnel that existed before #7158 — starts no
+    /// thread and is bit-identical to its previous behaviour.
+    pub(crate) fn spawn(
+        tunnel_name: &str,
+        targets: Vec<([u8; 32], String)>,
+        socket_is_v6: bool,
+    ) -> Option<Self> {
+        if targets.is_empty() {
+            return None;
+        }
+        let shared = Arc::new(ResolverShared {
+            resolved: Mutex::new(HashMap::new()),
+            last_error: Mutex::new(None),
+            counters: WgEndpointResolverCounters::default(),
+            stop: AtomicBool::new(false),
+        });
+        let thread_shared = Arc::clone(&shared);
+        let name = format!("xpf-wg-dns-{tunnel_name}");
+        let join = std::thread::Builder::new()
+            .name(name)
+            .spawn(move || resolver_thread(thread_shared, targets, socket_is_v6))
+            .ok()?;
+        Some(Self {
+            shared,
+            join: Some(join),
+        })
+    }
+
+    /// The freshest address known for `pubkey`, or `None` if it has never
+    /// resolved. Never blocks on DNS — this is a map read under an uncontended
+    /// mutex, safe to call from the control loop's timer pass.
+    pub(crate) fn latest(&self, pubkey: &[u8; 32]) -> Option<SocketAddr> {
+        self.shared
+            .resolved
+            .lock()
+            .ok()
+            .and_then(|m| m.get(pubkey).copied())
+    }
+
+    /// Test-only constructor with pre-seeded answers and NO thread, so a
+    /// caller's adoption logic can be driven deterministically without a
+    /// resolver, a clock, or a sleep.
+    #[cfg(test)]
+    pub(crate) fn with_resolved_for_test(entries: &[([u8; 32], SocketAddr)]) -> Self {
+        let mut map = HashMap::new();
+        for (pk, addr) in entries {
+            map.insert(*pk, *addr);
+        }
+        Self {
+            shared: Arc::new(ResolverShared {
+                resolved: Mutex::new(map),
+                last_error: Mutex::new(None),
+                counters: WgEndpointResolverCounters::default(),
+                stop: AtomicBool::new(true),
+            }),
+            join: None,
+        }
+    }
+
+    pub(crate) fn counters(&self) -> &WgEndpointResolverCounters {
+        &self.shared.counters
+    }
+
+    /// Most recent failure text, for the operator surface.
+    pub(crate) fn last_error(&self) -> Option<String> {
+        self.shared.last_error.lock().ok().and_then(|e| e.clone())
+    }
+}
+
+impl Drop for WgEndpointResolver {
+    fn drop(&mut self) {
+        self.shared.stop.store(true, Ordering::Relaxed);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+/// One resolution pass over every target. Split out so it is testable without
+/// a thread or a clock.
+///
+/// Returns the number of targets that hold an address after the pass, which the
+/// thread uses to choose its next cadence.
+fn resolve_once(
+    shared: &ResolverShared,
+    targets: &[([u8; 32], String)],
+    socket_is_v6: bool,
+) -> usize {
+    let mut held = 0usize;
+    for (pubkey, host_port) in targets {
+        match host_port.to_socket_addrs() {
+            Ok(addrs) => {
+                // Keep only the family the interface's single UDP socket can
+                // send from. A dual-stack name on a v4 socket must yield its A
+                // record, not whichever answer happened to sort first.
+                let chosen = addrs.into_iter().find(|a| a.is_ipv6() == socket_is_v6);
+                match chosen {
+                    Some(addr) => {
+                        shared.counters.resolve_ok.fetch_add(1, Ordering::Relaxed);
+                        if let Ok(mut map) = shared.resolved.lock() {
+                            let prior = map.insert(*pubkey, addr);
+                            if prior != Some(addr) {
+                                shared
+                                    .counters
+                                    .endpoint_changed
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                    None => {
+                        shared
+                            .counters
+                            .family_mismatch
+                            .fetch_add(1, Ordering::Relaxed);
+                        set_last_error(
+                            shared,
+                            format!(
+                                "{host_port} resolved, but to no {} address; \
+                                 this WireGuard interface binds one {} UDP socket",
+                                if socket_is_v6 { "IPv6" } else { "IPv4" },
+                                if socket_is_v6 { "IPv6" } else { "IPv4" },
+                            ),
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                shared.counters.resolve_fail.fetch_add(1, Ordering::Relaxed);
+                set_last_error(shared, format!("{host_port}: {e}"));
+                // Deliberately no removal from `resolved`: the last good
+                // address is retained across a failed lookup. See the module
+                // header for why tearing down here would make the tunnel less
+                // reliable than the name service.
+            }
+        }
+        if shared
+            .resolved
+            .lock()
+            .map(|m| m.contains_key(pubkey))
+            .unwrap_or(false)
+        {
+            held += 1;
+        }
+    }
+    held
+}
+
+fn set_last_error(shared: &ResolverShared, msg: String) {
+    if let Ok(mut slot) = shared.last_error.lock() {
+        *slot = Some(msg);
+    }
+}
+
+fn resolver_thread(
+    shared: Arc<ResolverShared>,
+    targets: Vec<([u8; 32], String)>,
+    socket_is_v6: bool,
+) {
+    while !shared.stop.load(Ordering::Relaxed) {
+        let held = resolve_once(&shared, &targets, socket_is_v6);
+        // Fast cadence while any peer still has no address at all: that
+        // interval is tunnel downtime, not staleness.
+        let wait_secs = if held < targets.len() {
+            WG_ENDPOINT_RETRY_INTERVAL_SECS
+        } else {
+            WG_ENDPOINT_RESOLVE_INTERVAL_SECS
+        };
+        let slices = (wait_secs * 1000) / STOP_POLL_SLICE_MS;
+        for _ in 0..slices {
+            if shared.stop.load(Ordering::Relaxed) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(STOP_POLL_SLICE_MS));
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "endpoint_resolver_tests.rs"]
+mod endpoint_resolver_tests;

--- a/userspace-dp/src/afxdp/wg/endpoint_resolver_tests.rs
+++ b/userspace-dp/src/afxdp/wg/endpoint_resolver_tests.rs
@@ -1,0 +1,191 @@
+//! #7158 endpoint-resolver tests.
+//!
+//! Hermetic: every fixture uses either an IP literal (which `to_socket_addrs`
+//! parses without touching a resolver) or a syntactically invalid target (which
+//! it rejects with `InvalidInput`, also without touching a resolver). No test
+//! here depends on a name existing, on `/etc/hosts`, or on the sandbox having
+//! working DNS — a resolver-dependent fixture would fail differently on a
+//! developer box and in CI, and the failure would look like the code.
+
+use super::*;
+
+const PK_A: [u8; 32] = [0xAA; 32];
+const PK_B: [u8; 32] = [0xBB; 32];
+
+/// A target `to_socket_addrs` rejects immediately, with no network involved.
+const UNRESOLVABLE: &str = "this-target-has-no-port";
+
+fn shared() -> ResolverShared {
+    ResolverShared {
+        resolved: Mutex::new(HashMap::new()),
+        last_error: Mutex::new(None),
+        counters: WgEndpointResolverCounters::default(),
+        stop: AtomicBool::new(false),
+    }
+}
+
+/// #7158 acceptance 4: a failed lookup must retain the last-good address and
+/// leave the session alone.
+///
+/// The policy this pins is not obvious and is the one a future reader is most
+/// likely to "simplify": clearing the entry on failure looks like correct
+/// cache hygiene. It would tear down a working tunnel because a DNS server
+/// blinked, making the tunnel strictly less reliable than the name service in
+/// front of it.
+///
+/// FAIL-ON-REVERT: add a `map.remove(pubkey)` to the `Err` arm of
+/// `resolve_once` and the retained-address assertion goes RED.
+#[test]
+fn a_failed_lookup_retains_the_last_good_endpoint_7158() {
+    let sh = shared();
+
+    // Pass 1: resolves.
+    let good = vec![(PK_A, "203.0.113.7:51820".to_string())];
+    assert_eq!(resolve_once(&sh, &good, false), 1);
+    let first = sh.resolved.lock().unwrap().get(&PK_A).copied();
+    assert_eq!(
+        first,
+        Some("203.0.113.7:51820".parse().unwrap()),
+        "precondition: the address must be held before failure can retain it"
+    );
+
+    // Pass 2: the SAME peer, now unresolvable.
+    let bad = vec![(PK_A, UNRESOLVABLE.to_string())];
+    assert_eq!(
+        resolve_once(&sh, &bad, false),
+        1,
+        "the peer still HOLDS an address after a failed lookup, so it is not \
+         counted as awaiting one — a peer with a stale address must not put \
+         the thread into its fast bring-up cadence"
+    );
+
+    assert_eq!(
+        sh.resolved.lock().unwrap().get(&PK_A).copied(),
+        first,
+        "a failed lookup must leave the last-good endpoint in place. Clearing \
+         it here drops a working peer to responder-only because DNS blinked \
+         (#7158)"
+    );
+    assert_eq!(
+        sh.counters.resolve_fail.load(Ordering::Relaxed),
+        1,
+        "the failure must be COUNTED — an operator whose tunnel is stale \
+         because DNS is broken has to be able to see that from the box"
+    );
+    assert!(
+        sh.last_error.lock().unwrap().is_some(),
+        "the failure text must be retained for the operator surface"
+    );
+}
+
+/// #7158: only addresses of the interface socket's family may be adopted, and a
+/// name that resolves to the wrong family is a COUNTED, named condition rather
+/// than a peer that silently never initiates.
+///
+/// This is what replaces the commit-time family gate for hostnames: the family
+/// is unknowable at commit, so it is enforced here, where it is known.
+#[test]
+fn only_addresses_of_the_socket_family_are_adopted_7158() {
+    // A v4-only target against a v6 socket.
+    let sh = shared();
+    let v4_target = vec![(PK_A, "203.0.113.7:51820".to_string())];
+    assert_eq!(
+        resolve_once(&sh, &v4_target, true),
+        0,
+        "no address is held: the only answer is the wrong family"
+    );
+    assert!(
+        sh.resolved.lock().unwrap().is_empty(),
+        "a v4 answer must not be adopted by a v6 socket — sending from it is \
+         impossible, so adopting it would present as a peer that initiates and \
+         never connects"
+    );
+    assert_eq!(
+        sh.counters.family_mismatch.load(Ordering::Relaxed),
+        1,
+        "counted separately from resolve_fail: the name WORKS and the record \
+         (or the tunnel's family) is wrong, which is a different operator action"
+    );
+    assert_eq!(
+        sh.counters.resolve_fail.load(Ordering::Relaxed),
+        0,
+        "a successful lookup of the wrong family is not a lookup failure"
+    );
+
+    // Positive control: the same target on a v4 socket IS adopted, so the
+    // emptiness above is the family filter and not a broken fixture.
+    let sh4 = shared();
+    assert_eq!(resolve_once(&sh4, &v4_target, false), 1);
+    assert_eq!(
+        sh4.resolved.lock().unwrap().get(&PK_A).copied(),
+        Some("203.0.113.7:51820".parse().unwrap())
+    );
+    assert_eq!(sh4.counters.family_mismatch.load(Ordering::Relaxed), 0);
+}
+
+/// #7158: `endpoint_changed` must count actual CHANGES, not lookups.
+///
+/// It is the operator's evidence that re-resolution is doing something. If it
+/// ticked once per pass it would read as a DDNS change every 30 s on a
+/// perfectly static name, which is worse than not having the counter.
+#[test]
+fn endpoint_changed_counts_changes_not_lookups_7158() {
+    let sh = shared();
+    let t1 = vec![(PK_A, "203.0.113.7:51820".to_string())];
+    resolve_once(&sh, &t1, false);
+    resolve_once(&sh, &t1, false);
+    resolve_once(&sh, &t1, false);
+    assert_eq!(
+        sh.counters.endpoint_changed.load(Ordering::Relaxed),
+        1,
+        "three lookups of an unchanged name are ONE change (the first, from \
+         nothing to an address)"
+    );
+    assert_eq!(sh.counters.resolve_ok.load(Ordering::Relaxed), 3);
+
+    // The DDNS move.
+    let t2 = vec![(PK_A, "198.51.100.9:51820".to_string())];
+    resolve_once(&sh, &t2, false);
+    assert_eq!(
+        sh.counters.endpoint_changed.load(Ordering::Relaxed),
+        2,
+        "an address change at the name must be counted"
+    );
+    assert_eq!(
+        sh.resolved.lock().unwrap().get(&PK_A).copied(),
+        Some("198.51.100.9:51820".parse().unwrap()),
+        "and adopted — acceptance 3 is that a DDNS move is picked up with no \
+         commit and no daemon restart"
+    );
+}
+
+/// #7158 acceptance 6: a tunnel whose peers are all IP literals must be
+/// bit-identical to its pre-#7158 behaviour, which starts with not existing.
+#[test]
+fn a_tunnel_with_no_hostname_peers_starts_no_resolver_7158() {
+    assert!(
+        WgEndpointResolver::spawn("wg0", Vec::new(), false).is_none(),
+        "no hostname peers means no thread: every tunnel that existed before \
+         #7158 must not acquire one"
+    );
+}
+
+/// #7158: per-peer isolation — one peer's failure must not disturb another's
+/// held address, since they share the resolver pass.
+#[test]
+fn one_peers_failure_does_not_disturb_another_7158() {
+    let sh = shared();
+    let targets = vec![
+        (PK_A, "203.0.113.7:51820".to_string()),
+        (PK_B, UNRESOLVABLE.to_string()),
+    ];
+    let held = resolve_once(&sh, &targets, false);
+    assert_eq!(held, 1, "only PK_A holds an address");
+    assert_eq!(
+        sh.resolved.lock().unwrap().get(&PK_A).copied(),
+        Some("203.0.113.7:51820".parse().unwrap()),
+        "PK_A resolved before PK_B failed in the same pass; the failure must \
+         not abort the pass or discard earlier work"
+    );
+    assert!(sh.resolved.lock().unwrap().get(&PK_B).is_none());
+}

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -89,6 +89,7 @@ pub(crate) mod counters;
 // MAC2) is PR-B; the inbound type-3 arm stays drop-only here.
 pub(crate) mod cookie;
 pub(crate) mod dscp;
+pub(crate) mod endpoint_resolver;
 pub(crate) mod engine;
 pub(crate) mod framing;
 // WireGuard S1 (#1709): on-wire handshake-message framing (type 1/2,


### PR DESCRIPTION
A peer `endpoint` had to be an IP literal, so a peer behind a dynamic WAN —
reachable only by a DDNS name — was a **hard reject at commit** and the
documented UniFi topology was unauthorable.

## The three design questions, settled before any parser work

**Where does resolution happen? Not at commit.** A lookup there is a blocking
network call inside a config transaction, so a broken resolver hangs commits —
including the commit that would *fix* the resolver. And an answer cached at
commit is correct at commit and silently stale a day later, which is precisely
what a DDNS name is for; that failure is worse than not resolving, because it
looks configured.

**And not in the WireGuard control loop** — the sharper constraint, and not
obvious until read against the code. That loop is **not control-only**: it
blocks in `poll(2)` over `{UDP socket, TUN}` and carries the tunnel's **data
path**. A blocking `to_socket_addrs` there would stall every packet on the
tunnel behind a slow resolver, turning a name-service problem into a forwarding
outage. There is no DNS anywhere in the helper today, so this is the first, and
it went on its own thread. A tunnel whose peers are all literals starts **no
thread at all**.

**What happens on failure? Retain the last-good address.** Clearing it looks
like correct cache hygiene and would tear down a working tunnel because a DNS
server blinked — making the tunnel strictly less reliable than the name service
in front of it. The cost is a stale address after a real DDNS move *while
lookups are failing*: the state the tunnel would be in anyway, self-correcting
on the next success, and counted rather than silent.

**DNS or a learned roam? The roam, for one attempt window.** An authenticated
datagram pins the endpoint for `REKEY_ATTEMPT_TIME`. The authenticated source is
where the peer **really** is, including its NAT; DNS is only where it *claims*
to be reachable, so DNS must not move a peer that is actively talking to us.
After a full attempt window of silence the learned address has already failed to
produce a handshake — it has stopped being evidence — and DNS takes over, which
is the case this feature exists for.

The #5182 invariant is **preserved, not relaxed**, restated at the time of USE:
every accepted endpoint becomes a real `SocketAddr` with the authored port
before the peer initiates. Port rules stay strict because a port *is* knowable
at commit.

A hostname's family is unknowable at commit, so it does not participate in the
one-UDP-socket mixed-family gate; literals still pin the family between
themselves, so **every config that gate rejected before still rejects**
(acceptance 5). The family is enforced where it becomes knowable — the resolver
keeps only answers matching the socket's family, counted separately from
lookup failures because the operator action differs.

## What the agreement test found

`test/fixtures/wg-endpoint-shape.txt` is read by **both** the Go commit test and
the Rust hydrate test, so the two gates are asserted to agree rather than each
restating its own belief about the other. **It failed on its first run.**

Rust's `parse::<SocketAddr>()` **accepts port 0**. Both sides documented that the
hydrate "rejects a missing/zero port" — the missing-port half is true, the
zero-port half never was. The strict gate does reject it, so this only mattered
on the **tolerant load path**, which is exactly the path this fail-closed hydrate
exists to backstop. Closed, and both stale comments corrected.

The test also first compared `parse::<SocketAddr>()` directly — testing the
standard library rather than the hydrate's decision, and blind to the fix. The
decision was extracted into `classify_wg_endpoint` and the test bound to it.

## A defect caught reviewing my own diff

The family classification sits **above** the allowed-ips gates in the per-peer
loop. The obvious spelling for "a hostname does not constrain the family" is
`continue` — which continues the **peer** loop and exempts every hostname peer
from the malformed-CIDR and duplicate-prefix checks: commit-clean, then dropped
at hydrate with no diagnostic. Scoped to `if fam != nil` and guarded.

## Mutation matrix

Rust full suite `--test-threads=1` plus `go test ./pkg/config/`.

| cell | edit | verdict | reds |
|------|------|---------|------|
| control | none | GREEN (rust 4859, go clean) | — |
| m1 | restore the pre-#7158 hostname reject | RED | shared fixture + both feature tests |
| m2 | `continue` instead of the scoped `if` | RED | the allowed-ips guard, alone |
| m3 | let the hydrate take port 0 | RED | the agreement test, alone |
| m4 | drop the entry when a lookup fails | RED | last-good retention, alone |
| m5 | let DNS overwrite a live roam | RED | roam precedence, alone |

m2's first attempt was a **VOID, not a red** — the edit broke the Go build, so
`rc=1` with zero named failures. Re-done line-anchored.

Resolver tests are hermetic: every fixture is an IP literal (parsed without a
resolver) or a syntactically invalid target (rejected without one), so no test
depends on a name existing or on the sandbox having DNS.

## Follow-up filed

https://github.com/psaab/xpf/issues/7936 — the four resolver counters are in-process only and not yet on the
status wire or Prometheus. The narrative half of visibility (endpoint-move log
line, retained error text) is present; the countable half is not, and widening
this change to carry it was not worth the coupling.

Docs: `docs/config-schema.md`'s WireGuard gate entry rewritten; reasoning in
`docs/log/7158.md`.

Closes #7158