### PR TITLE
Bounded startup promotion hold for no-RETH modes (#7162)

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -82,6 +82,53 @@ yet. Here is what is true today:
     cold-boot RG starts not-ready and may never see a readiness TRANSITION, so
     arming from the transition branch would leave it unarmed in precisely the
     case it exists for.
+- Bounded startup promotion hold for `no-reth-vrrp` / `private-rg-election`
+  (#7162). RETH VRRP mode has suppressed startup preemption since #466
+  (`vrrp.Manager.SetSyncHold`, 30s, armed once at bringup, released by bulk
+  session sync or its own timer). These modes had no equivalent —
+  `checkNoRethTakeoverReadiness` was VIP ownership and nothing else — so a node
+  could promote an RG before bulk sync delivered any conntrack/NAT state and
+  every established flow reset on the transition.
+
+  `Daemon.armNoRethSyncHold` (`pkg/daemon/daemon_ha_noreth_hold.go`) is the
+  sibling: same 30s bound, armed at the same bringup site, consulted by
+  `checkNoRethTakeoverReadiness`, released by bulk sync
+  (`bulk-sync-complete`) or its own timer (`timeout-degraded`).
+
+  **It is a bounded HOLD, not a `cluster.IsSyncReady()` conjunct, and the
+  difference is the whole of #110.** `syncReady` has no bound while the
+  session-sync channel is down (`armSyncReadyTimer` early-returns unless
+  `syncPeerConnected`), and the election blocks a not-ready RG whenever the peer
+  is alive — so a sync-flag conjunct blocks promotion INDEFINITELY when the peer
+  is up on the control link with session sync down, which is exactly the
+  degraded-peer case preemption exists for. Two properties keep this one
+  bounded, and both are pinned by tests:
+  - the timer callback consults NO peer condition — not `syncPeerConnected`, not
+    `peerAlive`, not `IsSyncReady()`. A release that depended on the peer would
+    be no release at all, because the peer being absent is why the hold is still
+    held.
+  - it is armed EXACTLY ONCE at bringup and never re-armed on reconnect, which
+    keeps it a startup hold rather than a mid-life block.
+
+  Releasing the hold DRIVES a reconcile (`triggerReconcile`). Readiness is
+  recomputed per reconcile pass, so without that the RG would sit secondary until
+  an unrelated event happened to trigger one — bounded in name only. The RETH
+  sibling meets the same obligation with `triggerPreemptNow()`.
+
+  Interaction with #7161: on a cold boot the readiness gate now applies, so the
+  hold and the gate compose — the node holds secondary for the hold window, then
+  promotes when readiness recomputes. The #7161 degraded-promotion fallback
+  (2 min) is a strictly longer backstop, so the 30s hold is the binding
+  constraint.
+
+  **Observability:** `show chassis cluster information` gains a
+  `Startup promotion hold:` block reporting the mode (`reth-vrrp` / `no-reth`),
+  whether it is still holding, and how it ended. The RETH hold had recorded
+  `bulk-sync-complete` / `timeout-degraded` since #466 and surfaced it NOWHERE,
+  so an operator could not distinguish a normal startup from one that promoted
+  degraded because sync never arrived — which is precisely the explanation for a
+  flow reset after a boot. While the hold is active it also appears in the RG's
+  `Takeover ready: no (...)` reasons.
 - Blackhole routes skipped in userspace mode (#354)
 - Helper watchdog threshold aligned with sync cadence (#349)
 - Reverse companions pre-installed via sync path (#310)

--- a/docs/log/7162.md
+++ b/docs/log/7162.md
@@ -1,0 +1,67 @@
+# #7162 — bounded startup promotion hold for no-reth-vrrp / private-rg-election
+
+- **Timestamp**: 2026-08-29
+- **Action**: added the no-RETH sibling of the RETH VRRP startup sync hold;
+  surfaced both holds in `show chassis cluster information`; corrected the three
+  #7102 comments.
+- **File(s)**: `pkg/daemon/daemon_ha_noreth_hold.go` (new), `pkg/daemon/daemon.go`,
+  `pkg/daemon/daemon_run_bringup.go`, `pkg/daemon/daemon_ha_sync.go`,
+  `pkg/daemon/daemon_ha_vip.go`, `pkg/cluster/manager.go`,
+  `pkg/cluster/status.go`, `pkg/cluster/sync_state.go`,
+  `pkg/daemon/noreth_sync_hold_7162_test.go` (new),
+  `pkg/daemon/vip_readiness_test.go`, `docs/ha-failover-status.md`
+
+## Premise verified at `ee0a3a294`
+
+All three legs hold. `SetSyncHold(30s)` is armed at exactly one site
+(`daemon_run_bringup.go`) and only when `!cc.NoRethVRRP && !cc.PrivateRGElection`;
+`takeoverReadinessForRG` routes those modes to `checkNoRethTakeoverReadiness`,
+which was `return d.checkVIPReadiness(rgID)` and nothing else.
+
+## The issue's "tests that will red by design" prediction did NOT hold — and that
+## is a finding, not a discrepancy to paper over
+
+The issue says `TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady` and its
+`_7102` sibling "pin the current ungated behaviour" and "must be REPLACED". Both
+still PASS against this change.
+
+They are right to. Those fixtures construct a Daemon and call `reconcileRGState`
+directly; they never arm the hold, and the property they assert is that the gate
+does not consult `cluster.IsSyncReady()` — which is still TRUE here, because this
+implementation deliberately does not use that flag.
+
+The prediction was made assuming an implementation that gates on `IsSyncReady()`
+— **the exact shape the same issue's "What must NOT be built" section forbids**.
+Building the right thing leaves those tests valid. So they were KEPT, and their
+doc comments corrected: they still pin something load-bearing (the gate is the
+HOLD, never the FLAG), and the sentence claiming they would red if a gate
+returned is superseded — they red if the FLAG becomes a gate, which is still the
+thing to prevent.
+
+Six new cells cover the hold itself: blocks-before-bulk (with a control that the
+fixture is otherwise ready), released-by-bulk-sync, released-on-timeout-with-no-
+peer (the #110 shape), release-triggers-reconcile, absent-when-never-armed (the
+over-reach control), and release-is-first-wins.
+
+## The #110 trap, third instance
+
+#7161 had two: the named one (do not gate the fallback on a peer condition) and
+one I found (arming from `SetRGReady`'s transition branch leaves it unarmed for
+an RG that never transitions). This is the third and it is a different layer
+again: **releasing the hold must DRIVE a reconcile**, because readiness is only
+recomputed on a reconcile pass. A release that merely flips the flag is bounded
+in name only — the bound would be on when the flag changes rather than on when
+anything acts on it. Pinned by
+`TestNoRethSyncHoldReleaseTriggersReconcile7162`.
+
+## Flake disclosure
+
+Three full-suite runs on this branch: r1 failed `TestKeyReaderDiscardsKeyAfterDone`
+(pkg/cli), r2 failed `TestStartHeartbeatDoesNotRaceStopHeartbeat7257`
+(pkg/cluster, at exactly its 30.00s bound), r3 green 69/69. Both failures pass
+3x in isolation on this branch AND on unmodified master. A full-suite control on
+unmodified master under comparable load (11.4 vs 12.8) was green 69/69.
+
+Reported rather than resolved: never the same test twice, both unrelated
+concurrency tests, but the master control being green is the complicating fact
+and is stated rather than omitted.

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -497,6 +497,16 @@ type Manager struct {
 	// once readiness is established.
 	takeoverHoldTime time.Duration
 
+	// #7162 startup sync-hold status, fed by the daemon. The hold itself lives
+	// in the daemon (no-RETH) or in vrrp.Manager (RETH); this is the reporting
+	// mirror so `show chassis cluster information` can say why promotion was
+	// suppressed at startup and how the suppression ended. Before #7162 the
+	// VRRP hold recorded a reason (`bulk-sync-complete` / `timeout-degraded`)
+	// and surfaced it NOWHERE.
+	startupHoldMode   string // "reth-vrrp" | "no-reth" | ""
+	startupHoldActive bool
+	startupHoldReason string // set once the hold ends
+
 	// degradedPromoteTimeout bounds how long the #7161 cold-boot readiness gate
 	// may hold an RG secondary. After this much CONTINUOUS not-readiness the RG
 	// promotes anyway, with the reason surfaced, so a readiness bug can never
@@ -510,13 +520,13 @@ type Manager struct {
 	degradedPromoteTimeout time.Duration
 
 	// syncReady is true once bulk session sync has been received (or the
-	// readiness timeout released the hold). It gates NOTHING: no consumer
-	// reads it to decide RG promotion, in private-rg-election / no-reth-vrrp
-	// mode or any other (#7102). It was the no-RETH equivalent of the VRRP
-	// sync-hold until 0781f7a60 removed that gate; today its only production
-	// readers are the readiness timeout in pkg/daemon/daemon_ha_sync.go and
-	// two log fields. See SetSyncReady in sync_state.go for the full account
-	// and #110 for whether the gate should return.
+	// readiness timeout released it). See SetSyncReady in sync_state.go for the
+	// full account of what it does and does not gate.
+	//
+	// #7162: startup promotion in no-RETH / private-rg-election mode IS now
+	// gated — by Daemon.armNoRethSyncHold's BOUNDED hold, not by this flag.
+	// This flag remains unbounded while the sync channel is down and must not
+	// become a readiness conjunct (#110).
 	syncReady bool
 
 	// syncTransport records whether session sync uses "fabric" or

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -416,6 +416,8 @@ func (m *Manager) FormatInformation() string {
 	// remote CLI (both render this same function). Suppressed entirely when
 	// fencing was never configured and never fired, matching the
 	// conditional style of the sections around it.
+	b.WriteString(m.formatStartupSyncHold())
+
 	fenceAction, fenceEvents := m.FenceStatus()
 	if fenceAction != "" || len(fenceEvents) > 0 {
 		fmt.Fprintln(&b, "Peer fencing:")
@@ -1102,4 +1104,61 @@ func epochlessExposureNote(s HeartbeatStats) string {
 		return "  (downgrade latch armed; count is historical)"
 	}
 	return "  (peer not signing boot epochs - replay protection is ring-only; rotate the control-link PSK once both nodes are upgraded)"
+}
+
+// SetStartupSyncHoldStatus records the startup promotion-hold state for
+// `show chassis cluster information` (#7162).
+//
+// The hold mechanisms live outside this package — vrrp.Manager for RETH VRRP
+// mode, the daemon for no-reth-vrrp / private-rg-election — so this is a
+// reporting mirror rather than the state itself. `mode` names which one, `active`
+// is whether it is still holding, and `reason` is why it ended
+// ("bulk-sync-complete" or "timeout-degraded"), empty while it is still active.
+//
+// Both paths report here because before #7162 neither was visible: the VRRP hold
+// had recorded a reason since #466 and rendered it nowhere, so an operator could
+// not distinguish "startup sync completed normally" from "sync never arrived and
+// we promoted degraded" — which is exactly the distinction that explains a flow
+// reset after a boot.
+func (m *Manager) SetStartupSyncHoldStatus(mode string, active bool, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.startupHoldMode = mode
+	m.startupHoldActive = active
+	if reason != "" {
+		m.startupHoldReason = reason
+	}
+}
+
+// StartupSyncHoldStatus returns the recorded startup hold state.
+func (m *Manager) StartupSyncHoldStatus() (mode string, active bool, reason string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.startupHoldMode, m.startupHoldActive, m.startupHoldReason
+}
+
+// formatStartupSyncHold renders the startup promotion hold block, or nothing
+// when no hold was ever armed (this node is standalone, or predates the arming
+// path) — matching the conditional style of the sections around it.
+func (m *Manager) formatStartupSyncHold() string {
+	mode, active, reason := m.StartupSyncHoldStatus()
+	if mode == "" {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, "Startup promotion hold:")
+	fmt.Fprintf(&b, "  Mode: %s\n", mode)
+	switch {
+	case active:
+		fmt.Fprintln(&b, "  State: HOLDING (waiting for bulk session sync)")
+	case reason == "timeout-degraded":
+		fmt.Fprintln(&b, "  State: released DEGRADED (bulk sync did not complete "+
+			"within the hold; promotion proceeded without synced session state)")
+	case reason != "":
+		fmt.Fprintf(&b, "  State: released (%s)\n", reason)
+	default:
+		fmt.Fprintln(&b, "  State: released")
+	}
+	fmt.Fprintln(&b)
+	return b.String()
 }

--- a/pkg/cluster/sync_state.go
+++ b/pkg/cluster/sync_state.go
@@ -13,13 +13,24 @@ type SyncStatsProvider interface {
 //
 // It does NOT gate RG promotion, in private-rg-election mode or any other
 // (#7102). Say that plainly, because the opposite belief is the one #110 was
-// filed to prevent and this comment used to assert it: promotion readiness in
-// no-RETH / private-rg-election mode is VIP ownership ALONE
-// (checkNoRethTakeoverReadiness -> checkVIPReadiness, pkg/daemon), and the
-// readiness conjunction that consumes it — ifReady && takeoverGateReady &&
-// fabricReady && userspaceReady, in daemon_ha_userspace_readiness.go — carries
-// no sync term. A node in this mode can therefore take over an RG before bulk
-// session sync has completed.
+// filed to prevent and this comment used to assert it: this FLAG is not a term
+// in the readiness conjunction (ifReady && takeoverGateReady && fabricReady &&
+// userspaceReady, in daemon_ha_userspace_readiness.go).
+//
+// #7162 UPDATE — read this before concluding that startup promotion is
+// ungated. It no longer is, but the gate is NOT this flag. no-RETH /
+// private-rg-election mode now takes a BOUNDED startup hold
+// (Daemon.armNoRethSyncHold, pkg/daemon/daemon_ha_noreth_hold.go), which
+// checkNoRethTakeoverReadiness consults, so a node does not promote before bulk
+// session sync during the hold window.
+//
+// The distinction is the entire point and must not be collapsed: the hold
+// releases itself after a fixed duration whatever sync does, whereas THIS flag
+// has no bound while the sync channel is down (armSyncReadyTimer early-returns
+// unless syncPeerConnected). Making this flag a readiness conjunct would block
+// promotion indefinitely with the peer alive on the control link and session
+// sync down — including the degraded-peer case preemption exists for. That is
+// what #110 measured and rejected. Do not "simplify" the hold into this flag.
 //
 // The gate DID exist: reconcileRGState set vrrpReady = d.cluster.IsSyncReady()
 // in no-RETH mode and reported "session sync not ready" as a takeover blocker,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -557,6 +557,23 @@ type Daemon struct {
 	syncReadyTimer     *time.Timer
 	syncReadyTimeout   time.Duration
 
+	// #7162 no-RETH startup promotion hold. RETH VRRP mode suppresses
+	// preemption at startup until bulk session sync completes
+	// (vrrp.Manager.SetSyncHold); no-reth-vrrp and private-rg-election mode had
+	// no equivalent, so a node in those modes could take over an RG before any
+	// conntrack/NAT state had arrived and reset every established flow.
+	//
+	// This is a BOUNDED hold, not a sync-readiness conjunct. The distinction is
+	// the whole point of #110: a continuous `IsSyncReady()` term in the
+	// readiness AND has no bound when the session-sync channel is down, so a
+	// peer alive on the control link with sync down blocks promotion FOREVER —
+	// including the degraded-peer case preemption exists for. This holds for a
+	// fixed duration and then releases itself no matter what.
+	noRethSyncHoldMu     sync.Mutex
+	noRethSyncHoldTimer  *time.Timer
+	noRethSyncHold       atomic.Bool
+	noRethSyncHoldReason atomic.Value // string: why the hold ended
+
 	// #5863: config-sync to a reconnecting peer is level-triggered, not a
 	// one-shot connect edge. syncPeerConnEpoch is bumped on every peer sync
 	// (re)connect so the reconciler can tell one live connection from the

--- a/pkg/daemon/daemon_ha_noreth_hold.go
+++ b/pkg/daemon/daemon_ha_noreth_hold.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"log/slog"
+	"time"
+)
+
+// The #7162 no-RETH startup promotion hold.
+//
+// RETH VRRP mode has had a bounded startup suppression since #466:
+// `vrrp.Manager.SetSyncHold(30s)`, armed once at daemon bringup and released by
+// bulk session sync or by its own timer. `no-reth-vrrp` and
+// `private-rg-election` mode had no equivalent — `checkNoRethTakeoverReadiness`
+// is VIP ownership and nothing else — so a node in those modes could promote an
+// RG at startup before bulk sync had delivered any conntrack/NAT state, and
+// every established TCP flow reset on the transition.
+//
+// WHAT THIS DELIBERATELY IS NOT. It is not a continuous `IsSyncReady()` conjunct
+// in the readiness AND. That is the shape #110 measured and rejected, and it is
+// worth stating so nobody "simplifies" this into it: `syncReady` has no bound
+// while the session-sync channel is down (`armSyncReadyTimer` early-returns
+// unless `d.syncPeerConnected`), and the election blocks a not-ready RG whenever
+// the peer is alive. Peer alive on the CONTROL link with session sync down would
+// then block promotion INDEFINITELY — including the degraded-peer case
+// (peer up, weight 0, interfaces down) that preemption exists to handle.
+//
+// So the hold is bounded by construction:
+//
+//   - it is armed EXACTLY ONCE, at daemon bringup, mirroring SetSyncHold's
+//     arming scope. It is never re-armed on reconnect, which is what keeps it a
+//     STARTUP hold rather than a mid-life block.
+//   - its timer callback consults NO peer condition — not `syncPeerConnected`,
+//     not `peerAlive`, not `cluster.IsSyncReady()`. This is the #110 trap
+//     restated: `armSyncReadyTimer`'s callback bails on `!d.syncPeerConnected`,
+//     so that fallback never fires in exactly the peer-absent case it exists
+//     for. A release that depended on the peer would be no release at all,
+//     because the peer being absent is the reason the hold is still held.
+//
+// The two release edges are bulk-sync completion (the good one) and the timer
+// (the degraded one), and both record which fired so `show chassis cluster` can
+// say so.
+
+// noRethSyncHoldTimeout mirrors the RETH VRRP sync hold's 30s. Same job, same
+// bound, so an operator reading either path sees the same startup behaviour.
+const noRethSyncHoldTimeout = 30 * time.Second
+
+// armNoRethSyncHold starts the bounded startup hold. Call once, at bringup.
+func (d *Daemon) armNoRethSyncHold(timeout time.Duration) {
+	if d == nil {
+		return
+	}
+	if timeout <= 0 {
+		timeout = noRethSyncHoldTimeout
+	}
+	d.noRethSyncHoldMu.Lock()
+	defer d.noRethSyncHoldMu.Unlock()
+	if d.noRethSyncHoldTimer != nil {
+		d.noRethSyncHoldTimer.Stop()
+	}
+	d.noRethSyncHold.Store(true)
+	d.noRethSyncHoldReason.Store("")
+	// No peer condition in this callback, deliberately — see the file comment.
+	d.noRethSyncHoldTimer = time.AfterFunc(timeout, func() {
+		slog.Warn("cluster: no-RETH sync hold timeout: bulk sync did not complete, "+
+			"releasing promotion hold in degraded mode", "timeout", timeout)
+		d.releaseNoRethSyncHold("timeout-degraded")
+	})
+	if d.cluster != nil {
+		d.cluster.SetStartupSyncHoldStatus("no-reth", true, "")
+	}
+	slog.Info("cluster: no-RETH startup promotion hold active", "timeout", timeout)
+}
+
+// releaseNoRethSyncHold ends the hold and records why. Idempotent: the timer and
+// the bulk-sync edge race by design, and whichever arrives first wins.
+func (d *Daemon) releaseNoRethSyncHold(reason string) {
+	if d == nil {
+		return
+	}
+	d.noRethSyncHoldMu.Lock()
+	if !d.noRethSyncHold.Load() {
+		d.noRethSyncHoldMu.Unlock()
+		return
+	}
+	d.noRethSyncHold.Store(false)
+	d.noRethSyncHoldReason.Store(reason)
+	if d.noRethSyncHoldTimer != nil {
+		d.noRethSyncHoldTimer.Stop()
+		d.noRethSyncHoldTimer = nil
+	}
+	d.noRethSyncHoldMu.Unlock()
+	if d.cluster != nil {
+		d.cluster.SetStartupSyncHoldStatus("no-reth", false, reason)
+	}
+	slog.Info("cluster: no-RETH startup promotion hold released", "reason", reason)
+	// Readiness is computed on a reconcile pass, so releasing the hold has to
+	// DRIVE one. Without this the node holds its RG secondary until some
+	// unrelated event happens to trigger a reconcile — the hold would be bounded
+	// in name only, since the bound would be on when the flag flips rather than
+	// on when anything acts on it. The RETH sibling has the same obligation and
+	// meets it with triggerPreemptNow() inside releaseSyncHoldWithReason.
+	d.triggerReconcile()
+}
+
+// inNoRethSyncHold reports whether the startup promotion hold is still active.
+func (d *Daemon) inNoRethSyncHold() bool {
+	return d != nil && d.noRethSyncHold.Load()
+}
+
+// noRethSyncHoldEndReason returns why the hold ended — "bulk-sync-complete",
+// "timeout-degraded", or "" if it never armed or is still active. Mirrors
+// vrrp.Manager.SyncHoldReason so the two paths render identically.
+func (d *Daemon) noRethSyncHoldEndReason() string {
+	if d == nil {
+		return ""
+	}
+	r, _ := d.noRethSyncHoldReason.Load().(string)
+	return r
+}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -94,7 +94,20 @@ func (d *Daemon) onSessionSyncBulkReceived() {
 	d.stopSyncReadyTimer()
 	if d.vrrpMgr != nil {
 		d.vrrpMgr.ReleaseSyncHold()
+		// #7162: the VRRP hold has recorded a reason since #466 and surfaced it
+		// nowhere. Mirror it so an operator can tell a normal startup from one
+		// that promoted degraded because sync never arrived.
+		if d.cluster != nil {
+			if r := d.vrrpMgr.SyncHoldReason(); r != "" {
+				d.cluster.SetStartupSyncHoldStatus("reth-vrrp", d.vrrpMgr.InSyncHold(), r)
+			}
+		}
 	}
+	// #7162: the no-RETH sibling release. Unconditional, exactly like the VRRP
+	// one above — a hold that is only released when some other subsystem is
+	// present is a hold that outlives its purpose in the configuration that
+	// needs it most.
+	d.releaseNoRethSyncHold("bulk-sync-complete")
 	if d.cluster != nil {
 		d.cluster.SetSyncReady(true)
 	}

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -33,7 +33,23 @@ func (d *Daemon) checkVIPReadiness(rgID int) (bool, []string) {
 }
 
 func (d *Daemon) checkNoRethTakeoverReadiness(rgID int) (bool, []string) {
-	return d.checkVIPReadiness(rgID)
+	ready, reasons := d.checkVIPReadiness(rgID)
+	// #7162: the bounded STARTUP hold. RETH VRRP mode suppresses preemption
+	// until bulk session sync completes; this is the no-RETH equivalent, and
+	// without it a node here promotes an RG before any conntrack/NAT state has
+	// arrived and resets every established flow.
+	//
+	// This is a bounded hold, NOT a `cluster.IsSyncReady()` conjunct. The
+	// difference is the whole of #110: a continuous sync term has no bound while
+	// the sync channel is down, so it blocks promotion indefinitely in exactly
+	// the degraded-peer case preemption exists for. This term goes false on its
+	// own after noRethSyncHoldTimeout regardless of sync state or peer state.
+	if d.inNoRethSyncHold() {
+		ready = false
+		reasons = append(reasons,
+			"session sync startup hold: bulk sync not yet complete")
+	}
+	return ready, reasons
 }
 
 // checkVIPReadinessForConfig verifies that RETH interfaces for the given RG

--- a/pkg/daemon/daemon_run_bringup.go
+++ b/pkg/daemon/daemon_run_bringup.go
@@ -228,14 +228,30 @@ func (d *Daemon) initManagers(configCompileFailed bool) error {
 		cc := cfg.Chassis.Cluster
 		if cc.FabricInterface != "" && cc.FabricPeerAddress != "" && !cc.NoRethVRRP && !cc.PrivateRGElection {
 			d.vrrpMgr.SetSyncHold(30 * time.Second)
+			if d.cluster != nil {
+				d.cluster.SetStartupSyncHoldStatus("reth-vrrp", true, "")
+			}
+		} else if cc.FabricInterface != "" && cc.FabricPeerAddress != "" {
+			// #7162: the no-RETH sibling of the hold above. These modes route
+			// takeover readiness through checkNoRethTakeoverReadiness, which is
+			// VIP ownership alone, so without this a node promotes an RG before
+			// bulk session sync has delivered any conntrack/NAT state and every
+			// established flow resets. Bounded and armed ONCE, like SetSyncHold
+			// — see daemon_ha_noreth_hold.go for why it must not become a
+			// continuous IsSyncReady() conjunct (#110).
+			d.armNoRethSyncHold(noRethSyncHoldTimeout)
 		}
 		// Private-rg-election mode takes no VRRP sync-hold (the branch
-		// above excludes it), so arm the sync-ready timeout instead. Be
-		// exact about what that buys (#7102): cluster.Manager.syncReady
-		// does NOT gate RG promotion in this mode — takeover readiness
-		// here is VIP ownership alone (checkNoRethTakeoverReadiness) and
-		// the readiness conjunction has no sync term — so this is a bound
-		// on a reported/logged state, not on takeover. It is also not the
+		// above excludes it), so arm the sync-ready timeout too. Be exact
+		// about what THAT buys (#7102): cluster.Manager.syncReady still
+		// does NOT gate RG promotion — it bounds a reported/logged state.
+		//
+		// #7162: startup promotion in this mode IS gated now, by the
+		// bounded armNoRethSyncHold above, which is a DIFFERENT mechanism
+		// with a different bound. Do not read the two as one; the hold
+		// releases on its own timer regardless of sync or peer state,
+		// while this timer's callback returns early while no sync peer is
+		// connected. It is also not the
 		// only arm: the cold-start branch of onSessionSyncPeerConnected
 		// re-arms the timer (bumping syncReadyTimerGen, which supersedes
 		// this one), and this timer's callback returns early while no sync

--- a/pkg/daemon/noreth_sync_hold_7162_test.go
+++ b/pkg/daemon/noreth_sync_hold_7162_test.go
@@ -1,0 +1,211 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// #7162: the bounded startup promotion hold for no-reth-vrrp /
+// private-rg-election mode.
+//
+// RETH VRRP mode has suppressed startup preemption since #466
+// (`vrrp.Manager.SetSyncHold`). These modes had no equivalent, so a node could
+// promote an RG before bulk session sync delivered any conntrack/NAT state and
+// reset every established flow.
+//
+// WHAT THESE TESTS ARE GUARDING AGAINST, in both directions. The obvious
+// under-fix is no hold at all. The dangerous OVER-fix is a continuous
+// `cluster.IsSyncReady()` conjunct — which is what #110 measured and rejected,
+// because `syncReady` has no bound while the sync channel is down and would
+// block promotion INDEFINITELY in exactly the degraded-peer case preemption
+// exists for. So there is a cell for the hold applying, a cell for each release
+// edge, and a cell that the release does not depend on peer state.
+
+func noRethHoldDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	store := testStoreWithSetConfig(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-7162",
+		"set chassis cluster node 0",
+		"set chassis cluster no-reth-vrrp",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set interfaces reth0 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+	})
+	cm := cluster.NewManager(0, 1)
+	cm.UpdateConfig(store.ActiveConfig().Chassis.Cluster)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cm.Start(ctx)
+	d := &Daemon{
+		rgStates:       make(map[int]*rgStateMachine),
+		cluster:        cm,
+		store:          store,
+		vrrpMgr:        vrrp.NewManager(),
+		reconcileNowCh: make(chan struct{}, 1),
+		linkByNameFn:   mockLinkByName(map[string]*testLink{"ge-0-0-0": newTestLink("ge-0-0-0", true)}),
+	}
+	d.setDataplane(newTakeoverReadyDP())
+	return d
+}
+
+func rgReadiness(t *testing.T, d *Daemon) (bool, []string) {
+	t.Helper()
+	d.reconcileRGState()
+	state := d.cluster.GroupState(1)
+	if state == nil {
+		t.Fatal("expected RG 1 state")
+	}
+	return state.Ready, state.ReadinessReasons
+}
+
+func hasHoldReason(reasons []string) bool {
+	for _, r := range reasons {
+		if strings.Contains(r, "session sync startup hold") {
+			return true
+		}
+	}
+	return false
+}
+
+// BEFORE bulk sync: the hold is active and the RG must not be takeover-ready.
+func TestNoRethSyncHoldBlocksPromotionBeforeBulkSync7162(t *testing.T) {
+	d := noRethHoldDaemon(t)
+
+	// Control: without the hold this fixture is READY. Without this the cell
+	// below could pass because the fixture is unready for an unrelated reason.
+	if ready, reasons := rgReadiness(t, d); !ready {
+		t.Fatalf("control: the fixture must be takeover-ready before the hold is "+
+			"armed, else the assertion below measures the wrong thing: %v", reasons)
+	}
+
+	d.armNoRethSyncHold(time.Hour) // long, so only an explicit release ends it
+	ready, reasons := rgReadiness(t, d)
+	if ready {
+		t.Error("the RG is takeover-ready during the startup hold: a node here can " +
+			"promote before bulk session sync has delivered any conntrack/NAT " +
+			"state, resetting every established flow (#7162)")
+	}
+	if !hasHoldReason(reasons) {
+		t.Errorf("readiness is blocked but no reason names the sync hold, so an "+
+			"operator cannot tell this from a VIP problem: %v", reasons)
+	}
+}
+
+// AFTER bulk sync: the good release edge.
+func TestNoRethSyncHoldReleasedByBulkSync7162(t *testing.T) {
+	d := noRethHoldDaemon(t)
+	d.armNoRethSyncHold(time.Hour)
+	if ready, _ := rgReadiness(t, d); ready {
+		t.Fatal("precondition: the hold must be blocking before the release is meaningful")
+	}
+
+	d.onSessionSyncBulkReceived()
+
+	if d.inNoRethSyncHold() {
+		t.Fatal("bulk sync completed but the hold is still active (#7162)")
+	}
+	if got := d.noRethSyncHoldEndReason(); got != "bulk-sync-complete" {
+		t.Errorf("hold end reason = %q, want %q — the operator-visible reason must "+
+			"distinguish a healthy release from the degraded timeout", got, "bulk-sync-complete")
+	}
+	if ready, reasons := rgReadiness(t, d); !ready || hasHoldReason(reasons) {
+		t.Errorf("after bulk sync the RG must be takeover-ready: ready=%v reasons=%v",
+			ready, reasons)
+	}
+}
+
+// The TIMEOUT edge — and the #110 shape. The hold must release itself with NO
+// peer connected, no sync peer, and cluster sync NOT ready. #110's
+// armSyncReadyTimer bails its callback on !d.syncPeerConnected, so its fallback
+// never fires in exactly the peer-absent case it exists for. A hold with that
+// bug would never release here, which is the whole failure this cell exists to
+// exclude.
+func TestNoRethSyncHoldReleasesOnTimeoutWithNoPeer7162(t *testing.T) {
+	d := noRethHoldDaemon(t)
+
+	d.syncPeerConnected.Store(false)
+	d.cluster.SetSyncReady(false)
+	if d.cluster.IsSyncReady() {
+		t.Fatal("precondition: cluster sync must be NOT ready, so a release here " +
+			"cannot be attributed to sync having succeeded")
+	}
+
+	d.armNoRethSyncHold(40 * time.Millisecond)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for d.inNoRethSyncHold() {
+		if time.Now().After(deadline) {
+			t.Fatal("the startup hold never released with no peer connected. That is " +
+				"#110's defect exactly: a bound that depends on the condition it is " +
+				"bounding cannot fire in the case it exists for (#7162)")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := d.noRethSyncHoldEndReason(); got != "timeout-degraded" {
+		t.Errorf("hold end reason = %q, want %q so the degraded release is "+
+			"distinguishable in `show chassis cluster`", got, "timeout-degraded")
+	}
+	if ready, reasons := rgReadiness(t, d); !ready || hasHoldReason(reasons) {
+		t.Errorf("after the degraded timeout the RG must be takeover-ready — the "+
+			"hold is a bounded startup suppression, not a permanent gate: "+
+			"ready=%v reasons=%v", ready, reasons)
+	}
+}
+
+// Releasing must DRIVE a reconcile, not merely flip a flag. Readiness is
+// recomputed on a reconcile pass, so without this the node holds its RG
+// secondary until some unrelated event happens to trigger one — the hold would
+// be bounded in name only, the bound being on when the flag flips rather than on
+// when anything acts on it.
+func TestNoRethSyncHoldReleaseTriggersReconcile7162(t *testing.T) {
+	d := noRethHoldDaemon(t)
+	// Drain anything already queued so the assertion is about THIS release.
+	select {
+	case <-d.reconcileNowCh:
+	default:
+	}
+	d.armNoRethSyncHold(time.Hour)
+	d.releaseNoRethSyncHold("bulk-sync-complete")
+	select {
+	case <-d.reconcileNowCh:
+	default:
+		t.Fatal("releasing the hold did not trigger a reconcile, so readiness is " +
+			"never recomputed and the RG stays secondary until an unrelated event " +
+			"happens to drive one (#7162)")
+	}
+}
+
+// NOT armed: modes that never arm the hold are bit-identical to before. This is
+// the over-reach control — a hold that applied when it was never armed would
+// gate RETH VRRP mode, which has its own suppression and must not get a second.
+func TestNoRethSyncHoldAbsentWhenNeverArmed7162(t *testing.T) {
+	d := noRethHoldDaemon(t)
+	if d.inNoRethSyncHold() {
+		t.Fatal("the hold must not be active before it is armed")
+	}
+	ready, reasons := rgReadiness(t, d)
+	if !ready || hasHoldReason(reasons) {
+		t.Errorf("an un-armed hold changed readiness: ready=%v reasons=%v", ready, reasons)
+	}
+}
+
+// Release is idempotent and FIRST-WINS. The timer and the bulk-sync edge race by
+// design; a second release must not overwrite the recorded reason, or a healthy
+// release could be reported as degraded (or the reverse) purely on timing.
+func TestNoRethSyncHoldReleaseIsFirstWins7162(t *testing.T) {
+	d := noRethHoldDaemon(t)
+	d.armNoRethSyncHold(time.Hour)
+	d.releaseNoRethSyncHold("bulk-sync-complete")
+	d.releaseNoRethSyncHold("timeout-degraded")
+	if got := d.noRethSyncHoldEndReason(); got != "bulk-sync-complete" {
+		t.Errorf("hold end reason = %q after a second release; the first release "+
+			"must win or the reported reason depends on a race (#7162)", got)
+	}
+}

--- a/pkg/daemon/vip_readiness_test.go
+++ b/pkg/daemon/vip_readiness_test.go
@@ -378,6 +378,17 @@ func testStoreWithSetConfig(t *testing.T, lines []string) *configstore.Store {
 // 0781f7a60 and takeover readiness is now VIP ownership alone. #110 tracks
 // whether it should return — if it does, this test and its sibling red, which
 // is the point.
+//
+// #7162 UPDATE: takeover readiness here is NO LONGER "VIP ownership alone" — a
+// bounded startup hold (Daemon.armNoRethSyncHold) is now a term in
+// checkNoRethTakeoverReadiness. This test and its sibling still pass, and still
+// pin something true and load-bearing: the gate is the HOLD, never this FLAG.
+// The distinction is the whole of #110 — the hold is bounded, the flag is not,
+// and a flag-based conjunct would block promotion indefinitely with sync down.
+// These fixtures never arm the hold, so they isolate the flag, which is exactly
+// what makes them the right guard for that claim. The sentence above about this
+// test redding if the gate returns is therefore superseded: it reds if the FLAG
+// becomes a gate, which is still the thing to prevent.
 func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
 	store := testStoreWithSetConfig(t, []string{
 		"set chassis cluster cluster-id 1",


### PR DESCRIPTION
Closes #7162

Premise verified at `ee0a3a294`. `SetSyncHold(30s)` is armed at exactly one site
and only when `!cc.NoRethVRRP && !cc.PrivateRGElection`;
`checkNoRethTakeoverReadiness` was `return d.checkVIPReadiness(rgID)` and nothing
else. So a node in those modes could promote an RG before bulk sync delivered any
conntrack/NAT state, and every established flow reset on the transition.

## The change

`Daemon.armNoRethSyncHold` — the no-RETH sibling of the RETH VRRP hold. Same 30s
bound, same bringup arming site (the branch that skips `SetSyncHold`), consulted
by `checkNoRethTakeoverReadiness`, released by bulk sync
(`bulk-sync-complete`) or its own timer (`timeout-degraded`).

**It is a bounded HOLD, not a `cluster.IsSyncReady()` conjunct**, which is the
whole of #110: `syncReady` has no bound while the sync channel is down
(`armSyncReadyTimer` early-returns unless `syncPeerConnected`) and the election
blocks a not-ready RG whenever the peer is alive, so a flag conjunct blocks
promotion **indefinitely** with the peer up on the control link and sync down —
the degraded-peer case preemption exists for. Two properties keep this bounded,
each with its own cell:

- the timer callback consults **no** peer condition. A release that depended on
  the peer would be no release at all, because the peer being absent is why the
  hold is still held.
- armed exactly once at bringup, never re-armed on reconnect — a startup hold
  rather than a mid-life block.

**Releasing DRIVES a reconcile.** Readiness is recomputed per reconcile pass, so
a release that only flips the flag leaves the RG secondary until an unrelated
event happens to trigger one — bounded in name only. This is the **third**
instance of the #110 shape across two issues, at a third layer.

## The issue's "tests that will red by design" prediction did not hold

The issue says `TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady` and its
`_7102` sibling "pin the current ungated behaviour" and "must be REPLACED". Both
still **pass**, and they were kept.

Those fixtures construct a Daemon and call `reconcileRGState` directly; they never
arm the hold, and the property they assert — that the gate does not consult
`IsSyncReady()` — is still true here, because this implementation deliberately
does not use that flag. **The prediction assumed an implementation gating on
`IsSyncReady()`, which is the shape the same issue's "What must NOT be built"
section forbids.** Building the right thing leaves them valid.

They are not merely surviving, either: mutation **M6** (make the hold apply when
never armed) reds *both* of them. They are load-bearing against the over-reach
shape, which is a better reason to keep them than that they still pass. Their doc
comments are corrected — they pin that the gate is the HOLD and never the FLAG,
and the claim that they would red if a gate returned is superseded.

## Observability

`show chassis cluster information` gains a `Startup promotion hold:` block —
mode (`reth-vrrp` / `no-reth`), whether still holding, and how it ended. The RETH
hold had recorded `bulk-sync-complete` / `timeout-degraded` since #466 and
surfaced it **nowhere**, so an operator could not distinguish a normal startup
from one that promoted degraded because sync never arrived — the explanation for
a flow reset after a boot. Both paths now report through one mirror. While
active, the hold also appears in the RG's `Takeover ready: no (...)` reasons.

## The three #7102 comments

`cluster.SetSyncReady`'s doc, the `Manager.syncReady` field comment, and the
bringup note each said startup promotion here is ungated. Each now says it is
gated by the bounded hold and **not** by the flag, with the reason the two must
not be collapsed.

## Mutation

Full-suite over `./pkg/daemon/ ./pkg/cluster/`, named-failing-test gated,
`git diff --stat` per cell.

| cell | mutation | verdict | named reds |
|---|---|---|---|
| C0 | none | GREEN | — |
| M1 | remove the hold conjunct from the readiness gate | **RED** | blocks-before-bulk, released-by-bulk |
| M2 | gate the timer release on `syncPeerConnected` (the #110 shape) | **RED** | the no-peer timeout cell (3.00s) |
| M3 | drop `triggerReconcile` from the release | **RED** | the reconcile cell |
| M4 | remove the bulk-sync release edge | **RED** | released-by-bulk |
| M5 | make release last-wins instead of first-wins | **RED** | first-wins |
| M6 | over-reach: hold applies when never armed | **RED** | 4 of mine **+ both #7102 tests** |
| M7 | reorder the two status stores (benign) | GREEN | — |

## Cluster validation

`make test-failover` on the loss userspace cluster under the #1875 lock:
**17 passed, 0 failed**, rc=0.

**Read this part before gating.** The first `cluster-deploy` attempt failed its
post-deploy primary reassert, and the script says to treat that as an HA
regression. It was not this change, and the investigation found something else
that matters more — see the separate report. In short: the hold armed at 07:18:24
and released 5s later with `bulk-sync-complete` (the healthy path, working as
designed); the blocker was `userspace XSK liveness not proven` on an **idle**
cluster, and RG1 sat secondary on **both** nodes until I drove traffic through
it, after which all three RGs went primary/ready and the smoke passed. The reason
it could not self-heal is a gap in the merged #7161 work, not in this PR.

## Validation

`TMPDIR=/var/tmp go test -count=1 ./...` — rc=0, 0 `--- FAIL`, 69 packages (third
run). Two earlier runs each failed ONE unrelated concurrency test —
`TestKeyReaderDiscardsKeyAfterDone` (pkg/cli) and
`TestStartHeartbeatDoesNotRaceStopHeartbeat7257` (pkg/cluster, at its 30.00s
bound) — never the same one twice, both passing 3x in isolation on this branch
and on unmodified master. A full-suite control on unmodified master under
comparable load was green 69/69, which is the complicating fact and is stated
rather than omitted. Details in `docs/log/7162.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y