### PR TITLE
cluster: give runElection the degraded-promotion fallback too

### DIFF
--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -325,8 +325,14 @@ func (m *Manager) runElection() {
 		// hasn't been ready for takeoverHoldTime. This does NOT demote
 		// an already-primary node. Only applies in cluster mode
 		// (controlInterface configured) — standalone nodes skip the gate.
+		degradedReason := ""
 		if result == electLocalPrimary && rg.State != StatePrimary && m.controlInterface != "" {
-			if !rg.IsReadyForTakeover(m.takeoverHoldTime) {
+			// #7939: through the SHARED verdict, so this path gets the degraded
+			// fallback electSingleNode already had. Before this, a stuck
+			// readiness term here left the RG secondary on both nodes with no
+			// way out — see readinessGateVerdictLocked.
+			promote, degReason := m.readinessGateVerdictLocked(rg)
+			if !promote {
 				slog.Info("cluster: election blocked by readiness gate",
 					"rg", rg.GroupID, "ready", rg.Ready,
 					"readySince", rg.ReadySince,
@@ -334,6 +340,7 @@ func (m *Manager) runElection() {
 					"reasons", rg.ReadinessReasons)
 				continue
 			}
+			degradedReason = degReason
 		}
 
 		oldState := rg.State
@@ -393,6 +400,18 @@ func (m *Manager) runElection() {
 			// Track failover count for primary→non-primary transitions.
 			if oldState == StatePrimary {
 				rg.FailoverCount++
+			}
+			// #7939: a promotion that only happened because the degraded
+			// timeout expired must be MARKED and said loudly, exactly as
+			// electSingleNode does. The RG is forwarding while not ready, which
+			// is the right trade against both nodes staying secondary — but it
+			// is not a normal promotion and must not read as one in the event
+			// stream or in `show chassis cluster status`.
+			if degradedReason != "" && rg.State == StatePrimary {
+				rg.DegradedPromoted = true
+				reason = degradedReason
+				slog.Warn("cluster: promoting NOT-READY RG after degraded timeout",
+					"rg", rg.GroupID, "reason", degradedReason)
 			}
 			m.sendEvent(rg.GroupID, oldState, rg.State, reason)
 		}
@@ -456,14 +475,13 @@ func (m *Manager) electSingleNode() {
 		degradedReason := ""
 		if rg.State != StatePrimary && rg.Weight > 0 && m.controlInterface != "" &&
 			(m.peerAlive || !m.peerEverSeen) {
-			if !rg.IsReadyForTakeover(m.takeoverHoldTime) {
-				if reason, ok := m.degradedPromoteDueLocked(rg); ok {
-					degradedReason = reason
-				} else {
-					m.armDegradedTimerLocked(rg)
-					continue
-				}
+			// #7939: the same shared verdict runElection uses. Written out
+			// separately here before, which is how the two drifted apart.
+			promote, reason := m.readinessGateVerdictLocked(rg)
+			if !promote {
+				continue
 			}
+			degradedReason = reason
 		}
 		oldState := rg.State
 		if rg.Weight > 0 {
@@ -775,6 +793,46 @@ func (m *Manager) reconcileMonitorDebtsLocked(cfg *config.ClusterConfig) {
 				"rg", rgID, "old", oldWeight, "new", rg.Weight)
 		}
 	}
+}
+
+// readinessGateVerdictLocked is the ONE readiness-gate decision, shared by both
+// election paths.
+//
+// #7939: it exists because the two paths had separate copies and they diverged.
+// #7161 put the degraded-promotion fallback in electSingleNode only. runElection
+// — the path taken whenever `peerAlive` is true, which is where a cluster spends
+// its life — kept a bare gate with no fallback, so #7161's guarantee that "a
+// readiness bug can never cost the cluster both nodes" held on the path a
+// cluster is almost never on and not on the path it is almost always on.
+//
+// That was observed live, not derived: after a routine cluster-deploy, RG1 sat
+// SECONDARY ON BOTH NODES indefinitely with `userspace XSK liveness not proven`,
+// logging twice a second for minutes. It could not self-heal, because proving
+// XSK liveness requires traffic and traffic requires a primary — the gate was
+// holding shut the only thing that could open it. It recovered only when traffic
+// was driven through the cluster by hand.
+//
+// Note what the divergence did to the fallback's own contract. #7161 required a
+// fallback NOT gated on any peer condition, precisely so it would fire when the
+// peer situation is what is wrong. Living only in electSingleNode gated it on a
+// peer condition anyway — just at the placement level rather than inside the
+// timer — which is the #110 shape one layer up: a fallback that cannot fire in
+// the case it exists for.
+//
+// Returns (promote, degradedReason). promote=false means hold this RG secondary
+// and the caller must not advance it. A non-empty degradedReason means promote
+// ANYWAY and say so loudly — the RG is not ready, and staying secondary is worse.
+//
+// Caller must hold m.mu.
+func (m *Manager) readinessGateVerdictLocked(rg *RedundancyGroupState) (bool, string) {
+	if rg.IsReadyForTakeover(m.takeoverHoldTime) {
+		return true, ""
+	}
+	if reason, ok := m.degradedPromoteDueLocked(rg); ok {
+		return true, reason
+	}
+	m.armDegradedTimerLocked(rg)
+	return false, ""
 }
 
 // degradedPromoteDueLocked reports whether the #7161 cold-boot readiness gate

--- a/pkg/cluster/runelection_degraded_fallback_7939_test.go
+++ b/pkg/cluster/runelection_degraded_fallback_7939_test.go
@@ -1,0 +1,210 @@
+package cluster
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+	"time"
+)
+
+// #7939: the degraded-promotion fallback must exist on the runElection path too,
+// not only on electSingleNode.
+//
+// WHAT WENT WRONG, observed live rather than derived. #7161 added the fallback so
+// "a readiness bug can never cost the cluster both nodes", and put it in
+// electSingleNode. runElection — the path taken whenever `peerAlive` is true,
+// which is where a cluster spends its life — kept a bare gate. After a routine
+// cluster-deploy, RG1 sat SECONDARY ON BOTH NODES indefinitely with
+// `userspace XSK liveness not proven`, logging twice a second for minutes, and
+// could not self-heal: proving XSK liveness needs traffic, traffic needs a
+// primary, and the gate was holding shut the only thing that could open it.
+//
+// Note what the split did to the fallback's own contract. #7161 required a
+// fallback NOT gated on any peer condition, so that it would fire when the peer
+// situation is what is wrong. Living only in electSingleNode gated it on a peer
+// condition anyway — at the placement level rather than inside the timer. That is
+// the #110 shape one layer up, and it is why this test drives the PEER-ALIVE
+// path specifically: a fixture with no peer exercises electSingleNode, which
+// already worked, and would pass against the shipped bug.
+
+// notReadyWithPeerAlive builds a manager on the runElection path — peer seen and
+// alive, local weight higher so the election wants us primary — with the RG NOT
+// ready. That is the shape that hung.
+func notReadyWithPeerAlive(t *testing.T) *Manager {
+	t.Helper()
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 200}))
+	cfg.ControlInterface = "em0" // cluster mode: the readiness gate applies
+	m.UpdateConfig(cfg)
+
+	// Peer heartbeat at LOWER priority: peerAlive/peerEverSeen become true (so
+	// electSingleNode is not the path) while the election still wants us
+	// primary (so the gate is actually consulted).
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 100, Weight: 100, State: uint8(StateSecondary)},
+		},
+	})
+
+	m.mu.Lock()
+	rg := m.groups[0]
+	rg.State = StateSecondary
+	rg.Ready = false
+	rg.ReadySince = time.Time{}
+	rg.ReadinessReasons = []string{"userspace XSK liveness not proven"}
+	m.mu.Unlock()
+	return m
+}
+
+func TestRunElectionHoldsSecondaryBeforeTheDegradedTimeout7939(t *testing.T) {
+	m := notReadyWithPeerAlive(t)
+	m.runElection()
+	if m.IsLocalPrimary(0) {
+		t.Fatal("a not-ready RG must stay secondary BEFORE the degraded timeout expires — " +
+			"without this the fallback is indistinguishable from having no gate at all")
+	}
+}
+
+func TestRunElectionPromotesAfterTheDegradedTimeout7939(t *testing.T) {
+	m := notReadyWithPeerAlive(t)
+
+	// First pass arms the fallback and holds secondary.
+	m.runElection()
+	if m.IsLocalPrimary(0) {
+		t.Fatal("precondition: must hold secondary on the first pass")
+	}
+
+	// Age the arm point past the timeout. This is what the live cluster could
+	// never reach, because nothing on this path armed or consulted it.
+	m.mu.Lock()
+	m.groups[0].NotReadySince = time.Now().Add(-2 * m.degradedPromoteTimeout)
+	m.mu.Unlock()
+
+	m.runElection()
+
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("after the degraded timeout the RG must promote ANYWAY on the peer-alive " +
+			"path. Holding secondary here is what left RG1 secondary on BOTH nodes with no " +
+			"way out, since proving readiness required the traffic that only a primary " +
+			"could carry (#7939)")
+	}
+	m.mu.RLock()
+	degraded := m.groups[0].DegradedPromoted
+	m.mu.RUnlock()
+	if !degraded {
+		t.Error("a promotion that only happened because the timeout expired must be MARKED " +
+			"DegradedPromoted — it is forwarding while not ready, and must not read as a " +
+			"normal promotion in the event stream or in show chassis cluster status")
+	}
+}
+
+// Control. Without it, an implementation that ignored readiness entirely — or
+// one that promoted on every pass — passes the timeout cell above for the wrong
+// reason.
+func TestRunElectionStillPromotesImmediatelyWhenReady7939(t *testing.T) {
+	m := notReadyWithPeerAlive(t)
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-time.Hour) // satisfies the hold time
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	m.runElection()
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("a READY RG must promote immediately, with no degraded timeout involved")
+	}
+	m.mu.RLock()
+	degraded := m.groups[0].DegradedPromoted
+	m.mu.RUnlock()
+	if degraded {
+		t.Error("a normal ready promotion must NOT be marked degraded — if it is, the flag " +
+			"stops meaning anything and the loud warning becomes noise")
+	}
+}
+
+// The shared verdict's own behaviour. NOTE what this cell does NOT establish:
+// reverting runElection to a bare gate leaves it GREEN, because the helper still
+// exists and still works — only its CALLER changed. Measured, not assumed. The
+// behavioural binding is TestRunElectionPromotesAfterTheDegradedTimeout7939,
+// which reds on exactly that mutation, and the wiring binding is the source
+// check below. This cell covers the third thing: that the verdict itself returns
+// the right answers, which neither of the others isolates.
+func TestBothElectionPathsShareOneReadinessVerdict7939(t *testing.T) {
+	m := notReadyWithPeerAlive(t)
+
+	// Not ready, timer not expired -> hold, from the shared verdict.
+	m.mu.RLock()
+	promote, reason := m.readinessGateVerdictLocked(m.groups[0])
+	m.mu.RUnlock()
+	if promote || reason != "" {
+		t.Fatalf("shared verdict on a freshly not-ready RG: promote=%v reason=%q, want false/\"\"",
+			promote, reason)
+	}
+
+	// Expired -> promote WITH a reason.
+	m.mu.Lock()
+	m.groups[0].NotReadySince = time.Now().Add(-2 * m.degradedPromoteTimeout)
+	m.mu.Unlock()
+	m.mu.RLock()
+	promote, reason = m.readinessGateVerdictLocked(m.groups[0])
+	m.mu.RUnlock()
+	if !promote || reason == "" {
+		t.Fatalf("shared verdict after the timeout: promote=%v reason=%q, want true and a "+
+			"non-empty operator-facing reason", promote, reason)
+	}
+}
+
+// Binds the WIRING, which is the claim the fix actually rests on: the two paths
+// must CONSULT one rule rather than each carrying a copy. A behavioural test
+// cannot distinguish "runElection calls the shared verdict" from "runElection
+// reimplements it correctly today" — and it is the second state that decays into
+// #7939 the next time a term is added to one copy and not the other.
+//
+// go/parser rather than grep: the comments in this file and on the function
+// itself both name readinessGateVerdictLocked, so a textual scan is satisfied by
+// the prose explaining the fix.
+func TestBothElectionPathsCallTheSharedVerdict7939(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "election.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing election.go: %v", err)
+	}
+
+	callsVerdict := map[string]bool{}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if fn.Name.Name != "runElection" && fn.Name.Name != "electSingleNode" {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if ok && sel.Sel.Name == "readinessGateVerdictLocked" {
+				callsVerdict[fn.Name.Name] = true
+			}
+			return true
+		})
+		if _, seen := callsVerdict[fn.Name.Name]; !seen {
+			callsVerdict[fn.Name.Name] = false
+		}
+	}
+
+	for _, name := range []string{"runElection", "electSingleNode"} {
+		called, found := callsVerdict[name]
+		if !found {
+			t.Fatalf("%s not found in election.go — if it was renamed, move this test with "+
+				"it; a missing function must not read as a passing wiring check", name)
+		}
+		if !called {
+			t.Errorf("%s does not call readinessGateVerdictLocked, so the two election paths "+
+				"carry separate copies of the readiness rule again. That divergence IS #7939: "+
+				"the fallback lived in one path and an RG sat secondary on BOTH nodes with no "+
+				"way to self-heal", name)
+		}
+	}
+}


### PR DESCRIPTION
**This is a gap in my own #7161 design call, found live by a lane on the cluster.** Filed as #7939.

#7161 added a degraded-promotion fallback so *"a readiness bug can never cost the cluster both nodes"* — and put it in `electSingleNode` only. `runElection`, the path taken whenever `peerAlive` is true, kept a bare readiness gate with no fallback. **So the guarantee held on the path a cluster is almost never on, and not on the path it is almost always on.**

## Observed, not derived

After a routine `cluster-deploy`, RG1 sat **secondary on both nodes** indefinitely:

```
node0  200  secondary   Takeover ready: no (userspace XSK liveness not proven)
node1  100  secondary
```

logging twice a second for minutes. **It could not self-heal**: proving XSK liveness requires traffic, traffic requires a primary, and the gate was holding shut the only thing that could open it. It recovered only when traffic was driven through by hand.

## What the split did to the fallback's own contract

Worth naming, because it is the same lesson arriving one layer up. #7161 required a fallback **not gated on any peer condition**, precisely so it would fire when the peer situation is what's wrong. Living only in `electSingleNode` gated it on a peer condition anyway — at the **placement** level rather than inside the timer.

That is the #110 shape again: *a fallback that cannot fire in the case it exists for.* The lesson was applied to the timer and missed at the call site. I specified the mechanism and not the placement, and that gap is mine.

## One shared verdict, not a second copy

The fix is `readinessGateVerdictLocked`, consulted by **both** paths. Copying the fallback into the second gate would leave exactly the same failure available the next time a term is added to one and not the other — the two gates diverged *because* they were separate copies of the rule.

## Tests, and a correction I made to my own

**The fixture drives the PEER-ALIVE path specifically.** A fixture with no peer exercises `electSingleNode`, which already worked, and would pass against the shipped bug. So the peer heartbeat is set at a **lower** priority: `peerAlive`/`peerEverSeen` become true while the election still wants this node primary, which is the only shape that reaches the gate on this path.

| cell | purpose |
|---|---|
| hold-before-timeout | stops the fallback being indistinguishable from having no gate |
| **promotes-after-timeout** | the defect itself |
| ready-promotes-immediately (control) | stops an implementation that ignores readiness from passing |
| shared-verdict behaviour | the verdict returns the right answers |
| **calls-the-shared-verdict** | the wiring |

**The last row exists because I measured my own test and it overclaimed.** `TestBothElectionPathsShareOneReadinessVerdict7939` stayed **GREEN** under the mutation — it exercises the helper, and reverting `runElection` to a bare gate changes only its *caller*. A behavioural test cannot distinguish "runElection calls the shared verdict" from "runElection reimplements it correctly today", and it is the second state that decays back into #7939. So the wiring is now bound with `go/parser` (not grep — the comments in that file name the function, so a textual scan is satisfied by the prose explaining the fix), and the cell that overclaimed now says in its doc what it does *not* establish.

## Mutation

Reverting `runElection` to the bare gate — i.e. restoring exactly what shipped:

- before adding the wiring cell: **1015 collected, 1 named FAIL** (`PromotesAfterTheDegradedTimeout`)
- after: **1016 collected, 2 named FAIL** (adds `CallsTheSharedVerdict`)

## Gate

Full Go suite against current master: **rc=0, 69 packages, 0 FAIL**. `make test-failover` owed on cluster/election code and queued behind the #1875 lock; result posted here before merge.

Closes #7939