### PR TITLE
ipsec: stop emitting start_action at connection level

### DIFF
--- a/docs/ipsec-swanctl-load-proof.md
+++ b/docs/ipsec-swanctl-load-proof.md
@@ -1,0 +1,92 @@
+# Proving the generated strongSwan config actually LOADS
+
+This is the procedure #7165 item 2 asked for, plus the two dead ends that look
+like it works and do not.
+
+## Why a text assertion is not a proof
+
+Every renderer test in `pkg/ipsec` asserts on the emitted **text**. A text
+assertion cannot know which keys strongSwan accepts — it will happily confirm
+that a line strongSwan *rejects* was emitted exactly as intended.
+
+That gap was not hypothetical. The first run of this procedure found that
+`start_action` was emitted at **connection** level as well as child level, and
+strongSwan answers:
+
+```
+loading connection 'vpn-a' failed: unknown option: start_action, config discarded
+loaded 0 of 1 connections, 1 failed to load, 0 unloaded
+```
+
+`config discarded` is the **whole connection**. Every VPN with
+`establish-tunnels immediately` generated a config strongSwan refused in its
+entirety — IPsec did not come up at all — and the full Go suite was green
+throughout. Fixed in #7165; pinned structurally by
+`start_action_placement_7165_test.go`.
+
+## Two instruments that DO NOT work
+
+Both return the same answer for a valid and a malformed config, so both
+"confirm" whatever you expected.
+
+**1. `swanctl --load-conns --file <path> --uri <bogus>`.** swanctl fails on the
+vici connection *before* parsing, so a good config and a deliberately truncated
+one produce byte-identical output. Verified with a control; without one this
+reads as a clean parse.
+
+**2. Any path under `/tmp`.** The strongSwan unit runs with `PrivateTmp`, so
+swanctl cannot see the host's `/tmp` and reports `failed to open config file`
+for a file that demonstrably exists — again identically for good and bad input.
+
+## The procedure that works
+
+Requires a node with strongSwan installed and `charon` running. The loss
+userspace cluster nodes qualify (`/usr/sbin/swanctl`, strongSwan 6.0.5);
+a developer workstation generally does not, which is what made this look
+environmentally blocked. Take the #1875 cluster lock first — this loads
+into the live daemon.
+
+```bash
+N=loss:xpf-userspace-fw0
+D=/etc/swanctl/conf.d
+
+# 0. Record the starting state. conf.d is normally EMPTY on a cluster node.
+incus exec $N -- bash -c "ls $D; swanctl --list-conns"
+
+# 1. NEGATIVE CONTROL FIRST. A malformed config must be REJECTED, or the
+#    positive result below means nothing.
+incus exec $N -- bash -c "printf 'connections {\n  broken {\n' > $D/zz-proof.conf && swanctl --load-conns"
+#    Expect: syntax error, unexpected end of file
+
+# 2. The generated config.
+incus file push ./rendered.conf ${N}${D}/zz-proof.conf
+incus exec $N -- swanctl --load-conns
+#    Expect: loaded connection '<name>' / successfully loaded N connections
+
+# 3. Verify it is really there, not merely accepted.
+incus exec $N -- swanctl --list-conns
+
+# 4. RESTORE. Always — the cluster is shared.
+incus exec $N -- bash -c "rm -f $D/zz-proof.conf && swanctl --load-conns"
+incus exec $N -- bash -c "swanctl --list-conns; ls $D"
+```
+
+Generate `rendered.conf` by calling `Manager.renderConfig` from a throwaway test
+with a representative `config.IPsecConfig`.
+
+## Reading the result
+
+- `loaded 0 of 1 connections, 1 failed to load` — a **failure**, even though the
+  command exits 0. Read the line, not the exit code.
+- A config that renders to `connections {\n}` is **empty** and proves nothing.
+  Check the byte count and that a connection name appears before trusting a
+  pass; a skipped VPN (unresolved IKE chain, unrenderable gateway) produces
+  exactly that and loads cleanly.
+- Step 1 failing to be rejected means the instrument is broken, not that the
+  config is good.
+
+## Restore, always
+
+The cluster is shared and `conf.d` is normally empty. Leaving a proof config
+behind changes what the next holder of the lock is testing — the same class of
+contamination as leaving a CoS fixture applied.

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -236,10 +236,24 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, map[string
 			b.WriteString("    rand_time = 0s\n")
 		}
 
-		// Start immediately?
-		if vpn.EstablishTunnels == "immediately" {
-			b.WriteString("    start_action = start\n")
-		}
+		// #7165: `start_action` is a CHILD setting in swanctl.conf, not a
+		// connection setting. It used to be emitted here as well as in the
+		// child below, and strongSwan rejects the connection outright:
+		//
+		//   loading connection 'vpn-a' failed: unknown option: start_action,
+		//   config discarded
+		//   loaded 0 of 1 connections, 1 failed to load
+		//
+		// "config discarded" is the whole connection, not the one line — so
+		// every VPN configured with `establish-tunnels immediately` produced a
+		// config that strongSwan refused in its entirety, and IPsec did not come
+		// up at all. The child-level emit below is the correct one and is
+		// sufficient on its own; nothing here replaces it.
+		//
+		// This survived because nothing ever LOADED the generated config: the
+		// renderer's tests assert on the emitted text, and text assertions
+		// cannot know which keys strongSwan accepts. Found by #7165 item 2,
+		// whose entire subject was the absence of that proof.
 
 		// Compute XFRM interface ID from bind-interface name
 		ifID := xfrmiIfID(vpn.BindInterface)

--- a/pkg/ipsec/start_action_placement_7165_test.go
+++ b/pkg/ipsec/start_action_placement_7165_test.go
@@ -1,0 +1,142 @@
+package ipsec
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7165 item 2: `start_action` is a CHILD setting in swanctl.conf, never a
+// connection setting.
+//
+// The renderer emitted it in BOTH places, and strongSwan 6.0.5 rejects the
+// connection outright rather than ignoring the stray key:
+//
+//	loading connection 'vpn-a' failed: unknown option: start_action, config discarded
+//	loaded 0 of 1 connections, 1 failed to load, 0 unloaded
+//
+// "config discarded" is the WHOLE connection. So every VPN configured with
+// `establish-tunnels immediately` generated a config strongSwan refused
+// entirely, and IPsec did not come up. Removing the connection-level line and
+// changing nothing else makes the same config load: `loaded connection 'vpn-a',
+// successfully loaded 1 connections`, verified against a live charon.
+//
+// WHY NO TEST CAUGHT IT, which is the part worth keeping. Every renderer test
+// asserts on the emitted TEXT, and a text assertion cannot know which keys
+// strongSwan accepts — it will happily confirm that a line strongSwan rejects
+// was emitted correctly. That is the exact gap #7165 item 2 was filed about
+// ("no proof that generated config actually LOADS"), and the first thing the
+// proof did was find this.
+//
+// This test cannot close that gap either — only loading against a real charon
+// can, and that needs a lab node (procedure in docs/ipsec-swanctl-load-proof.md).
+// What it CAN do is pin the structural rule the load proved, so the specific
+// defect cannot come back silently.
+
+func renderImmediateVPN(t *testing.T) string {
+	t.Helper()
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-prop": {
+				Name: "ike-prop", AuthMethod: "pre-shared-keys",
+				EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256",
+				DHGroup: 14, LifetimeSeconds: 3600,
+			},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Mode: "main", Proposals: []string{"ike-prop"}, PSK: config.Secret("secret123")},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw-a": {
+				Name: "gw-a", Address: "203.0.113.1", LocalAddress: "198.51.100.7",
+				IKEPolicy: "ike-pol", ExternalIface: "ge-0-0-2",
+			},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-prop": {
+				Name: "esp-prop", Protocol: "esp",
+				EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256",
+				DHGroup: 14, LifetimeSeconds: 3600,
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"esp-prop"}, PFSGroup: 14},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			// `immediately` is the setting that triggers start_action at all.
+			"vpn-a": {
+				Name: "vpn-a", Gateway: "gw-a", IPsecPolicy: "ipsec-pol",
+				BindInterface: "st0.0", EstablishTunnels: "immediately",
+			},
+		},
+	}
+	rendered, _, err := m.renderConfig(cfg)
+	if err != nil {
+		t.Fatalf("renderConfig: %v", err)
+	}
+	// Parsed, not string-matched. TestNoSwanctlSyntaxInContainmentNeedles_6824
+	// forbids a Contains needle spelling swanctl syntax, and it is right for
+	// exactly the reason this issue exists: a byte check cannot say which
+	// SECTION a setting landed in, which is the entire defect here.
+	doc := parseSwanctlDoc(t, rendered)
+	if _, ok := doc.at(t, "connections").children["vpn-a"]; !ok {
+		t.Fatalf("fixture rendered no connection at all, so nothing below is being "+
+			"asserted — a skipped VPN passes every check in this file. Got:\n%s", rendered)
+	}
+	return rendered
+}
+
+func TestStartActionIsChildOnly7165(t *testing.T) {
+	doc := parseSwanctlDoc(t, renderImmediateVPN(t))
+
+	// The connection section must NOT carry it. This is the defect: strongSwan
+	// answers "unknown option: start_action, config discarded" and drops the
+	// ENTIRE connection, so IPsec does not come up for a VPN with
+	// establish-tunnels immediately (#7165).
+	doc.at(t, "connections", "vpn-a").hasNoSetting(t, "start_action")
+
+	// And the child section MUST. Not decoration: a fix that deleted both
+	// emits would satisfy the assertion above while silently dropping the
+	// behaviour the operator asked for, leaving a connection that loads and
+	// never initiates.
+	doc.at(t, "connections", "vpn-a", "children", "vpn-a").
+		requireSetting(t, "start_action", "start")
+}
+
+// Control: with establish-tunnels NOT set to immediately, start_action must not
+// appear at all. Without this, a renderer that emitted the child-level line
+// unconditionally would pass the test above while ignoring the setting.
+func TestStartActionAbsentWhenNotImmediate7165(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-prop": {Name: "ike-prop", AuthMethod: "pre-shared-keys",
+				EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14, LifetimeSeconds: 3600},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Mode: "main", Proposals: []string{"ike-prop"}, PSK: config.Secret("s")},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw-a": {Name: "gw-a", Address: "203.0.113.1", IKEPolicy: "ike-pol"},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-prop": {Name: "esp-prop", Protocol: "esp", EncryptionAlg: "aes-256-cbc",
+				AuthAlg: "hmac-sha-256", DHGroup: 14, LifetimeSeconds: 3600},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"esp-prop"}, PFSGroup: 14},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"vpn-a": {Name: "vpn-a", Gateway: "gw-a", IPsecPolicy: "ipsec-pol", BindInterface: "st0.0"},
+		},
+	}
+	rendered, _, err := m.renderConfig(cfg)
+	if err != nil {
+		t.Fatalf("renderConfig: %v", err)
+	}
+	doc := parseSwanctlDoc(t, rendered)
+	conn := doc.at(t, "connections", "vpn-a")
+	conn.hasNoSetting(t, "start_action")
+	conn.at(t, "children", "vpn-a").hasNoSetting(t, "start_action")
+}


### PR DESCRIPTION
**#7165 item 2 asked for proof that the generated strongSwan config actually loads. I ran that proof, and it does not.**

```
loading connection 'vpn-a' failed: unknown option: start_action, config discarded
loaded 0 of 1 connections, 1 failed to load, 0 unloaded
```

`start_action` is a **child** setting in swanctl.conf, not a connection setting. `renderConfig` emitted it in both places, and strongSwan 6.0.5 does not ignore the stray key — **`config discarded` is the whole connection**. So every VPN with `establish-tunnels immediately` generated a config strongSwan refused in its entirety, and IPsec did not come up for it. Removing the connection-level line and changing nothing else: `loaded connection 'vpn-a', successfully loaded 1 connections`, with `--list-conns` showing the IKE and child SA config.

## Why nothing caught it

**Every renderer test asserts on the emitted TEXT, and a text assertion cannot know which keys strongSwan accepts** — it will happily confirm that a line strongSwan rejects was emitted exactly as intended. The full Go suite was green with IPsec unable to start. That gap *is* what item 2 was filed about, and the first run of a real load proof found this.

The item was also recorded as environmentally blocked, verified with a `which swanctl` that found nothing — **run on a workstation.** The loss cluster nodes have strongSwan 6.0.5 with charon running, so the proof was runnable all along.

## Two instruments that silently do not work

Both were caught by running a deliberately malformed config as a **control**, and both return the *same* answer for valid and malformed input — so without the control each reads as a clean pass:

| attempt | why it proves nothing |
|---|---|
| `--uri <bogus>` | swanctl fails on the vici connection **before** parsing; good and truncated configs give byte-identical output |
| any path under `/tmp` | the unit runs with `PrivateTmp`, so swanctl reports `failed to open config file` for a file that demonstrably exists |

`docs/ipsec-swanctl-load-proof.md` records the working procedure with the control **first**, plus how to read the result (`loaded 0 of 1` is a failure even though the command exits 0; a config rendering to empty `connections {}` proves nothing) and the requirement to restore the node afterwards.

## A pre-existing guard caught my own test

My first version used `strings.Contains(rendered, "vpn-a {")` as a fixture-sanity check, and `TestNoSwanctlSyntaxInContainmentNeedles_6824` rejected it — correctly, and for exactly this issue's reason:

> *A needle carrying `" = "` or ending in `" {"` claims something about the document's STRUCTURE while checking only its bytes: it cannot say which section the setting landed in.*

Which section the setting landed in **is the entire defect**. The test now parses with `parseSwanctlDoc` and asserts structurally: `connections.vpn-a` has no `start_action`; `connections.vpn-a.children.vpn-a` has it set to `start`. That is a better test than the one I wrote, and I only saw the guard because the mutation ran the **full package** — my earlier `-run 7165` filtered it out.

## Mutation

Restoring the connection-level emit verbatim: **256 collected, exactly 1 named FAIL** (`TestStartActionIsChildOnly7165`).

The child-level assertion is not decoration: a fix deleting **both** emits would satisfy the connection-level check while silently dropping the behaviour the operator asked for, leaving a connection that loads and never initiates. The negative-control test covers the third state (setting absent when `establish-tunnels` is not `immediately`).

## Gate

Full Go suite: **rc=0, 69 packages, 0 FAIL**. Go-only — no cluster smoke owed for the code change; the load proof itself ran on a node under the #1875 lock and restored `conf.d` to empty.

Refs #7165