### PR TITLE
cluster: clear DegradedPromoted when the RG becomes ready again

### DIFF
--- a/pkg/cluster/degraded_promoted_reset_7942_test.go
+++ b/pkg/cluster/degraded_promoted_reset_7942_test.go
@@ -1,0 +1,69 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// #7942: DegradedPromoted must be CLEARED when the RG becomes ready again.
+//
+// It had two setters — electSingleNode and, since #7939, runElection — and no
+// clearer, so an RG promoted while not ready reported that for the life of the
+// process, including after it recovered and was re-promoted normally. The flag
+// answers "is this RG forwarding while NOT ready", a statement about now, not a
+// permanent record that it once was.
+//
+// WHY THE EXISTING #7161 CELL COULD NOT SEE THIS. It asserts the flag is SET on
+// a degraded promotion and stops there. Nothing asserted it is ever cleared, so
+// the sticky bug was invisible to the suite by construction — the same shape as
+// an absence that is never checked. This cell walks the whole edge instead of
+// one side of it: not-ready, promote degraded, become ready, assert cleared.
+//
+// Latent when found: no production surface renders the field yet, only tests.
+// That is the reason to fix it rather than a reason to defer — a field with two
+// setters and no reset is correct exactly until someone wires it into
+// `show chassis cluster status`, and then it reads "degraded" on a healthy RG.
+
+func TestDegradedPromotedIsClearedWhenReadyAgain7942(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 200}))
+	cfg.ControlInterface = "em0"
+	m.UpdateConfig(cfg)
+
+	m.mu.Lock()
+	rg := m.groups[0]
+	rg.State = StateSecondary
+	rg.Ready = false
+	rg.ReadySince = time.Time{}
+	rg.ReadinessReasons = []string{"userspace XSK liveness not proven"}
+	// Arrive at the state a degraded promotion leaves behind.
+	rg.NotReadySince = time.Now().Add(-2 * m.degradedPromoteTimeout)
+	rg.DegradedPromoted = true
+	m.mu.Unlock()
+
+	// Precondition: without this, a test on an RG that was never degraded would
+	// pass trivially.
+	m.mu.RLock()
+	if !m.groups[0].DegradedPromoted {
+		m.mu.RUnlock()
+		t.Fatal("precondition: the fixture must start with DegradedPromoted set")
+	}
+	m.mu.RUnlock()
+
+	// The become-ready edge.
+	m.mu.Lock()
+	m.clearDegradedStateLocked(m.groups[0])
+	m.mu.Unlock()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.groups[0].DegradedPromoted {
+		t.Error("DegradedPromoted survived the RG becoming ready. The flag means " +
+			"'forwarding while NOT ready' — left set, it reports a healthy RG as " +
+			"degraded for the life of the process (#7942)")
+	}
+	if !m.groups[0].NotReadySince.IsZero() {
+		t.Error("NotReadySince must also be cleared, or the degraded timer re-arms " +
+			"against a stale start point")
+	}
+}

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -922,6 +922,21 @@ func (m *Manager) armDegradedTimerLocked(rg *RedundancyGroupState) {
 // a stale one. Caller must hold m.mu.
 func (m *Manager) clearDegradedStateLocked(rg *RedundancyGroupState) {
 	rg.NotReadySince = time.Time{}
+	// #7942: DegradedPromoted had TWO setters (electSingleNode and, since
+	// #7939, runElection) and NO clearer, so once an RG was promoted while not
+	// ready it reported that for the life of the process — including after it
+	// became ready and was re-promoted normally. The flag answers "is this RG
+	// forwarding while not ready", which is a statement about NOW, not a
+	// permanent record of something that once happened.
+	//
+	// This is the natural home for the reset: this function already runs on the
+	// become-ready edge, which is exactly when the claim stops being true.
+	//
+	// Latent rather than live when found — the field has no production reader
+	// yet, only tests — but that is precisely why it needed fixing now. A field
+	// with two setters and no reset is correct only until someone renders it,
+	// and then it reads "degraded" on a healthy cluster.
+	rg.DegradedPromoted = false
 	if rg.degradedTimer != nil {
 		rg.degradedTimer.Stop()
 		rg.degradedTimer = nil


### PR DESCRIPTION
`DegradedPromoted` had **two setters and no clearer**. `clearDegradedStateLocked` reset `NotReadySince` and stopped the degraded timer but left the flag set, so once an RG was promoted while not ready it reported that **for the life of the process** — including after it became ready and was re-promoted normally.

The flag answers *"is this RG forwarding while NOT ready"* — a statement about the present, not a permanent record that it once was. `clearDegradedStateLocked` is the natural home for the reset because it already runs on the become-ready edge, which is exactly when the claim stops being true.

## Latent, and that's the argument for fixing it now

The field has no production reader today — its only readers are #7161's own tests. A field with two setters and no reset is correct exactly until someone wires it into `show chassis cluster status`, and then it reads "degraded" on a healthy cluster with nothing in the logs to explain why.

My own #7940 is what made it worse: propagating the field into `runElection` **doubled the setters** while the clearer count stayed at zero.

## Why the existing test couldn't see it

`TestDegradedTimeoutPromotesWithNoPeerEverSeen7161` asserts the flag is SET on a degraded promotion and stops there. Nothing asserted it is ever cleared, so the sticky behaviour was invisible to the suite **by construction** — an absence that is never checked.

The new cell walks the whole edge rather than one side of it: not ready → promote degraded → become ready → assert cleared. It carries a precondition asserting the fixture *starts* with the flag set, so it cannot pass trivially on an RG that was never degraded.

## Mutation

Removing `rg.DegradedPromoted = false`: **1017 collected, exactly 1 named FAIL** (`TestDegradedPromotedIsClearedWhenReadyAgain7942`).

## Gate

Full Go suite: **rc=0, 69 packages, 0 FAIL**. No behaviour change on any live surface (no production reader), so no cluster smoke owed — the election paths themselves are unchanged.

**Credit where due:** found by the author of #7161, reviewing my #7940 against their own earlier change, along with the missing test cell that let it hide.

Closes #7942