### PR TITLE
Retain unproven io_uring buffers at teardown

### DIFF
--- a/docs/log/7106.md
+++ b/docs/log/7106.md
@@ -1,0 +1,77 @@
+# 7106 — retain unproven io_uring buffers at teardown
+
+- **Timestamp**: 2026-08-29
+- **Action**: took the hardening option; added the retained-buffer gauge and the
+  field-order source guard
+- **File(s)**: `userspace-dp/src/io_uring_write{,_tests}.rs`,
+  `userspace-dp/src/protocol/control.rs`,
+  `userspace-dp/src/server/{helpers/status,lifecycle}.rs`,
+  `userspace-dp/tests/fixtures/protocol_wire_v1.json`,
+  `pkg/dataplane/userspace/protocol_status.go`
+
+## Measured first, because the title says "optionally"
+
+#7106 asks to weigh how many entries can be live at teardown, saying
+"`reap_ready` runs at the top of every write, so the steady-state answer is 0".
+That is right about steady state and is not the state the leak fires in:
+`reap_ready` reclaims entries whose CQE has SURFACED, and during the storm that
+produces deferrals, none has.
+
+| writes deferred | `inflight_len` | slow-path bytes | state-ring bytes |
+|---|---|---|---|
+| 1 | 1 | 1,500 | 262,144 |
+| 16 | 16 | 24,000 | 4,194,304 |
+| 64 | 64 | 96,000 | 16,777,216 |
+
+Growth is 1:1 and uncapped, and **the SQ depth does not bound it** — the state
+ring's SQ is 8 and it held 32 entries after 32 deferred writes. It drains fully
+once the storm ends (64 → 0).
+
+So the leak is unbounded in SIZE. What decided it is that it is bounded in
+FREQUENCY: `retire_ring_to_sync` explicitly does **not re-promote** (no
+flapping), so a `RingWriter` drops at most once per ring per process — on a ring
+already being abandoned as broken — or at process exit, where a leak is
+irrelevant.
+
+## Verdict: take the hardening
+
+A bounded number of leaks on an already-failed path beats a use-after-free in
+which the KERNEL writes into a freed heap allocation. Leaking a buffer whose
+release cannot be proven is also the standard io_uring idiom, not a cop-out:
+the field-order mitigation narrows the window but `close()` does not wait —
+`io_uring_release` only queues `io_ring_exit_work` — so no ordering of drops
+can make it a barrier.
+
+The unbounded ACCUMULATION is a separate, pre-existing concern and is filed as
+https://github.com/psaab/xpf/issues/7944 rather than folded in.
+
+## Also landed, from #6168's task list
+
+* **Observability** — `io_uring_retained_buffers_total` / `_bytes_total` on the
+  status wire plus a log line. The condition is silent by construction: the
+  whole point is that nothing further is ever heard about those writes.
+* **Field-order guard** — `RingWriter`'s `ring`-before-`inflight` declaration
+  order is load-bearing and was guarded only by a comment. Source-text, because
+  Rust cannot reflect declaration order, so there is no runtime observable.
+
+## Mutation matrix — full suite, `--test-threads=1`
+
+| cell | edit | verdict | reds |
+|------|------|---------|------|
+| control | none | GREEN 4868 | — |
+| m1 | delete `impl Drop for InflightRegistry` | RED | the retention test, alone |
+| m2 | neuter `reap_ready` so proven entries reach Drop | RED | the over-reach guard + a pre-existing #5800 test |
+| m3 | swap `RingWriter`'s field declaration order | RED | the field-order guard, alone |
+
+m1's first attempt was a **VOID, not a red**: my slice left invalid Rust, so
+`collected=0`. Re-done with brace matching.
+
+m2 is the over-reach cell. Without it, m1's test is satisfied by a `Drop` that
+leaks unconditionally — which would turn every ordinary ring retirement into a
+leak, including the overwhelmingly common case where the drain works.
+
+## Golden regeneration
+
+`protocol_wire_v1.json` needed regenerating. Classified before accepting: **2
+keys added** (both the new counters), **0 removed, 0 values changed**, and both
+added keys are 0 in the default specimen — the benign signature.

--- a/pkg/dataplane/userspace/protocol_status.go
+++ b/pkg/dataplane/userspace/protocol_status.go
@@ -240,6 +240,13 @@ type ProcessStatus struct {
 	// inner meta would retry-TX a mis-rewritten outer packet once the
 	// neighbor resolves.
 	PendingNeighDecapDropsTotal uint64 `json:"pending_neigh_decap_drops_total,omitempty"`
+	// #7106: buffers the helper RETAINED (leaked) at io_uring ring teardown
+	// because the bounded drain could not prove the kernel had finished with
+	// them. Normally 0; non-zero means a ring was retired with writes it could
+	// not prove terminal, and their buffers were deliberately not freed rather
+	// than risk the kernel writing into a freed allocation.
+	IoUringRetainedBuffersTotal uint64 `json:"io_uring_retained_buffers_total,omitempty"`
+	IoUringRetainedBytesTotal   uint64 `json:"io_uring_retained_bytes_total,omitempty"`
 	// #2375: MissingNeighbor packets for a NEW distinct (egress_ifindex,
 	// next_hop) refused because pending_neigh is at MAX_PENDING_NEIGH
 	// distinct hops (distinct-hop neighbor exhaustion — the

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -106,6 +106,7 @@
 //!     reported as [`WriteResult::Deferred`] with `fatal_ring = true` (the buffer
 //!     is retained pending teardown), transient ones retry after a `yield_now`.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use io_uring::{IoUring, opcode, types};
 use std::io;
 
@@ -208,6 +209,73 @@ pub(crate) struct InflightRegistry {
     next_id: u64,
     /// Owned buffers for writes still considered in flight.
     inflight: Vec<InFlightWrite>,
+}
+
+/// #7106: buffers this process has RETAINED rather than freed, because the
+/// teardown drain could not prove the kernel was done with them. Cumulative and
+/// process-global: a registry that leaks is being dropped, so a per-registry
+/// counter would be destroyed with the thing it describes.
+///
+/// There is otherwise no operator-visible signal that a ring abandoned buffers
+/// — the condition is silent by construction, since the whole point is that
+/// nothing further will be heard about those writes.
+pub(crate) static RETAINED_BUFFERS: AtomicU64 = AtomicU64::new(0);
+/// Bytes held by [`RETAINED_BUFFERS`].
+pub(crate) static RETAINED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// #7106: leak, rather than free, any entry the teardown drain could not prove
+/// terminal.
+///
+/// ## Why leaking is the correct answer and not a cop-out
+///
+/// `drain_for_teardown` is the proof path: every buffer it releases has had its
+/// target write's terminal CQE observed. What reaches this `Drop` is the
+/// remainder — entries for which the kernel may STILL hold a pointer, because
+/// the drain hit its `MAX_WAIT_RETRIES` ceiling or the ring went fatally dead.
+///
+/// Freeing those is a use-after-free waiting to happen. `RingWriter`'s field
+/// order closes the ring fd before this registry drops, but `close()` does not
+/// wait: `io_uring_release` only QUEUES `io_ring_exit_work`, so a write already
+/// executing in io-wq can still be writing into that allocation at the instant
+/// it returns to the allocator (#6168). Field order narrows the window; it is
+/// not a barrier. Leaking removes the dependence on kernel teardown timing
+/// entirely, which is the standard io_uring idiom for a buffer whose release
+/// cannot be proven.
+///
+/// ## What it costs, measured
+///
+/// The registry accumulates one entry per DEFERRED write and is not bounded by
+/// the ring's submission-queue depth (measured: 32 entries on the state ring,
+/// whose SQ is 8). So the leak is unbounded in SIZE.
+///
+/// It is bounded in FREQUENCY, which is what makes the trade acceptable: a
+/// `RingWriter` drops when its ring is retired to the sync fallback, and
+/// `retire_ring_to_sync` does not re-promote (no flapping), so this runs at most
+/// once per ring per process — on a ring already being abandoned as broken — or
+/// at process exit, where a leak is irrelevant. A bounded number of leaks on an
+/// already-failed path is a better trade than heap corruption by the kernel.
+///
+/// The unbounded accumulation itself is a separate, pre-existing concern: it is
+/// a memory-growth vector during a storm whether or not anything leaks.
+impl Drop for InflightRegistry {
+    fn drop(&mut self) {
+        if self.inflight.is_empty() {
+            return;
+        }
+        let mut bytes = 0u64;
+        let count = self.inflight.len() as u64;
+        for entry in self.inflight.drain(..) {
+            bytes += entry.bytes.len() as u64;
+            // The allocation is deliberately never returned to the allocator:
+            // the kernel may still write into it.
+            std::mem::forget(entry);
+        }
+        RETAINED_BUFFERS.fetch_add(count, Ordering::Relaxed);
+        RETAINED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+        eprintln!(
+            "xpf-userspace-dp: io_uring teardown retained {count} unproven buffer(s)              ({bytes} bytes) — the kernel may still reference them, so they are              leaked rather than freed (#7106)"
+        );
+    }
 }
 
 /// Bound on wait retries so a pathological always-EINTR storm cannot wedge a

--- a/userspace-dp/src/io_uring_write_tests.rs
+++ b/userspace-dp/src/io_uring_write_tests.rs
@@ -711,3 +711,222 @@ fn drain_empty_is_noop() {
     assert_eq!(ring.cancel_calls, 0);
     assert_eq!(ring.wait_calls, 0);
 }
+
+// ---------------------------------------------------------------------------
+// #7106 measurement: what does the ceiling-during-teardown residual actually
+// cost, and what would the proposed `mem::forget` hardening leak?
+// ---------------------------------------------------------------------------
+
+/// #7106 MEASUREMENT (not an assertion): how many entries can be live in the
+/// registry at teardown, and how many bytes would the proposed leak retain?
+///
+/// #7106 asks whether to give `InflightRegistry` a `Drop` that `mem::forget`s
+/// any entry the teardown drain could not prove terminal, making the #5800
+/// buffer-lifetime invariant hold unconditionally at the cost of a leak. The
+/// issue's own framing says to weigh "how many entries can actually be live at
+/// teardown (`reap_ready` runs at the top of every write, so the steady-state
+/// answer is 0)".
+///
+/// That parenthetical is right about steady state and is not the question the
+/// leak has to survive. `reap_ready` reclaims entries whose CQE has SURFACED;
+/// during the storm that produces deferrals, none has. So this measures the
+/// accumulation directly rather than reasoning about it.
+#[test]
+#[ignore = "measurement, not an assertion; run with --ignored --nocapture"]
+fn measure_teardown_residual_7106() {
+    // Payload sizes of the two real ring users:
+    //   slowpath.rs:590   ring.write(fd, bytes, false, "slow-path")  -- one packet
+    //   state_writer.rs:436 ring.write(fd, data, true, "state")      -- a snapshot
+    const SLOW_PATH_PKT: usize = 1500;
+    const STATE_SNAPSHOT: usize = 256 * 1024;
+
+    println!("\n#7106: registry accumulation under a sustained EINTR storm");
+    println!("(every write defers: its CQE never surfaces, so reap_ready reclaims nothing)");
+    println!(" writes   inflight_len   slow-path bytes   state bytes");
+    let mut reg = InflightRegistry::new();
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+    for n in 1..=64usize {
+        let out = write_all(&mut ring, &mut reg, vec![0u8; 64], false, "slow-path");
+        assert!(
+            matches!(out, WriteResult::Deferred { .. }),
+            "write {n} must defer for this measurement to mean anything"
+        );
+        if n == 1 || n == 8 || n == 16 || n == 32 || n == 64 {
+            let len = reg.inflight_len();
+            println!(
+                "{n:7}   {len:12}   {:15}   {:11}",
+                len * SLOW_PATH_PKT,
+                len * STATE_SNAPSHOT
+            );
+        }
+    }
+
+    // Does the accumulation drain once the storm ends? This is what decides
+    // whether it is a transient spike or a monotonic leak in normal operation.
+    let before = reg.inflight_len();
+    ring.complete_inflight_now(64);
+    reg.reap_ready(&mut ring);
+    println!(
+        "\nafter the storm ends and completions surface: {before} -> {} live",
+        reg.inflight_len()
+    );
+
+    // And the state-writer ring, whose SQ is only 8 entries deep (RingWriter::new(8))
+    // versus the slow path's 256 (slowpath.rs:522) -- does the SQ depth bound
+    // the registry?
+    let mut reg2 = InflightRegistry::new();
+    let mut ring2 = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+    for _ in 0..32 {
+        let _ = write_all(&mut ring2, &mut reg2, vec![0u8; 64], true, "state");
+    }
+    println!(
+        "state-ring shape after 32 deferred writes: inflight_len={} (SQ depth is 8)",
+        reg2.inflight_len()
+    );
+}
+
+/// #7106 fail-on-revert (the hardening #6168 left on the board): a buffer the
+/// teardown drain could not PROVE terminal must be retained, not returned to
+/// the allocator, when the registry drops.
+///
+/// Before this, such a buffer was freed by `Vec`'s own `Drop`. `RingWriter`'s
+/// field order closes the ring fd first, but `close()` does not wait —
+/// `io_uring_release` only queues `io_ring_exit_work` — so a write still
+/// executing in io-wq could be writing into that allocation as it returned to
+/// the allocator. Field order narrows the window; it is not a barrier.
+///
+/// Observed through the production counters, which are also the operator signal
+/// the condition otherwise has none of. They are process-global and cumulative,
+/// so this asserts a DELTA. Exact equality is correct under the project's
+/// mandated `-- --test-threads=1` (parallel `cargo test` deadlocks this crate
+/// anyway); a concurrent registry drop is the only thing that could inflate it.
+///
+/// FAIL-ON-REVERT: delete `impl Drop for InflightRegistry` and `Vec`'s Drop
+/// frees the buffer again — both deltas are 0 and this goes RED.
+#[test]
+fn unproven_buffers_are_retained_not_freed_7106() {
+    const PAYLOAD: usize = 4096;
+    let before_bufs = super::RETAINED_BUFFERS.load(std::sync::atomic::Ordering::Relaxed);
+    let before_bytes = super::RETAINED_BYTES.load(std::sync::atomic::Ordering::Relaxed);
+    {
+        // A fatal ring: every wait returns the permanent error, so the drain
+        // can prove nothing and retains the entry.
+        let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EBADF);
+        let mut reg = InflightRegistry::new();
+        let out = write_all(&mut ring, &mut reg, vec![0u8; PAYLOAD], false, "slow-path");
+        assert!(
+            matches!(out, WriteResult::Deferred { fatal_ring: true, .. }),
+            "precondition: a fatal ring must defer the buffer"
+        );
+        assert_eq!(
+            reg.drain_for_teardown(&mut ring),
+            0,
+            "precondition: a fatal ring cannot prove release, so the drain frees nothing"
+        );
+        assert_eq!(reg.inflight_len(), 1, "precondition: the entry is retained");
+    } // the registry drops HERE — this is the subject.
+
+    assert_eq!(
+        super::RETAINED_BUFFERS.load(std::sync::atomic::Ordering::Relaxed) - before_bufs,
+        1,
+        "the unproven buffer must be RETAINED at registry drop, not freed. \
+         Freeing it hands an allocation the kernel may still be writing into \
+         back to the allocator (#7106)"
+    );
+    assert_eq!(
+        super::RETAINED_BYTES.load(std::sync::atomic::Ordering::Relaxed) - before_bytes,
+        PAYLOAD as u64,
+        "the retained BYTES must be accounted too — the count alone does not \
+         tell an operator how much memory a retiring ring abandoned"
+    );
+}
+
+/// #7106: the leak is confined to unproven entries. A drain that PROVES every
+/// entry terminal must free them normally and retain nothing.
+///
+/// Without this, `unproven_buffers_are_retained_not_freed_7106` is satisfied by
+/// a `Drop` that leaks unconditionally — which would turn every ordinary ring
+/// retirement into a leak, including the overwhelmingly common case where the
+/// drain works.
+#[test]
+fn a_proven_drain_retains_nothing_7106() {
+    let before_bufs = super::RETAINED_BUFFERS.load(std::sync::atomic::Ordering::Relaxed);
+    {
+        let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+        let mut reg = InflightRegistry::new();
+        let out = write_all(&mut ring, &mut reg, vec![0u8; 64], false, "slow-path");
+        assert!(matches!(out, WriteResult::Deferred { .. }));
+        // The storm ends: the write's terminal CQE surfaces and is reaped.
+        ring.complete_inflight_now(64);
+        reg.reap_ready(&mut ring);
+        assert_eq!(
+            reg.inflight_len(),
+            0,
+            "precondition: a proven-terminal entry is released before drop"
+        );
+    }
+    assert_eq!(
+        super::RETAINED_BUFFERS.load(std::sync::atomic::Ordering::Relaxed),
+        before_bufs,
+        "a registry that proved every entry terminal must leak NOTHING; a \
+         Drop that forgets unconditionally would leak on every ordinary ring \
+         retirement"
+    );
+}
+
+/// #7106 (#6168 task 3): `RingWriter`'s field DECLARATION ORDER is load-bearing
+/// and was guarded only by a comment.
+///
+/// Rust drops struct fields in declaration order, so `ring` before `inflight`
+/// means the ring fd closes — starting the kernel's teardown — before the
+/// registry drops. Swapping the two declarations compiles, passes every
+/// behavioural test, and silently removes that ordering.
+///
+/// Source-text rather than behavioural because Rust cannot reflect declaration
+/// order: there is no runtime observable to assert on. Same instrument as the
+/// existing `*_doc_guard` tests. Comments are stripped first, because this
+/// file and the struct's own comment both NAME the fields and an unstripped
+/// scan would match the prose describing the invariant rather than the
+/// invariant.
+#[test]
+fn ring_writer_drops_the_ring_before_the_registry_7106() {
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("io_uring_write.rs"),
+    )
+    .expect("io_uring_write.rs must be readable");
+    let code: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let start = code
+        .find("pub(crate) struct RingWriter {")
+        .expect(
+            "struct RingWriter not found — either it was renamed, in which case \
+             this guard is scanning for something that no longer exists, or the \
+             drop-order invariant moved. Either way this is not evidence.",
+        );
+    let body_end = code[start..]
+        .find('}')
+        .expect("unterminated struct RingWriter");
+    let body = &code[start..start + body_end];
+
+    let ring_at = body
+        .find("ring:")
+        .expect("RingWriter has no `ring` field; the guard cannot speak for it");
+    let inflight_at = body
+        .find("inflight:")
+        .expect("RingWriter has no `inflight` field; the guard cannot speak for it");
+
+    assert!(
+        ring_at < inflight_at,
+        "`ring` must be DECLARED before `inflight`. Rust drops fields in \
+         declaration order, so this ordering is what closes the ring fd — \
+         starting the kernel's teardown — before the registry drops and \
+         releases buffers. Swapping them compiles and passes every behavioural \
+         test while silently widening the #6168 window (#7106)"
+    );
+}

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -393,6 +393,19 @@ pub(crate) struct ProcessStatus {
     /// packet). Additive / defaulted for backward compatibility.
     #[serde(rename = "pending_neigh_decap_drops_total", default)]
     pub pending_neigh_decap_drops_total: u64,
+    /// #7106: buffers this process RETAINED (leaked) at io_uring ring teardown
+    /// because the bounded drain could not prove the kernel was done with them.
+    ///
+    /// Cumulative and normally 0. Non-zero means a ring was retired while
+    /// writes it had submitted could not be proven terminal, so their buffers
+    /// were deliberately not returned to the allocator. Without this the
+    /// condition is silent by construction: the whole point is that nothing
+    /// further is ever heard about those writes.
+    #[serde(rename = "io_uring_retained_buffers_total", default)]
+    pub io_uring_retained_buffers_total: u64,
+    /// Bytes held by `io_uring_retained_buffers_total`.
+    #[serde(rename = "io_uring_retained_bytes_total", default)]
+    pub io_uring_retained_bytes_total: u64,
     /// #2375: MissingNeighbor packets for a NEW distinct
     /// `(egress_ifindex, next_hop)` refused because `pending_neigh` is at
     /// `MAX_PENDING_NEIGH` distinct hops (distinct-hop neighbor

--- a/userspace-dp/src/server/helpers/status.rs
+++ b/userspace-dp/src/server/helpers/status.rs
@@ -74,6 +74,12 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // outer-frame/inner-meta pairing must never reach the in-place
     // retry TX path).
     state.status.pending_neigh_decap_drops_total = state.afxdp.pending_neigh_decap_drops_total();
+    // #7106: process-global, not per-binding — a registry that retains buffers
+    // is being dropped, so the count has to outlive it.
+    state.status.io_uring_retained_buffers_total =
+        crate::io_uring_write::RETAINED_BUFFERS.load(std::sync::atomic::Ordering::Relaxed);
+    state.status.io_uring_retained_bytes_total =
+        crate::io_uring_write::RETAINED_BYTES.load(std::sync::atomic::Ordering::Relaxed);
     // #2375: distinct-hop capacity-drop gate at pending_neigh admission
     // (a NEW unresolved hop refused because the map is at
     // MAX_PENDING_NEIGH) — the scan/upstream-outage failure mode, kept

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -224,6 +224,8 @@ pub(crate) fn run() -> Result<(), String> {
             neg_neigh_fast_fail_total: 0,
             pending_neigh_duplicate_drops_total: 0,
             pending_neigh_decap_drops_total: 0,
+            io_uring_retained_buffers_total: 0,
+            io_uring_retained_bytes_total: 0,
             pending_neigh_capacity_drops_total: 0,
             dynamic_neighbor_learn_cap_drops_total: 0,
             session_publish_errors_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -883,6 +883,8 @@
     "io_uring_last_error": "",
     "io_uring_mode": "",
     "io_uring_planned": false,
+    "io_uring_retained_buffers_total": 0,
+    "io_uring_retained_bytes_total": 0,
     "last_cache_flush_at": 0,
     "last_fib_generation": 0,
     "last_snapshot_generation": 0,


### PR DESCRIPTION
#6168 fixed the docs half and recorded the residual as **ACCEPTED**: an entry
`drain_for_teardown` cannot prove terminal is retained and then **freed** when the
registry drops. `RingWriter`'s field order closes the ring fd first, but
`close()` does not wait — `io_uring_release` only *queues* `io_ring_exit_work` —
so a write still executing in io-wq can be writing into that allocation as it
returns to the allocator. Field order narrows the window; it is not a barrier.

## Measured, because the title says "optionally"

#7106 asks how many entries can be live at teardown, noting that `reap_ready`
runs at the top of every write "so the steady-state answer is 0". That is right
about steady state and **is not the state the leak fires in**: `reap_ready`
reclaims entries whose CQE has *surfaced*, and during the storm that produces
deferrals, none has.

| writes deferred | `inflight_len` | slow-path bytes | state-ring bytes |
|---|---|---|---|
| 1 | 1 | 1,500 | 262,144 |
| 16 | 16 | 24,000 | 4,194,304 |
| 64 | 64 | 96,000 | 16,777,216 |

Growth is 1:1 and uncapped, and **the SQ depth does not bound it** — the
state-writer ring's SQ is 8, yet it held 32 entries after 32 deferred writes. It
*does* drain fully once the storm ends (64 → 0), so it is transient in normal
operation.

## Verdict: take the hardening

The leak is unbounded in **size**. What decides the trade is that it is bounded
in **frequency**: `retire_ring_to_sync` explicitly does **not re-promote** (no
flapping), so a `RingWriter` drops at most once per ring per process — on a ring
already being abandoned as broken — or at process exit, where a leak is
irrelevant.

A bounded number of leaks on an already-failed path beats a use-after-free in
which the **kernel** writes into freed heap. Leaking a buffer whose release
cannot be proven is also the standard io_uring idiom rather than a cop-out: no
ordering of drops can make the fd close a barrier.

The unbounded **accumulation** is a separate, pre-existing memory-growth vector —
filed as  rather than folded in.

## Also landed, from #6168's task list

- **Observability** — `io_uring_retained_buffers_total` / `_bytes_total` on the
  status wire plus a log line. The condition is *silent by construction*: the
  whole point is that nothing further is ever heard about those writes.
- **Field-order guard** — `ring`-before-`inflight` was load-bearing and guarded
  only by a comment. Source-text, because Rust cannot reflect declaration order,
  so there is no runtime observable to assert on.

## Mutation matrix

| cell | edit | verdict | reds |
|------|------|---------|------|
| control | none | GREEN 4868 | — |
| m1 | delete `impl Drop for InflightRegistry` | RED | retention test, alone |
| m2 | neuter `reap_ready` so proven entries reach Drop | RED | over-reach guard + a pre-existing #5800 test |
| m3 | swap `RingWriter`'s field declaration order | RED | field-order guard, alone |

**m2 is the over-reach cell and it earns its place**: without it, m1's test is
satisfied by a `Drop` that leaks *unconditionally*, which would turn every
ordinary ring retirement into a leak — including the overwhelmingly common case
where the drain works.

m1's first attempt was a **VOID, not a red** — my slice left invalid Rust
(`collected=0`). Re-done with brace matching.

## Golden

`protocol_wire_v1.json` needed regenerating; the diff was **classified before
accepting**: 2 keys added (both new counters), **0 removed, 0 values changed**,
both added keys 0 in the default specimen.

Reasoning in `docs/log/7106.md`.

Closes #7106