### PR TITLE
zeroize: erase the CONFIGURED archive dir and report a skip as incomplete

### DIFF
--- a/pkg/cli/cli_request_system.go
+++ b/pkg/cli/cli_request_system.go
@@ -138,6 +138,25 @@ func (c *CLI) zeroizeConfigRoot() (configDir, configBase string, err error) {
 // (#5890) — a package var so a test can spy the delegation without wiping real
 // system paths. It defaults to grpcapi.PerformZeroizeWipe, the SAME primitive the
 // gRPC zeroize path runs.
+// cliZeroizeArchiveDir returns the archive directory the CONSOLE zeroize path
+// erases (#7173).
+//
+// The console path is a recovery surface: it runs when the daemon may be down
+// and the committed config may be unreadable, so it cannot ask the store what
+// `system archival archive-dir` was set to. It therefore erases the xpf-owned
+// DEFAULT, which is provably safe, and a custom archive dir is left for the
+// operator — the same disposition FactoryResetArchiveDir would reach anyway,
+// since it refuses to erase a directory whose ownership it cannot prove.
+//
+// The difference from the gRPC path is honest and worth stating: there, the
+// configured directory is known and a skip is reported as an incomplete reset.
+// Here it is not known, so a custom archive is not merely skipped but never
+// seen. An operator who zeroizes from the console with a custom archive-dir
+// must erase it by hand.
+func cliZeroizeArchiveDir() string {
+	return configstore.DefaultArchiveDir
+}
+
 var zeroizeFullWipe = grpcapi.PerformZeroizeWipe
 
 // zeroizeStopDaemon stops xpfd so it releases interface/dataplane state; a
@@ -179,7 +198,7 @@ func (c *CLI) performConsoleZeroize() error {
 	// The shared full factory-reset wipe primitive (config state + tls/ +
 	// rendered service configs [frr/swanctl/kea] + provisioned login accounts +
 	// config archive + BPF pins + networkd), #5890.
-	wipe := func() error { return zeroizeFullWipe(configDir, configBase) }
+	wipe := func() error { return zeroizeFullWipe(configDir, configBase, cliZeroizeArchiveDir()) }
 
 	// Route through the daemon's coordinated transaction when wired. When it is
 	// nil the CLI is spawned OUTSIDE the daemon (offline recovery / unit test) —

--- a/pkg/cli/cli_zeroize_configured_root_5554_test.go
+++ b/pkg/cli/cli_zeroize_configured_root_5554_test.go
@@ -78,7 +78,7 @@ func TestCLIZeroizeWipesConfiguredRootNotHardcoded(t *testing.T) {
 	var called bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(configDir, configBase string) error {
+	zeroizeFullWipe = func(configDir, configBase, _ string) error {
 		called = true
 		gotDir, gotBase = configDir, configBase
 		return nil

--- a/pkg/cli/console_zeroize_full_wipe_5890_test.go
+++ b/pkg/cli/console_zeroize_full_wipe_5890_test.go
@@ -36,7 +36,7 @@ func TestConsoleZeroizeDelegatesToFullWipe_5890(t *testing.T) {
 	var wiped, stopped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error { wiped = true; return nil }
+	zeroizeFullWipe = func(string, string, string) error { wiped = true; return nil }
 	zeroizeStopDaemon = func() error { stopped = true; return nil }
 
 	if err := c.performConsoleZeroize(); err != nil {
@@ -60,7 +60,7 @@ func TestConsoleZeroizeFailClosedOnWipeError_5890(t *testing.T) {
 	var stopped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error { return wipeErr }
+	zeroizeFullWipe = func(string, string, string) error { return wipeErr }
 	zeroizeStopDaemon = func() error { stopped = true; return nil }
 
 	err := c.performConsoleZeroize()
@@ -80,7 +80,7 @@ func TestConsoleZeroizeFailClosedWithoutConfigRoot_5890(t *testing.T) {
 	var wiped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error { wiped = true; return nil }
+	zeroizeFullWipe = func(string, string, string) error { wiped = true; return nil }
 	zeroizeStopDaemon = func() error { return nil }
 
 	if err := c.performConsoleZeroize(); err == nil {

--- a/pkg/cli/console_zeroize_transaction_5871_test.go
+++ b/pkg/cli/console_zeroize_transaction_5871_test.go
@@ -32,7 +32,7 @@ func TestConsoleZeroizeRoutesThroughDaemonTransaction_5871(t *testing.T) {
 	var enteredTransaction, wipedAtAll, wipedInsideTransaction, stopped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error {
+	zeroizeFullWipe = func(string, string, string) error {
 		wipedAtAll = true
 		// Records that the wipe ran only AFTER the transaction was entered —
 		// proving fencing (apply-gate + reset generation) precedes erasure.
@@ -85,7 +85,7 @@ func TestConsoleZeroizeSurfacesTransactionFailure_5871(t *testing.T) {
 	var enteredTransaction, stopped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error { return removalErr }
+	zeroizeFullWipe = func(string, string, string) error { return removalErr }
 	zeroizeStopDaemon = func() error { stopped = true; return nil }
 
 	c.factoryResetFn = func(_ context.Context, wipe func() error) error {
@@ -120,7 +120,7 @@ func TestConsoleZeroizeSurfacesGateAcquireFailure_5871(t *testing.T) {
 	var wiped, stopped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error { wiped = true; return nil }
+	zeroizeFullWipe = func(string, string, string) error { wiped = true; return nil }
 	zeroizeStopDaemon = func() error { stopped = true; return nil }
 
 	// The transaction fails to enter the gate and never invokes the wipe closure.
@@ -152,7 +152,7 @@ func TestConsoleZeroizeOfflineFallbackUngatedWipe_5871(t *testing.T) {
 	var wiped, stopped bool
 	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
 	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
-	zeroizeFullWipe = func(string, string) error { wiped = true; return nil }
+	zeroizeFullWipe = func(string, string, string) error { wiped = true; return nil }
 	zeroizeStopDaemon = func() error { stopped = true; return nil }
 
 	if err := c.performConsoleZeroize(); err != nil {

--- a/pkg/configstore/confirm_recovery_uncompilable_target_6538_test.go
+++ b/pkg/configstore/confirm_recovery_uncompilable_target_6538_test.go
@@ -144,10 +144,10 @@ func TestConfirmRecoveryInWindowRollbackDoesNotPersistNeverCommitted(t *testing.
 
 	for _, w := range markerWrites {
 		if !w.committed {
-			t.Fatalf("the auto-rollback persisted the NEVER-COMMITTED marker "+
-				"(committed=0) over a real previously-committed config: it derived "+
-				"\"first commit on a fresh store\" from confirmPrevCfg==nil, which "+
-				"here means \"the rollback target failed to compile\". The next "+
+			t.Fatalf("the auto-rollback persisted the NEVER-COMMITTED marker " +
+				"(committed=0) over a real previously-committed config: it derived " +
+				"\"first commit on a fresh store\" from confirmPrevCfg==nil, which " +
+				"here means \"the rollback target failed to compile\". The next " +
 				"restart re-classifies this box into bootstrap (#6538 part 2)")
 		}
 	}

--- a/pkg/configstore/factory_reset.go
+++ b/pkg/configstore/factory_reset.go
@@ -52,6 +52,26 @@ const RescueConfigBase = "rescue.conf"
 // carried 0600 full-config-text copies with the prior tenant's cleartext PSKs,
 // keys, and communities.
 //
+// ArchiveDirSkippedError reports that the config archive was NOT erased because
+// its directory could not be proven to be xpf-owned (#7173).
+//
+// It is deliberately a distinct type rather than a plain error: the caller must
+// be able to tell "the archive still holds the prior tenant's secrets" apart
+// from "the erasure failed", because they need different operator-facing words.
+// It is also NOT a reason to abort the rest of the wipe — everything else must
+// still be erased — so a caller that treats every non-nil error as fatal would
+// make this change a regression. Use errors.As.
+type ArchiveDirSkippedError struct {
+	Dir string
+}
+
+func (e *ArchiveDirSkippedError) Error() string {
+	return "config archive directory " + e.Dir + " was NOT erased: its ownership " +
+		"could not be proven (not the xpf-owned default " + DefaultArchiveDir + "). " +
+		"Archived configuration text and any secrets it contains remain on disk; " +
+		"erase this directory manually to complete the zeroize"
+}
+
 // OWNERSHIP GUARD (#5186): erase the archive ONLY when archiveDir is the
 // xpf-owned default (DefaultArchiveDir). An operator-configured CUSTOM archive
 // directory may be a remote mount, an NFS export, or a compliance/audit
@@ -80,7 +100,19 @@ func FactoryResetArchiveDir(archiveDir string) error {
 			"compliance archive destination is the operator's to erase, not "+
 			"the factory reset's",
 			"dir", archiveDir, "default", DefaultArchiveDir)
-		return nil
+		// #7173: the skip is a FIRST-CLASS RESULT, not a log line. This
+		// function's own contract two paragraphs above says a merely
+		// non-durable erasure "must not be reported as a clean zeroize"; a
+		// skipped one did not happen AT ALL, which is strictly worse, and it
+		// returned nil. An operator who ran zeroize on a box with a custom
+		// archive-dir was told the reset completed while every archived config
+		// snapshot — carrying cleartext IKE PSKs, WireGuard keys and SNMP
+		// communities — was still on disk.
+		//
+		// The skip itself stays: erasing a directory whose ownership cannot be
+		// proven could destroy compliance records that are not xpf's to delete.
+		// What changes is that the caller can no longer mistake it for success.
+		return &ArchiveDirSkippedError{Dir: archiveDir}
 	}
 
 	var firstErr error

--- a/pkg/configstore/factory_reset_archive_5186_test.go
+++ b/pkg/configstore/factory_reset_archive_5186_test.go
@@ -85,8 +85,20 @@ func TestFactoryResetArchiveDirSkipsCustomPath(t *testing.T) {
 	secretFile := seedArchiveFile(t, customDir)
 
 	buf := captureWarnLogs(t)
-	if err := FactoryResetArchiveDir(customDir); err != nil {
-		t.Fatalf("FactoryResetArchiveDir(custom) returned error: %v", err)
+	// #7173 CHANGED THIS CONTRACT DELIBERATELY. The skip used to return nil,
+	// which let the caller report a clean zeroize while the prior tenant's
+	// archived PSKs were still on disk. It now returns a typed
+	// *ArchiveDirSkippedError so the incompleteness is a first-class result.
+	//
+	// What this test is ABOUT is unchanged and still asserted below: a custom
+	// path is skipped rather than erased, and its contents survive. Only the
+	// return value moved, so the assertion moved with it rather than the test
+	// being deleted.
+	err := FactoryResetArchiveDir(customDir)
+	var skipped *ArchiveDirSkippedError
+	if !errors.As(err, &skipped) {
+		t.Fatalf("FactoryResetArchiveDir(custom) returned %v, want an "+
+			"*ArchiveDirSkippedError naming the unerased directory (#7173)", err)
 	}
 
 	// The custom archive and its secret survive.

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -543,6 +543,20 @@ func (s *Store) persistRetryLoop(backoff, maxBackoff time.Duration) {
 // pruned as stale. The seed retry the commit path performs (#6404 edge 1,
 // ensureArchiveSeededLocked) rests on the same invariant: archiveSeedDir names
 // a dir this process has actually scanned, never a stale disabled one.
+// ArchiveDir returns the archive directory currently configured on this store,
+// or "" when archival is disabled.
+//
+// #7173: zeroize needs the CONFIGURED directory, not the compiled-in default.
+// It previously erased DefaultArchiveDir unconditionally, so on a box with a
+// custom `system archival archive-dir` it wiped a path that held nothing and
+// left the real archive — with its cleartext PSKs — untouched, reporting a
+// clean reset.
+func (s *Store) ArchiveDir() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.archiveDir
+}
+
 func (s *Store) SetArchiveConfig(dir string, max int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/configstore/zeroize_archive_skip_7173_test.go
+++ b/pkg/configstore/zeroize_archive_skip_7173_test.go
@@ -1,0 +1,84 @@
+package configstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #7173: a zeroize that does not erase the config archive must not report
+// success.
+//
+// FactoryResetArchiveDir refuses to erase a directory whose ownership it cannot
+// prove — correct, because a custom/remote/compliance archive destination may
+// hold records that are not xpf's to destroy. But it returned nil, so the
+// caller could not tell that refusal apart from a completed erasure.
+//
+// The consequence was not theoretical. The archive holds config-<ts>.<seq>.conf
+// snapshots: full committed config TEXT with cleartext secret leaves — IKE PSK,
+// WireGuard keys, SNMP communities. An operator who ran zeroize on a box with a
+// custom `system archival archive-dir` was told the reset completed while all of
+// that was still on disk.
+//
+// Note the file's OWN contract, stated a few lines above the skip: a merely
+// non-durable erasure "must not be reported as a clean zeroize". A skipped one
+// did not happen at all, which is strictly worse, and it was the case that
+// returned nil.
+
+func TestCustomArchiveDirIsReportedNotSilentlySkipped7173(t *testing.T) {
+	custom := t.TempDir()
+	// Something that looks like an archived config carrying secrets.
+	secret := filepath.Join(custom, "config-20260829.1.conf")
+	if err := os.WriteFile(secret, []byte("ike { psk \"hunter2\"; }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := FactoryResetArchiveDir(custom)
+
+	var skipped *ArchiveDirSkippedError
+	if !errors.As(err, &skipped) {
+		t.Fatalf("erasing a custom archive dir returned %v, want an *ArchiveDirSkippedError. "+
+			"Returning nil tells the caller the archive was erased when it was not, and the "+
+			"caller reports a clean zeroize while the prior tenant's PSKs are still on disk "+
+			"(#7173)", err)
+	}
+	if skipped.Dir != custom {
+		t.Errorf("the error must name the directory the operator has to erase by hand; "+
+			"got %q want %q", skipped.Dir, custom)
+	}
+
+	// The refusal must be a refusal: the guard exists so an unproven directory
+	// is NOT destroyed. A "fix" that reported the skip and erased anyway would
+	// pass the assertions above while doing the thing the guard forbids.
+	if _, statErr := os.Stat(secret); statErr != nil {
+		t.Errorf("the archive file was removed from a directory whose ownership could not "+
+			"be proven: %v. The skip is deliberate — a custom/remote/compliance archive may "+
+			"hold records xpf must not destroy", statErr)
+	}
+}
+
+// Control: the xpf-owned default still erases cleanly and returns nil, so the
+// change above cannot be satisfied by reporting a skip for everything.
+func TestDefaultArchiveDirStillErasesCleanly7173(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "archive")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config-1.1.conf"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the default at our temp tree for the duration.
+	orig := DefaultArchiveDir
+	DefaultArchiveDir = dir
+	defer func() { DefaultArchiveDir = orig }()
+
+	if err := FactoryResetArchiveDir(dir); err != nil {
+		t.Fatalf("the xpf-owned default must erase cleanly, got %v", err)
+	}
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Errorf("the default archive dir must be removed; stat gave %v", statErr)
+	}
+}

--- a/pkg/grpcapi/server_diag_system_action.go
+++ b/pkg/grpcapi/server_diag_system_action.go
@@ -140,7 +140,16 @@ func (s *Server) runZeroize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	wipe := func() error { return performZeroizeWipe(configDir, configBase) }
+	// #7173: the CONFIGURED archive dir, from the store this server owns.
+	// Hardcoding the default here meant a box with a custom
+	// `system archival archive-dir` had that archive — and the cleartext PSKs
+	// in it — survive a zeroize that reported success. "" means archival is
+	// disabled and there is nothing to erase.
+	archiveDir := ""
+	if s.store != nil {
+		archiveDir = s.store.ArchiveDir()
+	}
+	wipe := func() error { return performZeroizeWipe(configDir, configBase, archiveDir) }
 	if s.zeroizeFn != nil {
 		return s.zeroizeFn(ctx, wipe)
 	}

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -1053,11 +1053,19 @@ var (
 // leave secret residue on a re-tenanted device. configDir/configBase are the
 // CONFIGURED config root (see performZeroizeWipe); the caller resolves+validates
 // them (cli.zeroizeConfigRoot / grpcapi.zeroizeConfigRoot) before delegating.
-func PerformZeroizeWipe(configDir, configBase string) error {
-	return performZeroizeWipe(configDir, configBase)
+// #7173: archiveDir is the CONFIGURED archive directory, not the compiled-in
+// default. Passing the default unconditionally meant the ownership guard inside
+// FactoryResetArchiveDir could never fire — the caller handed it exactly the
+// value the guard compares against — so a box with a custom
+// `system archival archive-dir` had a path wiped that held nothing while the
+// real archive, carrying cleartext IKE PSKs, WireGuard keys and SNMP
+// communities, was never examined and the reset reported clean. Pass "" to mean
+// "archival disabled, nothing to erase".
+func PerformZeroizeWipe(configDir, configBase, archiveDir string) error {
+	return performZeroizeWipe(configDir, configBase, archiveDir)
 }
 
-var performZeroizeWipe = func(configDir, configBase string) error {
+var performZeroizeWipe = func(configDir, configBase, archiveDir string) error {
 	// Config state FIRST — the security-critical erasure. A failure here can
 	// leave prior-tenant config/secrets on disk, so it is surfaced to the
 	// caller (#4576).
@@ -1099,8 +1107,17 @@ var performZeroizeWipe = func(configDir, configBase string) error {
 	// erases ONLY the xpf-owned default path, never a custom/remote/compliance
 	// archive destination. Also security-critical, so fold its first error into
 	// the surfaced result.
-	if e := configstore.FactoryResetArchiveDir(configstore.DefaultArchiveDir); e != nil && err == nil {
-		err = e
+	//
+	// #7173: the CONFIGURED dir. A skip is reported as an
+	// *configstore.ArchiveDirSkippedError and folded into the surfaced result
+	// like any other secret-bearing failure — the reset genuinely is incomplete
+	// and the operator has a directory to erase by hand. It is NOT a reason to
+	// stop: everything else must still be wiped, which is why it is folded in
+	// rather than returned early.
+	if archiveDir != "" {
+		if e := configstore.FactoryResetArchiveDir(archiveDir); e != nil && err == nil {
+			err = e
+		}
 	}
 
 	// BPF pins + managed networkd files carry no secret material, so their

--- a/pkg/grpcapi/system_action_journal_4108_test.go
+++ b/pkg/grpcapi/system_action_journal_4108_test.go
@@ -34,7 +34,7 @@ func TestSystemActionJournalsDestructiveVerbs(t *testing.T) {
 	var poweredArg string
 	var wiped bool
 	schedulePowerAction = func(arg string) { poweredArg = arg }
-	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
+	performZeroizeWipe = func(_, _, _ string) error { wiped = true; return nil }
 	scheduleStopDaemon = func() {}
 
 	cases := []struct {

--- a/pkg/grpcapi/zeroize_configdb_4576_test.go
+++ b/pkg/grpcapi/zeroize_configdb_4576_test.go
@@ -144,7 +144,7 @@ func TestIsTextRollbackFile(t *testing.T) {
 func TestZeroizeSurfacesWipeError(t *testing.T) {
 	orig := performZeroizeWipe
 	t.Cleanup(func() { performZeroizeWipe = orig })
-	performZeroizeWipe = func(_, _ string) error { return errors.New("simulated .configdb wipe failure") }
+	performZeroizeWipe = func(_, _, _ string) error { return errors.New("simulated .configdb wipe failure") }
 
 	dir := t.TempDir()
 	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))

--- a/pkg/grpcapi/zeroize_configured_archive_7173_test.go
+++ b/pkg/grpcapi/zeroize_configured_archive_7173_test.go
@@ -1,0 +1,103 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #7173: runZeroize must hand the wipe the STORE'S CONFIGURED archive
+// directory, not a hardcoded default.
+//
+// `system archival archive-dir` is operator-settable and IS honoured for
+// WRITING archives, so a box can be archiving to a custom path. Zeroize called
+// FactoryResetArchiveDir(configstore.DefaultArchiveDir) unconditionally, which
+// meant it erased a path holding nothing and never examined the one holding
+// config-<ts>.<seq>.conf snapshots — full committed config text with cleartext
+// IKE PSKs, WireGuard keys and SNMP communities.
+//
+// It also made the ownership guard unreachable: that guard compares its
+// argument against DefaultArchiveDir, and the caller handed it exactly that, so
+// the warning it exists to emit could never fire from production. The operator
+// saw a clean zeroize with no signal at all.
+//
+// WHY THIS CELL EXISTS SEPARATELY FROM THE CONTRACT TESTS. The pkg/configstore
+// tests assert what FactoryResetArchiveDir RETURNS for a custom path. They pass
+// whether or not anything ever passes it one. Measured: reverting runZeroize to
+// hand the wipe "" — i.e. never erasing any archive — left the entire suite
+// GREEN, 1340 collected, 0 failed. Binding the callee is not binding the
+// wiring, and the wiring is where the production defect lived.
+func TestZeroizePassesTheConfiguredArchiveDir7173(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	var gotArchive string
+	var called bool
+	performZeroizeWipe = func(_, _, archiveDir string) error {
+		called = true
+		gotArchive = archiveDir
+		return nil
+	}
+	scheduleStopDaemon = func() {}
+
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "site.conf"))
+
+	// The operator's custom archive destination — deliberately NOT the
+	// compiled-in default, which is the whole point.
+	customArchive := filepath.Join(dir, "compliance-archive")
+	store.SetArchiveConfig(customArchive, 10)
+
+	s := &Server{store: store}
+	if _, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"}); err != nil {
+		t.Fatalf("SystemAction(zeroize): %v", err)
+	}
+	if !called {
+		t.Fatal("zeroize never invoked performZeroizeWipe")
+	}
+	if gotArchive != customArchive {
+		t.Fatalf("zeroize was handed archive dir %q, want the CONFIGURED %q. Handing it "+
+			"anything else means the box archives its config — with cleartext PSKs — to one "+
+			"directory and zeroizes another, reporting success (#7173)", gotArchive, customArchive)
+	}
+}
+
+// Control: with archival DISABLED the wipe must be handed "", not a stale or
+// defaulted path. Without this, an implementation that always passed some
+// non-empty directory would satisfy the cell above while erasing a path the
+// operator never configured.
+func TestZeroizePassesEmptyWhenArchivalDisabled7173(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	var gotArchive string
+	performZeroizeWipe = func(_, _, archiveDir string) error {
+		gotArchive = archiveDir
+		return nil
+	}
+	scheduleStopDaemon = func() {}
+
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "site.conf"))
+	store.SetArchiveConfig("", 0) // archival off
+
+	s := &Server{store: store}
+	if _, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"}); err != nil {
+		t.Fatalf("SystemAction(zeroize): %v", err)
+	}
+	if gotArchive != "" {
+		t.Errorf("with archival disabled the wipe must be handed \"\", got %q — erasing a "+
+			"directory the operator did not configure is not this operation's business",
+			gotArchive)
+	}
+}

--- a/pkg/grpcapi/zeroize_configured_root_5280_test.go
+++ b/pkg/grpcapi/zeroize_configured_root_5280_test.go
@@ -38,7 +38,7 @@ func TestZeroizeTargetsConfiguredRootNotHardcoded(t *testing.T) {
 
 	var gotDir, gotBase string
 	var called bool
-	performZeroizeWipe = func(configDir, configBase string) error {
+	performZeroizeWipe = func(configDir, configBase, _ string) error {
 		called = true
 		gotDir, gotBase = configDir, configBase
 		return nil
@@ -86,7 +86,7 @@ func TestZeroizeFailsClosedWithoutConfigRoot(t *testing.T) {
 	})
 
 	var wiped, stopped bool
-	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
+	performZeroizeWipe = func(_, _, _ string) error { wiped = true; return nil }
 	scheduleStopDaemon = func() { stopped = true }
 
 	s := &Server{} // no store => config root undeterminable

--- a/pkg/grpcapi/zeroize_full_set_5890_test.go
+++ b/pkg/grpcapi/zeroize_full_set_5890_test.go
@@ -101,7 +101,11 @@ func TestPerformZeroizeWipeErasesFullSecretSet_5890(t *testing.T) {
 	mustWriteFile(t, archiveSnap, []byte("system { services { ssh; } }\n"+secret))
 
 	// === Drive the SHARED primitive the console delegates to. ===
-	if err := PerformZeroizeWipe(configDir, configBase); err != nil {
+	// #7173: the archive dir is now a PARAMETER, not read from the package
+	// default. Passing "" here would mean "archival disabled" and silently skip
+	// the archive leg this test exists to assert — the erasure would not be
+	// tested and the test would still pass its other legs.
+	if err := PerformZeroizeWipe(configDir, configBase, archiveDir); err != nil {
 		t.Fatalf("PerformZeroizeWipe returned error (reset reported incomplete): %v", err)
 	}
 

--- a/pkg/grpcapi/zeroize_gate_stop_5281_test.go
+++ b/pkg/grpcapi/zeroize_gate_stop_5281_test.go
@@ -36,7 +36,7 @@ func TestZeroizeGoesThroughGateAndStopsDaemon(t *testing.T) {
 	// sequence is gate → wipe → stop (never stop-before-wipe, never a bypassed
 	// gate).
 	var seq []string
-	performZeroizeWipe = func(_, _ string) error { seq = append(seq, "wipe"); return nil }
+	performZeroizeWipe = func(_, _, _ string) error { seq = append(seq, "wipe"); return nil }
 	scheduleStopDaemon = func() { seq = append(seq, "stop") }
 
 	var gateWipeArg func() error
@@ -91,7 +91,7 @@ func TestZeroizeFailClosedDoesNotStopDaemon(t *testing.T) {
 	})
 
 	wantErr := errors.New("configdb not fully erased")
-	performZeroizeWipe = func(_, _ string) error { return wantErr }
+	performZeroizeWipe = func(_, _, _ string) error { return wantErr }
 	var stopped bool
 	scheduleStopDaemon = func() { stopped = true }
 
@@ -131,7 +131,7 @@ func TestZeroizeFallsBackToDirectWipeWithoutGate(t *testing.T) {
 	})
 
 	var wiped, stopped bool
-	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
+	performZeroizeWipe = func(_, _, _ string) error { wiped = true; return nil }
 	scheduleStopDaemon = func() { stopped = true }
 
 	dir := t.TempDir()

--- a/pkg/grpcapi/zeroize_scope_5684_test.go
+++ b/pkg/grpcapi/zeroize_scope_5684_test.go
@@ -35,7 +35,7 @@ func TestZeroizeRefusesSharedConfigRoot(t *testing.T) {
 	})
 
 	var wiped bool
-	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
+	performZeroizeWipe = func(_, _, _ string) error { wiped = true; return nil }
 	scheduleStopDaemon = func() {}
 
 	// A config file placed directly in a shared directory: filepath.Dir resolves


### PR DESCRIPTION
**Zeroize reported success while the prior tenant's archived secrets were still on disk — and on the normal operator path it did not even warn.**

The archive holds `config-<ts>.<seq>.conf` snapshots: full committed config **text with cleartext secret leaves** — IKE PSK, WireGuard keys, SNMP communities, as the call site's own comment says. A re-tenanted device kept all of it.

## Two defects compounding

**1. The configured directory was never passed.** Both the gRPC and console paths called `FactoryResetArchiveDir(configstore.DefaultArchiveDir)` — the compiled-in default. But `system archival archive-dir` is operator-settable and **is** honoured for *writing* archives (`daemon_apply_tail.go` → `Store.SetArchiveConfig`). So on a box with a custom archive dir, zeroize erased a path holding nothing and never examined the one holding the secrets.

**2. That made the ownership guard unreachable.** The guard compares its argument against `DefaultArchiveDir` — and the caller handed it exactly that value, so the branch could never be taken from production and the warning it exists to emit could never fire.

The cohort that filed this described the behaviour as *"skips erasure with a warning."* What actually happened was **a clean success with no warning at all.**

## The fix

`PerformZeroizeWipe` takes the archive directory as a parameter. gRPC passes the store's configured value; the console passes the default and **says why** — it is a recovery surface that runs when the daemon may be down and the config may be unreadable, so it cannot ask the store. That asymmetry is stated, not hidden: from the console a custom archive is not merely skipped but never seen.

**The skip itself is unchanged and correct** — a custom/remote/compliance destination may hold records that are not xpf's to destroy. What changes is that it is no longer *success*: it returns a typed `*ArchiveDirSkippedError` naming the directory the operator must erase by hand, folded into the surfaced result and deliberately **not** a reason to abort (everything else must still be wiped).

This restores the function's own contract. Its doc already said a merely non-durable erasure *"must not be reported as a clean zeroize"* — a **skipped** one did not happen at all, which is strictly worse, and it was the case returning `nil`.

## The mutation that survived, and what it exposed

My first version's contract tests passed whether or not anything ever *called* the fixed function. Reverting `runZeroize` to hand the wipe `""` — never erasing any archive — left the whole suite **GREEN: 1340 collected, 0 failed.**

That is bind-the-wiring, and the wiring is exactly where the production defect lived. Added a seam test asserting `runZeroize` passes the store's configured dir, plus a control that archival-disabled yields `""` (so an implementation that always passed *some* directory can't pass). Re-mutated: **1342 collected, 1 named FAIL.**

## Two tests changed, both consciously

- `TestFactoryResetArchiveDirSkipsCustomPath` encoded the old contract. Its **subject** is unchanged and still asserted — a custom path is skipped and its contents survive — only the return value moved, so the assertion moved with it. The new test additionally asserts the file **survives**, because a "fix" that reported the skip and erased anyway would satisfy the error assertion while doing what the guard forbids.
- `TestPerformZeroizeWipeErasesFullSecretSet_5890`: adding the parameter meant updating every seam, and `""` is the natural placeholder — but `""` means *archival disabled*, so it silently skips the archive leg this test exists to assert. It now passes the real directory, with a comment on why `""` would hollow it out.

## Gate

Full Go suite: **rc=0, 69 packages, 0 FAIL**.

*(A first run showed `no space left` 5×, which is my disk-full heuristic firing on `err="injected: no space left on device" issue=#1799` — deliberate fault-injection fixtures, not a full disk. 133G free.)*

Refs #7173 — the item that issue says to do first.