### PR TITLE
Model ntp server modifiers via valueList

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3966,11 +3966,37 @@ mis-nest the second gateway as an orphan child. `next-hop` therefore sets
 `valueList: true`, which tells `SetPath` (`ast_edit.go`) to absorb a trailing
 value list (tokens that are neither a sibling nor a known child) onto the leaf
 while STILL descending into the container when the next token names the
-`interface` child. Only `next-hop` sets it; every other `multi`+children node
-(the CoS named containers) is unchanged — the guard `children == nil ||
-valueList` keeps them on the container path. The compiler reads every gateway
+`interface` child. Since #7132 `system ntp server` sets it too, and the pair is now the
+pattern rather than a one-off exception: a leaf that takes a VALUE and also
+accepts trailing MODIFIER keywords is exactly this shape. `server` is
+`multi: true` (so `server [ 1.1.1.1 2.2.2.2 ]` collapses onto one leaf) with
+`prefer`/`key`/`version`/`routing-instance` modifier children.
+
+That replaced `ntpServerOptionArgs`, a hand-written keyword-to-argcount table
+that existed only because the schema was believed unable to express the shape.
+It could, and had been able to since #3872 — so #7132 asked for a design
+decision whose answer was already shipped. The argcount now comes from the
+schema's own `args`, which is the point: a second source of truth for one
+grammar is what the table was.
+
+Every other `multi`+children node (the CoS named containers) is unchanged — the
+guard `children == nil || valueList` keeps them on the container path. The compiler reads every gateway
 from `Keys[1:]` (skipping an inline `interface <if>` pair) plus the `interface`
-child. This is DISTINCT from a `qualified-next-hop`, which is a separate
+child.
+
+**Both spellings, or neither (#2419).** A `valueList` leaf's modifiers arrive in
+two shapes and the compiler must read both: the COMPACT spelling puts the
+modifier and its argument on the stanza's own `Keys`
+(`server A key 5` -> `Keys=[server A key 5]`), the BLOCK spelling files them as
+a child (`server A { key 5; }` -> `Keys=[server A]` + child `[key 5]`). A reader
+that captures one and returns before applying the other is compact-blind, which
+is the #2419 class.
+
+Note what the #2419 gate can and cannot see: it detects "the compact spelling
+drops the VALUE", so a VALUE-LESS modifier is invisible to it. #7132's `prefer`
+was compact-blind alongside `key`/`version`/`routing-instance` and the gate
+reported only the other three. A value-less modifier needs its own equivalence
+cell. This is DISTINCT from a `qualified-next-hop`, which is a separate
 floating-backup leaf carrying its own per-next-hop preference (#3871): a plain
 `next-hop` list is equal-cost ECMP, a `qualified-next-hop` is a distance-N
 backup.

--- a/docs/log/7132.md
+++ b/docs/log/7132.md
@@ -1,0 +1,89 @@
+# 7132 — ntp server modifiers via valueList (handover completion)
+
+- **Timestamp**: 2026-08-29
+- **Action**: took over `design/7132-modifier-keywords` at `adbfec14d` and closed
+  the three failures it documented
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/ntp_server_modifier_spellings_7132_test.go` (new),
+  `pkg/config/schema_spelling_gate_coverage_7484_test.go`,
+  `pkg/config/testdata/golden_4406.json`, `docs/config-schema.md`
+  (plus the handover's own schema/type/daemon changes)
+
+## Inherited and NOT re-derived
+
+The design decision (`valueList` + modifier children, the #3872 shape static
+`route next-hop` already uses) and the `unreachable` ceiling measurement
+(147 -> 144) were settled by the previous lane and are taken as given.
+
+## Failure 1 — golden: classified, not regenerated
+
+`golden_4406.actual.json` was already on disk from the failing run, and the
+branch had not touched `golden_4406.json`, so the on-disk expected file WAS the
+merge target. Diffing them directly is therefore a real classification and can
+show removals — which a regen-then-diff cannot:
+
+    total keys expected=11143 actual=11161
+    ADDED   : 18   (all [].config.System.NTPServerOptions, all null)
+    REMOVED : 0
+    CHANGED : 0
+
+Benign signature. Regenerated.
+
+## Failure 2 — compact-blind sites: measured, and the handover's account was wrong
+
+The handover said two sites remained (`key`, `routing-instance`) and that the
+compact capture had fixed `version`/`prefer`. The gate actually reported THREE
+(`key`, `routing-instance`, `version`), and a probe showed `prefer` was broken
+too — **all four modifiers were compact-blind**, and `prefer` was invisible to
+the gate because its check is "the compact spelling drops the VALUE" and a
+value-less flag has no value to drop.
+
+Probing both spellings (dump the AST, compile, diff the typed config) located it
+in one line, and it is not in the schema at all:
+
+    if !touched { return servers, nil }
+
+`ntpServerValues` DOES capture compact modifiers off the parent's `Keys` — the
+loop is right there. But `touched` is set only by the CHILD-modifier loop, so on
+a compact spelling it is always false and every captured option is discarded on
+return. The fix is to write `cur` back only when a child contributed, and to
+gate the return on whether ANY option was captured.
+
+This is the issue's own class reappearing one line below the fix for it — the
+same shape as the two regressions the previous lane recorded.
+
+## Failure 3 — the two ratchets
+
+Both moved deliberately, with the reason at the site:
+
+* `gateBlindFlag` 175 -> 176. This is the one raise that is not a concession:
+  the class is "read, but value-less", the differential works by VARYING a
+  value, and Junos `prefer` takes no argument. It cannot be made to compare by
+  any change to the gate or the schema, unlike a `unreachable` leaf that a
+  #7492-style parent-stanza fix can rescue. In the class by construction.
+* `gateCoverageFloor` 689 -> 691. `key`/`version`/`routing-instance` became
+  compared. The gate reports this itself as "COVERAGE IMPROVED — TIGHTEN THE
+  RATCHET (this is a good failure)"; leaving it slack would let a regression
+  fall back to 689 unnoticed.
+
+## Stale comment
+
+Already resolved: the "the compiler is therefore the only place the distinction
+can be drawn" claim was attached to `ntpServerOptionArgs`, which the handover
+retired, so it went with the table.
+
+## Mutation matrix — FULL PACKAGE, never `-run` filtered
+
+A filter would have hidden the pre-existing guards, which is exactly what m3
+demonstrates.
+
+| cell | edit | verdict | reds |
+|------|------|---------|------|
+| control | none | GREEN | — |
+| m1 | restore `if !touched { return servers, nil }` | RED | the 2419 gate + all four #7132 spelling subtests |
+| m2 | drop the `len(opts) == 0` nil-return | GREEN | none — and correctly so: it returns an EMPTY map, and the caller ranges over it, so the mutation is behaviour-neutral |
+| m2b | write `cur` back unconditionally | RED | the no-options over-reach guard, alone |
+| m3 | `i += nargs` -> `i += 0` (the lane's regression 1) | RED | the #7132 cells AND the pre-existing `Test_6690_NTPServerOptionTokensAreNotServers` |
+
+m1 reds the `prefer` subtest where the 2419 gate does not, which is the coverage
+that gate structurally cannot provide.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -108,7 +108,14 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			// second NTP server and rendered verbatim into a chrony directive
 			// (#4902 types the value for exactly that reason).
 			for _, ntpChild := range child.FindChildren("server") {
-				sys.NTPServers = append(sys.NTPServers, ntpServerValues(ntpChild)...)
+				ntpServers, ntpOpts := ntpServerValues(ntpChild)
+				sys.NTPServers = append(sys.NTPServers, ntpServers...)
+				for addr, opt := range ntpOpts {
+					if sys.NTPServerOptions == nil {
+						sys.NTPServerOptions = map[string]NTPServerOption{}
+					}
+					sys.NTPServerOptions[addr] = opt
+				}
 			}
 			if thNode := child.FindChild("threshold"); thNode != nil {
 				if v := nodeVal(thNode); v != "" {
@@ -3044,73 +3051,144 @@ func validateBackupRouterDst(cfg *Config, lenient bool) ([]string, error) {
 	return nil, fmt.Errorf("%s", msg)
 }
 
-// ntpServerOptionArgs maps each Junos per-server option keyword that may
-// follow `system ntp server <address>` to the number of argument tokens it
-// consumes. These are the tokens that can legally appear AFTER the server
-// address on the same statement, so they must never be mistaken for a second
-// server address.
+// ntpServerModifierNames returns the modifier keywords modeled as children of
+// the `system ntp server` leaf in setSchema (#7132).
 //
-// The schema types `system ntp server` as a single-argument multi:true leaf
-// (schema_system.go), which means SetPath and the block parser both absorb any
-// trailing tokens onto the node's Keys without complaint — `prefer` is even a
-// syntactically valid hostname, so ValidateNTPServer accepts it. The compiler
-// is therefore the only place the distinction can be drawn.
-var ntpServerOptionArgs = map[string]int{
-	"prefer":           0,
-	"key":              1,
-	"version":          1,
-	"routing-instance": 1,
+// This REPLACES ntpServerOptionArgs, a hand-written keyword->argcount table that
+// existed only because the schema could not express "a value leaf that also has
+// modifiers". It can: `valueList: true` plus modifier children is the #3872
+// shape that static `route next-hop` already uses. The table was a second source
+// of truth for the same grammar, and every future leaf in this shape would have
+// grown its own copy.
+func ntpServerModifierNames() map[string]int {
+	out := map[string]int{}
+	sys, ok := setSchema.children["system"]
+	if !ok || sys == nil {
+		return out
+	}
+	ntp, ok := sys.children["ntp"]
+	if !ok || ntp == nil {
+		return out
+	}
+	server, ok := ntp.children["server"]
+	if !ok || server == nil {
+		return out
+	}
+	for name, child := range server.children {
+		// The ARGUMENT COUNT matters as much as the name, and losing it was a
+		// real regression caught by Test_6690_NTPServerOptionTokensAreNotServers:
+		// the HIERARCHICAL spelling puts `server 1.1.1.1 key 5` on ONE node's
+		// Keys, so skipping only the keyword leaves `5` to be read as a second
+		// server. That argcount is exactly what the retired ntpServerOptionArgs
+		// table carried — it now comes from the schema's own `args`, which is the
+		// point of the retirement: one source of truth, not two.
+		n := 0
+		if child != nil {
+			n = child.args
+		}
+		out[name] = n
+	}
+	return out
 }
 
-// ntpServerValues returns every NTP server address carried by one `server`
-// node, across all five spellings the parser can produce (#6690):
+// ntpServerValues returns the NTP server addresses carried by one `server` node,
+// and the per-server modifiers attached to them (#7132).
 //
-//   - hierarchical block, one leaf child per server
-//     `ntp { server { a; b; } }`  → Keys=["server"], children ["a"], ["b"]
-//   - hierarchical bracket list
-//     `ntp { server [ a b ]; }`   → Keys=["server","a","b"], no children
-//   - hierarchical repeated leaf
-//     `ntp { server a; server b; }` → two sibling nodes, one address each
-//     (the caller's FindChildren("server") loop visits both)
-//   - flat-set repeated leaf       → same as above
-//   - flat-set bracket list
-//     `set system ntp server [ a b ]` → Keys=["server","a","b"]
+// Since #7132 a modifier is a schema-modeled CHILD, so the two are separable in
+// the AST: `server 1.1.1.1 prefer` files Keys=["server","1.1.1.1"] with a child
+// ["prefer"], while `server [ 1.1.1.1 2.2.2.2 ]` still collapses both addresses
+// onto Keys. Before that they were byte-identical — Keys=["server",<tok>,<tok>]
+// either way — which is why a keyword table was the only available remedy.
 //
-// and skips the per-server option tokens in ntpServerOptionArgs together with
-// their arguments, so `server 1.1.1.1 prefer;`, `server 1.1.1.1 key 5;` and
-// `server 1.1.1.1 { prefer; }` still compile to exactly one server.
-//
-// The option skip counter deliberately carries across the Keys→Children
-// boundary: an option whose argument was split onto a child node must not
-// leak that argument into the server list.
-func ntpServerValues(n *Node) []string {
+// The modifiers attach to the LAST address on the node, matching Junos: the
+// modifier follows the server it qualifies.
+func ntpServerValues(n *Node) ([]string, map[string]NTPServerOption) {
 	if n == nil {
-		return nil
+		return nil, nil
 	}
+	modifiers := ntpServerModifierNames()
 	var servers []string
-	skip := 0
-	consume := func(tokens []string) {
-		for _, tok := range tokens {
-			if skip > 0 {
-				skip--
-				continue
+	opts := map[string]NTPServerOption{}
+	// The COMPACT spelling puts a modifier and its argument on the parent's Keys
+	// (`server 1.1.1.1 key 5;`), while the block spelling files them as a child
+	// (`server 1.1.1.1 { key 5; }`). Both must produce the same compiled config —
+	// that equivalence is the #2419 contract, and TestCompactBlockEquivalence-
+	// Inventory2419 caught this reader dropping the compact value when it merely
+	// SKIPPED modifiers here instead of capturing them.
+	keyTokens := n.Keys[1:]
+	for i := 0; i < len(keyTokens); i++ {
+		tok := keyTokens[i]
+		if nargs, isMod := modifiers[tok]; isMod {
+			arg := ""
+			if nargs > 0 && i+1 < len(keyTokens) {
+				arg = keyTokens[i+1]
 			}
-			if nargs, isOption := ntpServerOptionArgs[tok]; isOption {
-				skip = nargs
-				continue
+			i += nargs
+			if len(servers) > 0 {
+				target := servers[len(servers)-1]
+				cur := opts[target]
+				applyNTPServerModifier(&cur, tok, arg)
+				opts[target] = cur
 			}
-			if tok != "" {
-				servers = append(servers, tok)
-			}
+			continue
+		}
+		if tok != "" {
+			servers = append(servers, tok)
 		}
 	}
-	if len(n.Keys) > 1 {
-		consume(n.Keys[1:])
-	}
+	// The child walk runs UNCONDITIONALLY, before any modifier is attached.
+	//
+	// It used to early-return when Keys carried no server, which silently dropped
+	// the #6689 nested-BLOCK spelling — `server { 1.1.1.1; 2.2.2.2; }` files both
+	// addresses as CHILDREN and leaves Keys with just "server", so the early
+	// return discarded every server on that shape. Caught by
+	// Test_6690_NTPServerEveryHierarchicalSpelling. The block is the third shape
+	// docs/config-schema.md warns about, and it is exactly the one an
+	// early-return on Keys cannot see.
+	var mods []*Node
 	for _, child := range n.Children {
-		consume(child.Keys)
+		if child == nil || len(child.Keys) == 0 {
+			continue
+		}
+		if _, isMod := modifiers[child.Keys[0]]; isMod {
+			mods = append(mods, child)
+			continue
+		}
+		// A bracket-list member or a nested-block server, not a modifier.
+		servers = append(servers, child.Keys...)
 	}
-	return servers
+	if len(servers) == 0 {
+		return servers, nil
+	}
+	target := servers[len(servers)-1]
+	cur := opts[target]
+	touched := false
+	for _, child := range mods {
+		name := child.Keys[0]
+		touched = true
+		arg := ""
+		if len(child.Keys) > 1 {
+			arg = child.Keys[1]
+		}
+		applyNTPServerModifier(&cur, name, arg)
+	}
+	// `touched` records only whether a CHILD modifier was applied to `cur`, so
+	// it must not gate the return: the COMPACT spelling files its modifiers on
+	// the parent's Keys, and the loop above has already written them into
+	// `opts`. Returning nil here because no CHILD was seen discarded every
+	// compact-spelled modifier — which is exactly the #2419 divergence this
+	// reader was changed to close, reappearing one line below the fix for it.
+	//
+	// Write `cur` back only when a child actually contributed, so a plain
+	// `server 1.1.1.1` with no modifiers at all still yields nil rather than a
+	// map holding an all-zero option.
+	if touched {
+		opts[target] = cur
+	}
+	if len(opts) == 0 {
+		return servers, nil
+	}
+	return servers, opts
 }
 
 // archiveSite is one authored `system archival configuration archive-sites`
@@ -3193,4 +3271,24 @@ func archiveSiteEntries(n *Node) []archiveSite {
 		out = append(out, sites...)
 	}
 	return out
+}
+
+// applyNTPServerModifier records one per-server modifier (#7132). Shared by the
+// COMPACT (parent Keys) and BLOCK (child node) spellings so the two cannot
+// diverge — the divergence being exactly what #2419 is about.
+func applyNTPServerModifier(opt *NTPServerOption, name, arg string) {
+	switch name {
+	case "prefer":
+		opt.Prefer = true
+	case "key":
+		if v, err := strconv.Atoi(arg); err == nil {
+			opt.Key = v
+		}
+	case "version":
+		if v, err := strconv.Atoi(arg); err == nil {
+			opt.Version = v
+		}
+	case "routing-instance":
+		opt.RoutingInstance = arg
+	}
 }

--- a/pkg/config/ntp_server_modifier_spellings_7132_test.go
+++ b/pkg/config/ntp_server_modifier_spellings_7132_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// compileNTPText compiles one config text and returns the NTP server list and
+// per-server modifier options.
+func compileNTPText(t *testing.T, text string) ([]string, map[string]NTPServerOption) {
+	t.Helper()
+	p := NewParser(text)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse %q: %v", text, perrs)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil || cfg == nil {
+		t.Fatalf("compile %q: err=%v cfg=%v", text, err, cfg)
+	}
+	return cfg.System.NTPServers, cfg.System.NTPServerOptions
+}
+
+// TestNTPServerModifierSpellingsAgree_7132 is the fail-on-revert for the
+// compact-spelling capture.
+//
+// #2419's contract: the compact spelling (`server A key 5;` — modifier and its
+// argument on the stanza's own Keys) and the block spelling
+// (`server A { key 5; }` — modifier as a child) must compile identically.
+//
+// The bug this pins is one line, and it sat directly beneath the fix for the
+// same class. `ntpServerValues` DOES capture compact modifiers off the parent's
+// Keys — and then discarded them:
+//
+//	if !touched { return servers, nil }
+//
+// `touched` is set only by the CHILD-modifier loop, so on a compact spelling it
+// is always false and every captured option was thrown away on return.
+//
+// FAIL-ON-REVERT: restore that early return and every COMPACT subtest below
+// goes RED with `map[]` against the block spelling's populated map.
+func TestNTPServerModifierSpellingsAgree_7132(t *testing.T) {
+	cases := []struct{ name, mod, val string }{
+		{"key", "key", "5"},
+		{"version", "version", "4"},
+		{"routing-instance", "routing-instance", "xpfaaa"},
+		// `prefer` is here deliberately and is the reason this test exists
+		// separately from TestCompactBlockEquivalenceInventory2419.
+		//
+		// That gate detects "the compact spelling drops the VALUE". `prefer` is
+		// value-less, so it has nothing to drop and the gate is structurally
+		// blind to it — it reported three divergent sites while FOUR modifiers
+		// were broken. A fix validated only against that gate would have left
+		// `prefer` silently compact-blind.
+		{"prefer", "prefer", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sep := " "
+			if c.val == "" {
+				sep = ""
+			}
+			blockSrv, blockOpts := compileNTPText(t,
+				"system { ntp { server xpfarg { "+c.mod+sep+c.val+"; } } }")
+			compactSrv, compactOpts := compileNTPText(t,
+				"system { ntp { server xpfarg "+c.mod+sep+c.val+"; } }")
+
+			// Non-vacuity: if the BLOCK spelling records nothing either, the
+			// comparison below is `nil == nil` and proves nothing about the
+			// compact path.
+			if len(blockOpts) == 0 {
+				t.Fatalf("block spelling recorded no options for %q; this cell "+
+					"cannot prove anything about the compact spelling", c.mod)
+			}
+			if !reflect.DeepEqual(blockSrv, compactSrv) {
+				t.Errorf("server list differs: block=%v compact=%v", blockSrv, compactSrv)
+			}
+			if !reflect.DeepEqual(blockOpts, compactOpts) {
+				t.Errorf("#7132/#2419: the compact spelling must compile to the "+
+					"same typed config as the block spelling.\n  block   = %+v\n  compact = %+v\n"+
+					"An empty compact map means the modifiers were captured off the "+
+					"parent's Keys and then discarded on return.", blockOpts, compactOpts)
+			}
+		})
+	}
+}
+
+// TestNTPServerNoModifiersYieldsNoOptions_7132 is the over-reach guard.
+//
+// Without it, the test above is satisfied by always returning a populated map —
+// including for a plain `server A` with no modifiers at all, which would put an
+// all-zero option in the typed config (and in the #4406 golden) for every NTP
+// server anyone has ever configured.
+func TestNTPServerNoModifiersYieldsNoOptions_7132(t *testing.T) {
+	srv, opts := compileNTPText(t, "system { ntp { server xpfarg; } }")
+	if len(srv) != 1 || srv[0] != "xpfarg" {
+		t.Fatalf("precondition: expected one server, got %v", srv)
+	}
+	if len(opts) != 0 {
+		t.Errorf("a server with no modifiers must carry NO options entry, got %+v", opts)
+	}
+}
+
+// TestNTPServerModifierRegressionShapes_7132 pins the two shapes the previous
+// lane broke and fixed while building this, recorded as fixtures because they
+// are the same class the issue is about.
+func TestNTPServerModifierRegressionShapes_7132(t *testing.T) {
+	// 1. Skipping only the modifier NAME left its argument to be read as a
+	//    second server: `server a key 5` -> servers [a, 5].
+	srv, opts := compileNTPText(t, "system { ntp { server xpfarg key 5; } }")
+	if !reflect.DeepEqual(srv, []string{"xpfarg"}) {
+		t.Errorf("a modifier's ARGUMENT must not be read as a server: got %v", srv)
+	}
+	if opts["xpfarg"].Key != 5 {
+		t.Errorf("the modifier argument must land on the server: got %+v", opts)
+	}
+
+	// 2. An early return on empty Keys dropped the #6689 nested-BLOCK shape,
+	//    whose servers live in Children rather than on Keys.
+	nested, _ := compileNTPText(t, "system { ntp { server { xpfaaa; xpfbbb; } } }")
+	if !reflect.DeepEqual(nested, []string{"xpfaaa", "xpfbbb"}) {
+		t.Errorf("the nested-block spelling must yield both servers, got %v", nested)
+	}
+}

--- a/pkg/config/schema_spelling_gate_coverage_7484_test.go
+++ b/pkg/config/schema_spelling_gate_coverage_7484_test.go
@@ -154,7 +154,14 @@ func classifyGateBlindLeaf(g gateLeaf) gateBlindClass {
 // neither landed in a blind class, so no ceiling moved. That is the shape a
 // coverage ratchet is supposed to see when a gap is closed rather than papered
 // over: the floor rises and the blind spots stay put.
-const gateCoverageFloor = 689
+//
+// #7132 raised it 689 -> 691. Modeling the `system ntp server` modifiers as
+// schema children made `key`, `version` and `routing-instance` COMPARE (+3),
+// while `prefer` moved into `flag` (+1 there, see the ceiling below) — a net
+// +2 here. The gate itself asked for this: it reports a floor it can now beat
+// as "COVERAGE IMPROVED — TIGHTEN THE RATCHET (this is a good failure)", and
+// leaving it slack would let a later regression drop back to 689 unnoticed.
+const gateCoverageFloor = 691
 
 var gateBlindCeiling = map[gateBlindClass]int{
 	// #7492 moved leaves out of `unreachable` in two rounds. The parent
@@ -183,7 +190,22 @@ var gateBlindCeiling = map[gateBlindClass]int{
 	// TestStreamSourceInterfaceIsValidated_6875, and both apply paths by the
 	// daemon and CLI cells; it is blind to THIS instrument only.
 	gateBlindUnreachable: 144,
-	gateBlindFlag:        175,
+	// #7132 raised this 175 -> 176 for `system ntp server ... prefer`.
+	//
+	// Raised deliberately, and it is the one kind of raise that is not a
+	// concession: this class is "read, but value-less", and the spelling
+	// differential works by VARYING a leaf's value. Junos `prefer` takes no
+	// argument, so it has no value to vary — it cannot be made to compare by
+	// any change to the gate or to the schema, the way a #7492-style
+	// parent-stanza fix can rescue an `unreachable` leaf. It is in this class
+	// by construction, not by omission.
+	//
+	// It is not untested: both spellings of `prefer` are pinned by the #7132
+	// cells, which is also how its compact-spelling blindness was found. That
+	// blindness was invisible to TestCompactBlockEquivalenceInventory2419 for
+	// exactly the reason it is invisible here — that gate detects "the compact
+	// spelling drops the VALUE", and a value-less flag has none to drop.
+	gateBlindFlag:        176,
 	gateBlindErr:         43,
 	gateBlindValueMoves:  1,
 }

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -167,7 +167,29 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		// `server`/`pool` directive. Type it as an IP-or-hostname so a
 		// space/control/malformed value cannot inject a second chrony directive
 		// token or fail the chrony reload.
-		"server": {desc: "NTP server", args: 1, multi: true, valueType: ValueHostname, valueDesc: "NTP server IP address or hostname", valueExamples: []string{"192.0.2.1", "pool.ntp.org"}, validator: ValidateNTPServer, placeholder: "<address>", children: nil},
+		// #7132: the four Junos per-server MODIFIERS are modeled as children, and
+		// the leaf opts into `valueList` so it keeps absorbing a bracket list of
+		// SERVERS while descending into the container when the next token names a
+		// modifier.
+		//
+		// Before this, `children: nil` made the two indistinguishable in the AST —
+		// measured: `server 1.1.1.1 prefer` and `server [ 1.1.1.1 2.2.2.2 ]` both
+		// produced a leaf whose Keys were ["server", <tok>, <tok>], so nothing
+		// downstream could tell a modifier from a second server. `prefer` is a
+		// syntactically valid hostname, so ValidateNTPServer accepted it too.
+		//
+		// `valueList` is the existing mechanism for exactly this shape (#3872), not
+		// a new one: static `route next-hop` already carries a value slot AND an
+		// `interface` modifier child the same way. The SetPath absorber checks
+		// `childSchema.children[nextToken]` first (ast_edit.go), so a modeled
+		// modifier attaches as a child and everything else is absorbed as a value.
+		"server": {desc: "NTP server", args: 1, multi: true, valueList: true, valueType: ValueHostname, valueDesc: "NTP server IP address or hostname", valueExamples: []string{"192.0.2.1", "pool.ntp.org"}, validator: ValidateNTPServer, placeholder: "<address>",
+			children: map[string]*schemaNode{
+				"prefer":           {desc: "Prefer this server", children: nil},
+				"key":              {desc: "Authentication key id for this server", args: 1, placeholder: "<key-id>", valueType: ValueInteger, children: nil},
+				"version":          {desc: "NTP version for this server", args: 1, placeholder: "<version>", valueType: ValueInteger, children: nil},
+				"routing-instance": {desc: "Routing instance to reach this server in", args: 1, placeholder: "<instance>", children: nil},
+			}},
 		"threshold": {desc: "Threshold", args: 1, placeholder: "<seconds>",
 			valueType: ValueInteger, valueDesc: "NTP step threshold in seconds (>= 1; 0 means 'use the default')",
 			valueExamples: []string{"128", "600"},

--- a/pkg/config/testdata/compact_block_divergences_2419.txt
+++ b/pkg/config/testdata/compact_block_divergences_2419.txt
@@ -368,7 +368,6 @@ system login user xpfarg authentication ssh-rsa
 system login user xpfarg class
 system master-password pseudorandom-function
 system name-server
-system ntp server
 system root-authentication encrypted-password
 system root-authentication ssh-dsa
 system root-authentication ssh-ed25519

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -1100,6 +1100,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -2368,6 +2369,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -3635,6 +3637,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -4902,6 +4905,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -6170,6 +6174,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -7437,6 +7442,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -8394,6 +8400,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -9370,6 +9377,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -10345,6 +10353,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -11320,6 +11329,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -12296,6 +12306,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -13271,6 +13282,7 @@
           "1.1.1.1"
         ],
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -13684,6 +13696,7 @@
         "TimeZone": "",
         "NameServers": null,
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -13964,6 +13977,7 @@
         "TimeZone": "",
         "NameServers": null,
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -14244,6 +14258,7 @@
         "TimeZone": "",
         "NameServers": null,
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -14591,6 +14606,7 @@
         "TimeZone": "",
         "NameServers": null,
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -14927,6 +14943,7 @@
         "TimeZone": "",
         "NameServers": null,
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,
@@ -15263,6 +15280,7 @@
         "TimeZone": "",
         "NameServers": null,
         "NTPServers": null,
+        "NTPServerOptions": null,
         "NTPThreshold": 0,
         "NTPThresholdAction": "",
         "NoRedirects": false,

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -12,20 +12,29 @@ import (
 
 // SystemConfig holds system-level configuration.
 type SystemConfig struct {
-	HostName           string
-	DomainName         string   // system domain-name (e.g. "example.com")
-	DomainSearch       []string // system domain-search (search domains)
-	TimeZone           string
-	NameServers        []string // DNS server addresses
-	NTPServers         []string // NTP server addresses
-	NTPThreshold       int      // NTP threshold in seconds (0 = default)
-	NTPThresholdAction string   // "accept" or "reject"
-	NoRedirects        bool     // disable ICMP redirects
-	BackupRouter       string   // backup default gateway IP
-	BackupRouterDst    string   // backup router destination prefix
-	Lo0FilterInputV4   string   // lo0 unit 0 family inet filter input (host-bound filtering)
-	Lo0FilterInputV6   string   // lo0 unit 0 family inet6 filter input (host-bound filtering)
-	DataplaneType      string   // empty defaults to "userspace"; explicit "ebpf" is legacy; "dpdk" is retired (#1525) and tolerated via rewriteRetiredDataplaneType (pkg/configstore/dataplane_retire.go) at both Store.Load and Store.SyncApply for stored-config rolling upgrade
+	HostName     string
+	DomainName   string   // system domain-name (e.g. "example.com")
+	DomainSearch []string // system domain-search (search domains)
+	TimeZone     string
+	NameServers  []string // DNS server addresses
+	NTPServers   []string // NTP server addresses
+	// NTPServerOptions carries the Junos per-server MODIFIERS, keyed by the
+	// server address they follow (#7132). Empty for a server authored without
+	// modifiers, which is the common case.
+	//
+	// Kept BESIDE NTPServers rather than replacing it with a struct slice: every
+	// existing consumer reads the address list and none of them needed changing,
+	// so widening the shared field would have been churn in three packages to
+	// serve one of them.
+	NTPServerOptions   map[string]NTPServerOption
+	NTPThreshold       int    // NTP threshold in seconds (0 = default)
+	NTPThresholdAction string // "accept" or "reject"
+	NoRedirects        bool   // disable ICMP redirects
+	BackupRouter       string // backup default gateway IP
+	BackupRouterDst    string // backup router destination prefix
+	Lo0FilterInputV4   string // lo0 unit 0 family inet filter input (host-bound filtering)
+	Lo0FilterInputV6   string // lo0 unit 0 family inet6 filter input (host-bound filtering)
+	DataplaneType      string // empty defaults to "userspace"; explicit "ebpf" is legacy; "dpdk" is retired (#1525) and tolerated via rewriteRetiredDataplaneType (pkg/configstore/dataplane_retire.go) at both Store.Load and Store.SyncApply for stored-config rolling upgrade
 	UserspaceDataplane *UserspaceConfig
 	InternetOptions    *InternetOptionsConfig
 	Services           *SystemServicesConfig
@@ -1932,4 +1941,25 @@ type DHCPStaticBinding struct {
 	// HostName is the optional reservation hostname (Kea `hostname`). Empty
 	// when not configured.
 	HostName string
+}
+
+// NTPServerOption is the set of Junos `system ntp server <addr>` per-server
+// modifiers (#7132). Before #7132 these were absorbed into the server address
+// list as if they were additional servers — `prefer` is a syntactically valid
+// hostname, so validation accepted it — and a hand-written keyword table in the
+// compiler existed solely to skip them. They are now modeled in setSchema as
+// modifier children of the `server` leaf, so the compiler reads them from the
+// AST instead of pattern-matching keywords.
+type NTPServerOption struct {
+	// Prefer marks this source preferred to chrony.
+	Prefer bool
+	// Key is the authentication key id (0 = unset).
+	Key int
+	// Version is the NTP protocol version to use (0 = chrony default).
+	Version int
+	// RoutingInstance is the VRF the server is reached in ("" = default).
+	// Recorded but not yet honoured by the chrony renderer — chrony has no
+	// per-source VRF directive, so acting on it needs a routing change rather
+	// than a config one.
+	RoutingInstance string
 }

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -570,7 +570,9 @@ var (
 	chronyThresholdPath = "/etc/chrony/conf.d/xpf-threshold.conf"
 )
 
-func renderChronySources(servers []string) string {
+// renderChronySources renders the chrony source lines. opts carries the #7132
+// per-server modifiers keyed by address; a nil map renders exactly as before.
+func renderChronySources(servers []string, opts map[string]config.NTPServerOption) string {
 	var b strings.Builder
 	for _, server := range servers {
 		// #4902 render belt: a leniently-loaded / peer-synced value that is not
@@ -587,7 +589,23 @@ func renderChronySources(servers []string) string {
 		if net.ParseIP(server) != nil {
 			directive = "server"
 		}
-		fmt.Fprintf(&b, "%s %s iburst\n", directive, server)
+		// #7132: per-server modifiers. Before #7132 these were absorbed into the
+		// address list as if they were extra servers, so `prefer` reached this
+		// function AS A SERVER NAME and was rendered as its own source line.
+		// `version`/`key` take chrony's own spellings; `routing-instance` has no
+		// chrony equivalent and is recorded in the typed config only.
+		opt := opts[server]
+		line := fmt.Sprintf("%s %s iburst", directive, server)
+		if opt.Version > 0 {
+			line += fmt.Sprintf(" version %d", opt.Version)
+		}
+		if opt.Key > 0 {
+			line += fmt.Sprintf(" key %d", opt.Key)
+		}
+		if opt.Prefer {
+			line += " prefer"
+		}
+		fmt.Fprintf(&b, "%s\n", line)
 	}
 	return b.String()
 }
@@ -748,7 +766,7 @@ func (d *Daemon) applySystemNTP(cfg *config.Config) {
 		return
 	}
 
-	sourcesChanged, err := reconcileManagedFile(chronySourcesPath, renderChronySources(cfg.System.NTPServers))
+	sourcesChanged, err := reconcileManagedFile(chronySourcesPath, renderChronySources(cfg.System.NTPServers, cfg.System.NTPServerOptions))
 	if err != nil {
 		slog.Warn("failed to reconcile chrony sources", "err", err)
 		return

--- a/pkg/daemon/ntp_test.go
+++ b/pkg/daemon/ntp_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRenderChronySources(t *testing.T) {
-	got := renderChronySources([]string{"10.0.0.1", "pool.example.net"})
+	got := renderChronySources([]string{"10.0.0.1", "pool.example.net"}, nil)
 	want := "server 10.0.0.1 iburst\npool pool.example.net iburst\n"
 	if got != want {
 		t.Fatalf("renderChronySources() = %q, want %q", got, want)

--- a/pkg/daemon/system_string_injection_belt_4902_test.go
+++ b/pkg/daemon/system_string_injection_belt_4902_test.go
@@ -22,7 +22,7 @@ func TestRenderChronySources_SkipsInjected_4902(t *testing.T) {
 		"pool.example.net",                  // valid hostname
 		"pool.example.net local stratum 10", // embedded space -> skip
 		"evil.example\nmakestep 1 -1",       // newline -> skip
-	})
+	}, nil)
 	// Valid servers still render.
 	if !strings.Contains(got, "server 10.0.0.1 iburst\n") {
 		t.Errorf("valid IP server dropped; got:\n%s", got)


### PR DESCRIPTION
Completes the handover on `design/7132-modifier-keywords` (`adbfec14d`). The
design decision and the `unreachable` measurement were settled by the previous
lane and are taken as given; this closes the three documented failures.

## What was inherited

`valueList: true` plus modifier children — the #3872 shape static `route
next-hop` already uses. So #7132 asked for a design decision whose answer was
already shipped. `ntpServerOptionArgs` (a hand-written keyword→argcount table)
is retired; the argcount now comes from the schema's own `args`.

## Failure 1 — golden: **classified**, not regenerated

`golden_4406.actual.json` was already on disk from the failing run, and the
branch had never touched `golden_4406.json` — so the on-disk expected file *was*
the merge target. Diffing them directly is a real classification and **can show
removals**, which a regen-then-diff cannot:

```
total keys expected=11143 actual=11161
ADDED   : 18   (all [].config.System.NTPServerOptions, all null)
REMOVED : 0
CHANGED : 0
```

Benign signature → regenerated.

## Failure 2 — measured, and the handover's account was wrong in two ways

The handover said two sites remained and that the compact capture had fixed
`version`/`prefer`. The gate actually reported **three** (`key`,
`routing-instance`, **`version`**), and probing showed **`prefer` was broken
too** — *all four* modifiers were compact-blind.

`prefer` was invisible to `TestCompactBlockEquivalenceInventory2419` for a
structural reason worth recording: that gate detects "the compact spelling drops
the **value**", and a value-less flag has no value to drop. A fix validated only
against that gate would have shipped `prefer` still broken.

Probing both spellings — dump the AST, compile, diff the typed config — put it in
one line, and **not in the schema**:

```go
if !touched { return servers, nil }
```

`ntpServerValues` *does* capture compact modifiers off the parent's `Keys`; the
loop is right there. But `touched` is set only by the **child**-modifier loop, so
on a compact spelling it is always false and every captured option was discarded
on return. This is the issue's own class reappearing one line below the fix for
it.

## Failure 3 — both ratchets, moved deliberately

- **`gateBlindFlag` 175 → 176.** The one raise that is not a concession: the
  class is "read, but value-less", the differential works by *varying a value*,
  and Junos `prefer` takes no argument. It cannot be made to compare by any
  change to the gate or the schema — unlike an `unreachable` leaf, which a
  #7492-style parent-stanza fix can rescue. In the class by construction.
- **`gateCoverageFloor` 689 → 691.** The gate asks for this itself: "COVERAGE
  IMPROVED — TIGHTEN THE RATCHET (this is a good failure)."

The `unreachable` ceiling did **not** move (147 → 144, under the ceiling), as
measured by the previous lane.

## Mutation matrix — FULL PACKAGE, never `-run` filtered

| cell | edit | verdict | reds |
|------|------|---------|------|
| control | none | GREEN | — |
| m1 | restore `if !touched { return servers, nil }` | RED | the 2419 gate + **all four** #7132 subtests |
| m2 | drop the `len(opts) == 0` nil-return | GREEN | none — **correctly**: it returns an *empty* map and the caller ranges over it, so the mutation is behaviour-neutral |
| m2b | write `cur` back unconditionally | RED | the over-reach guard, alone |
| m3 | `i += nargs` → `i += 0` | RED | the #7132 cells **and** the pre-existing `Test_6690_NTPServerOptionTokensAreNotServers` |

m1 reds the **`prefer`** subtest where the 2419 gate does not — the coverage that
gate structurally cannot provide. m3 is why these ran full-package: a `-run`
filter would have hidden the pre-existing guard that catches it.

m2 is reported as a green rather than quietly dropped, because "the mutation is
behaviour-neutral" is a different finding from "the test missed it", and m2b is
the cell that actually probes the over-reach.

## Stale comment

Already resolved: *"the compiler is therefore the only place the distinction can
be drawn"* was attached to `ntpServerOptionArgs`, so it went with the table.

Docs: `docs/config-schema.md` now presents `valueList` + modifier children as the
**pattern** rather than a `next-hop` one-off, and records what the #2419 gate can
and cannot see. Reasoning in `docs/log/7132.md`.

Closes #7132