### PR TITLE
nat: stop inventing a port range for a no-translation source pool

### DIFF
--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -745,11 +745,26 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 				}
 			}
 		}
-		if pool.PortLow == 0 {
-			pool.PortLow = 1024
-		}
-		if pool.PortHigh == 0 {
-			pool.PortHigh = 65535
+		// #7173: do NOT invent a port range for a pool that does not translate
+		// ports. `port no-translation` takes the address-only path, so 1024-65535
+		// here was a value the compiler made up for a field nothing in that mode
+		// consumes — and a future reader would reasonably assume it meant
+		// something.
+		//
+		// Safe to skip because this defaulting is not load-bearing: BOTH readers
+		// apply the same default independently. config.SourceNATPoolPortRange
+		// substitutes 1024/65535 for a zero low/high, and that accessor is what
+		// builds the dataplane snapshot (which the pool-utilization alarm then
+		// reads, so its capacity computation is unaffected). This was the third
+		// copy of one default, and the one that mutated the stored config so it
+		// no longer said what the operator wrote.
+		if !pool.PortNoTranslation {
+			if pool.PortLow == 0 {
+				pool.PortLow = 1024
+			}
+			if pool.PortHigh == 0 {
+				pool.PortHigh = 65535
+			}
 		}
 		sec.NAT.SourcePools[pool.Name] = pool
 	}

--- a/pkg/natshow/source.go
+++ b/pkg/natshow/source.go
@@ -120,14 +120,26 @@ func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn fun
 					if len(pool.Addresses) > 0 {
 						fmt.Fprintf(w, "    Pool addresses:          %s\n", strings.Join(pool.Addresses, ", "))
 					}
-					portLow, portHigh := pool.PortLow, pool.PortHigh
-					if portLow == 0 {
-						portLow = 1024
+					// #7173: a `port no-translation` pool does not translate the
+					// source port at all — the dataplane takes the address-only
+					// path and ignores the range entirely (see the #3906 note in
+					// pkg/dataplane/userspace/nat_source.go). Printing
+					// "Port range: 1024-65535" for one told the operator the pool
+					// uses a port range it does not use, and the number shown was
+					// a default this display invented locally rather than
+					// anything configured.
+					if pool.PortNoTranslation {
+						fmt.Fprintf(w, "    Port translation:        disabled (source port preserved)\n")
+					} else {
+						portLow, portHigh := pool.PortLow, pool.PortHigh
+						if portLow == 0 {
+							portLow = 1024
+						}
+						if portHigh == 0 {
+							portHigh = 65535
+						}
+						fmt.Fprintf(w, "    Port range:              %d-%d\n", portLow, portHigh)
 					}
-					if portHigh == 0 {
-						portHigh = 65535
-					}
-					fmt.Fprintf(w, "    Port range:              %d-%d\n", portLow, portHigh)
 				}
 			}
 

--- a/pkg/natshow/source_port_notranslation_7173_test.go
+++ b/pkg/natshow/source_port_notranslation_7173_test.go
@@ -1,0 +1,86 @@
+package natshow
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7173: a `port no-translation` source pool must not be shown with a port
+// range it does not use.
+//
+// The dataplane takes the address-only path for such a pool and ignores the
+// range entirely (the #3906 note in pkg/dataplane/userspace/nat_source.go says
+// so). The display nonetheless printed "Port range: 1024-65535" — and those
+// numbers were a default the display invented locally, not anything the
+// operator configured. An operator reading that was told the pool uses a port
+// range that plays no part in its behaviour.
+//
+// Both directions are asserted. Showing the range for a NORMAL pool is correct
+// and must survive: a fix that simply stopped printing the line would satisfy
+// the no-translation assertion while removing real information from every other
+// pool.
+
+func renderSourcePools(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	RenderSourceRuleDetail(&buf, cfg, nil, nil)
+	return buf.String()
+}
+
+func poolCfg(noTranslation bool) *config.Config {
+	pool := &config.NATPool{
+		Name:              "p1",
+		Addresses:         []string{"198.51.100.10"},
+		PortNoTranslation: noTranslation,
+	}
+	if !noTranslation {
+		pool.PortLow, pool.PortHigh = 5000, 6000
+	}
+	return &config.Config{
+		Security: config.SecurityConfig{
+			NAT: config.NATConfig{
+				SourcePools: map[string]*config.NATPool{"p1": pool},
+				Source: []*config.NATRuleSet{
+					{
+						Name: "rs1",
+						Rules: []*config.NATRule{
+							{Name: "r1", Then: config.NATThen{PoolName: "p1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestNoTranslationPoolShowsNoPortRange7173(t *testing.T) {
+	out := renderSourcePools(t, poolCfg(true))
+
+	if strings.Contains(out, "Port range:") {
+		t.Errorf("a `port no-translation` pool was shown with a Port range line. The pool "+
+			"does not translate the source port at all, and the numbers printed were a "+
+			"default the display invented locally — not configuration (#7173).\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "Port translation:") {
+		t.Errorf("the no-translation state must be REPORTED, not merely omitted — an "+
+			"operator needs to see that port translation is off, and silence reads as "+
+			"'not applicable' rather than 'disabled'.\ngot:\n%s", out)
+	}
+}
+
+// Control: a normal pool must STILL show its configured range. Without this,
+// deleting the line entirely passes the cell above while hiding real
+// information from every pool that does translate ports.
+func TestNormalPoolStillShowsItsPortRange7173(t *testing.T) {
+	out := renderSourcePools(t, poolCfg(false))
+
+	if !strings.Contains(out, "Port range:") {
+		t.Fatalf("a normal pool must still show its port range.\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "5000-6000") {
+		t.Errorf("the CONFIGURED range must be shown, not a default: want 5000-6000.\ngot:\n%s", out)
+	}
+}


### PR DESCRIPTION
A `port no-translation` source pool **does not translate the source port at all** — the dataplane takes the address-only path and ignores the range entirely (the #3906 note in `pkg/dataplane/userspace/nat_source.go` says so). Two places produced a range for one anyway.

## The operator-facing half

`show security nat source rule` printed:

```
Port range:              1024-65535
```

for a pool that translates no ports — and **those numbers were not configuration**. The display substituted them locally for a zero low/high. Now:

```
Port translation:        disabled (source port preserved)
```

Reporting it rather than omitting the line matters: silence reads as *"not applicable"*, not *"off"*.

## The compiler half — the cohort's actual row

`compiler_nat_source.go` defaulted `PortLow`/`PortHigh` to 1024/65535 **unconditionally**, with no `PortNoTranslation` check, mutating the stored config so it no longer said what the operator wrote.

Safe to skip, because that defaulting was **the third copy of one default** and the only one that touched the config itself:

| copy | where | still defaults? |
|---|---|---|
| compile time | `compiler_nat_source.go` | **removed for no-translation pools** |
| accessor | `config.SourceNATPoolPortRange` | yes — and it builds the dataplane snapshot |
| display | `pkg/natshow/source.go` | yes, now scoped to the case where a range applies |

I checked the consumer chain before touching it: the pool-utilization alarm computes `capacity = AddressCount × (PortHigh − PortLow + 1)`, which looked like it would break — but it reads `mgr.AppliedNATView()`, i.e. the **dataplane snapshot**, which is built through `SourceNATPoolPortRange` and still defaults. So the alarm is insulated.

## The cohort understated this row

#7173 calls it *"No-op today — worth fixing precisely because it is a no-op today and a future reader will assume the fields are meaningful."* That reasoning holds, but the fields are read **directly** by `pkg/natshow` and reach an operator-facing surface, so the invented value was **visible**, not merely stored.

## Tests

Both directions, and the control does double duty. A normal pool must **still** show its configured range — a fix that just stopped printing the line would satisfy the no-translation assertion while removing real information from every pool that does translate ports. That same control is what stops the absence assertion being vacuous: a renderer producing no output at all would otherwise pass it.

Mutation: reverting the `natshow` branch reds `TestNoTranslationPoolShowsNoPortRange7173` (35 collected, 1 named FAIL).

## Gate

Full Go suite: **rc=0, 69 packages, 0 FAIL**. Go-only, no cluster smoke owed.

Refs #7173