### PR TITLE
config,routing: record two by-design trade-offs where the code is

### DIFF
--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -731,6 +731,20 @@ func junosHostZoneExemptNetdevs(cfg *Config, zoneName string, zone *ZoneConfig, 
 	}
 	// Per-netdev accumulation of the effective coarse verdict across every
 	// interface ref whose host-bound traffic arrives on it.
+	//
+	// #7173: this UNIONS the verdicts of VLAN siblings that share one physical
+	// parent — addRow calls note(parent, ...) for every unit — so a parent's
+	// entry is the union of what each of its units admits, not any single
+	// unit's. That is deliberate and it errs toward OVER-shielding: an
+	// exemption one unit needs is applied to the parent, so a sibling unit is
+	// shielded where it did not strictly have to be. It is safe in the
+	// direction that matters because the exempted services are authenticated
+	// (IKE) or self-limiting (ident-reset) and the units share a zone, so the
+	// union cannot admit anything the zone's own policy does not already allow.
+	//
+	// Recorded here rather than only in the issue: the natural "fix" is to make
+	// the parent entry per-unit, which would narrow the shield and is the wrong
+	// direction for a defense-in-depth surface.
 	type verdict struct{ ike, ident, fullAdmit bool }
 	byNetdev := make(map[string]*verdict, len(netdevs))
 	note := func(nd, ref string) {

--- a/pkg/routing/probe_pin.go
+++ b/pkg/routing/probe_pin.go
@@ -108,6 +108,18 @@ func BuildProbePins(rpmCfg *config.RPMConfig, rethMap map[string]string) []Probe
 // physical member, slashes become dashes, and the default ".0" unit
 // suffix is stripped (VLAN units like ".50" are real kernel names and
 // are preserved). Mirrors the FRR static-route name translation.
+//
+// #7173: on a rethMap MISS the RETH base falls through to
+// config.LinuxIfName(base) — the raw translated Junos name — rather than
+// failing here. That is the safe direction and is deliberate: the resulting
+// name will not resolve, and the downstream LinkByName failure HOLDS the probe
+// instead of letting it run unpinned. A probe that is held is visibly broken; a
+// probe that silently ran against the wrong interface, or against no interface
+// at all, would report reachability it never measured and drive
+// ip-monitoring route injection off it.
+//
+// So do not "fix" the miss by substituting a default interface or by dropping
+// the pin — either turns a held probe into a false-passing one.
 func ResolveProbeInterface(name string, rethMap map[string]string) string {
 	if name == "" {
 		return ""


### PR DESCRIPTION
Two rows from the #7173 cohort are deliberate, safe-direction trade-offs rather than defects. Both were reasoned about when written; neither reasoning lived anywhere a future reader would look — **only in an audit issue, which is where a trade-off goes to be "fixed" by someone who has not read it.**

**`junosHostZoneExemptNetdevs`** unions the verdicts of VLAN siblings sharing one physical parent. It errs toward **over**-shielding, and is safe in the direction that matters because the exempted services are authenticated (IKE) or self-limiting (ident-reset) and the units share a zone — so the union cannot admit anything the zone's own policy does not already allow. The natural "fix" is a per-unit parent entry, which **narrows** the shield; the comment says so explicitly.

**`ResolveProbeInterface`** falls through to the raw translated name on a `rethMap` miss. The name does not resolve and the downstream `LinkByName` failure **HOLDS** the probe. A held probe is visibly broken; one that silently ran against the wrong interface — or none — would report reachability it never measured and drive ip-monitoring route injection off it. The comment names the two "fixes" that would turn a held probe into a false-passing one.

## The other two rows needed nothing, and I checked rather than assumed

- the VLAN-trunk parent-zone first-wins arm already carries its rationale, including the #6722 note on why egress must not read `ifindex_to_zone_id`
- `LenientContentDropped` already records that the strict commit path rejects all three shapes, so the flag is only ever set on the tolerant path

That is 4 of the cohort's by-design rows dispositioned for the cost of 2 comments.

Comments only; no behaviour change. Full Go suite: **rc=0, 69 packages, 0 FAIL**.

Refs #7173