### PR TITLE
zone_counters: record why the two slots are gated independently

### DIFF
--- a/userspace-dp/src/afxdp/zone_counters.rs
+++ b/userspace-dp/src/afxdp/zone_counters.rs
@@ -475,6 +475,18 @@ thread_local! {
 /// forwarding resolution), so this is two flat-LUT reads plus a thread-local
 /// accumulate — no hash, no atomic, no allocation. An unassigned zone (slot 0)
 /// contributes nothing.
+///
+/// #7173: the two slots are gated INDEPENDENTLY — a call with one side
+/// unzoned still attributes the other. That is deliberate: if the ingress zone
+/// is known and the egress is not, counting the ingress is correct, because
+/// each slot is a per-zone traffic counter and not half of a flow record.
+/// Requiring both would discard true information about the known side to avoid
+/// an incompleteness no consumer reads that way.
+///
+/// So do not "fix" this by gating both slots on both zones being resolved. The
+/// result would be silently lower per-zone totals on exactly the traffic whose
+/// other half could not be resolved — a counter that undercounts is worse than
+/// one that is candid about counting each side on its own knowledge.
 #[inline]
 pub(in crate::afxdp) fn record_zone_traffic(
     slot_map: &ZoneCounterSlotMap,


### PR DESCRIPTION
`record_zone_traffic` gates the ingress and egress slots on their own zone ids, so a call with one side unzoned still attributes the other. The #7173 cohort flagged that as a gap. **It is not — it is correct**, and the reasoning was not written down anywhere a reader would find it.

Each slot is a **per-zone traffic counter, not half of a flow record.** If the ingress zone is known and the egress is not, counting the ingress is right: you count what you know. Requiring both would discard true information about the known side to avoid an incompleteness that no consumer of a per-slot counter reads as a partial flow.

The comment names the "fix" that would make things worse, because that is the one someone reaches for: gating both slots on both zones being resolved yields **silently lower per-zone totals** on exactly the traffic whose other half could not be resolved. A counter that undercounts is worse than one that is candid about counting each side on its own knowledge.

Comment only; no behaviour change. `make test-rust`: **rc=0, 10 binaries, 4937 passed, 0 failed.**

This is the last row of the #7173 cohort that needed anything in the tree — full disposition of all 11 rows is on the issue.

Refs #7173