### PR TITLE
Revalidate a reverse-canonical NAT match against the arrival zone

### DIFF
--- a/docs/log/7169.md
+++ b/docs/log/7169.md
@@ -1,0 +1,98 @@
+# 7169 — revalidate a reverse-canonical NAT match against the arrival zone
+
+- **Timestamp**: 2026-08-29
+- **Action**: threaded the observed ingress zone into
+  `lookup_forward_nat_across_scopes` and required it to match the forward
+  session's egress zone before a reverse session is synthesized
+- **File(s)**: `userspace-dp/src/afxdp/shared_ops.rs`,
+  `userspace-dp/src/afxdp/session_glue/{mod,tests}.rs`,
+  `userspace-dp/src/afxdp/icmp_embed/nat_match_v{4,6}.rs`
+
+## Inherited, not re-derived
+
+Condition 1 is settled: no uRPF/anti-spoof anywhere in the dataplane, and the
+omission is structural — `lookup_forward_nat_across_scopes` had no ingress
+parameter to revalidate against.
+
+## Condition 2 — the topology judgement, answered in prose on the issue first
+
+Verdict: **worth fixing**. Two premises were checkable and were checked rather
+than assumed:
+
+* a session hit DOES bypass policy — `poll_descriptor/mod.rs:408` calls it "the
+  established fast path", and policy evaluation lives in the session-MISS block.
+  So the installed reverse session is a durable bypass, not a one-time verdict;
+* the pre-NAT range is routable across internal segments by construction, since
+  inter-zone routing is what the firewall does.
+
+The deciding argument: "the attacker is already internal" is the assumption a
+ZONE-BASED firewall exists to deny. The escalation over plain spoofing is that
+the firewall's own session table ends up asserting a zone pair it never
+observed. Stated against it: the attacker needs the full 5-tuple including the
+ephemeral port, and the fix widens a main-path signature.
+
+## The fix
+
+`ReverseIngress` has three states and no variant that silently means "skip":
+
+* `Zone(u16)` — must equal `forward_match.metadata.egress_zone`. On mismatch the
+  lookup returns NO MATCH rather than dropping, so the packet falls through to
+  ordinary policy evaluation *in the zone it actually arrived in*.
+* `Unzoned` — the arrival interface has no zone mapping. Fails CLOSED. It exists
+  precisely so a map-lookup miss cannot reach the same outcome as a deliberate
+  exemption, which is how this check would have been silently bypassed for the
+  traffic least accounted for.
+* `Unconstrained` — deliberate exemption, owing a reason at the call site. Two
+  hold: the ICMP embedded-error rewriters (install no session; an error may
+  legitimately originate off-path, so constraining it breaks PMTUD), and
+  FABRIC-ingress packets (arrive on the fabric link from the peer, so their
+  arrival zone is structurally not the flow's).
+
+Zone, not ifindex: a zone can span interfaces, so a reply may legitimately
+arrive on a different member (LAG, ECMP, route change). Ifindex equality would
+reject those, and zone is the granularity policy is written against.
+
+`ingress_ifindex` stays **0**, with the reason recorded at the site. #7169 lists
+that zero as part of the defect; it is not, and inheriting the forward match's
+value is the #7917 regression — the forward ingress is a PREDICTION of where a
+reply will arrive, not an OBSERVATION of where it did.
+
+## Mutation matrix — full suite, `--test-threads=1`
+
+| cell | edit | verdict | reds |
+|------|------|---------|------|
+| control | none | GREEN 4873 | — |
+| m1 | `Zone(_) => Some(m)` (tuple equality alone) | RED | wrong-zone cell, alone |
+| m2 | `Unzoned => Some(m)` (fail open) | RED | unzoned cell, alone |
+| m3 | installing path passes `Unconstrained` unconditionally | RED | **the wiring guard, alone** |
+| m4 | inherit `ingress_ifindex` from the forward match | RED | the #7917 guard, alone |
+
+**m3 is the cell that justifies the wiring guard.** The first three cells drive
+`lookup_forward_nat_across_scopes` directly with an explicit `ReverseIngress`,
+so they bind the revalidation FUNCTION and are blind to whether the installing
+call site passes a real zone. m3 reopens the hole completely and reds only the
+source-shape wiring guard.
+
+## HA smoke: NOT RUN — cluster unavailable, and this is a gap
+
+This change touches the session path (including the synced `shared_nat_sessions`
+scope) and adds a fabric-ingress carve-out, so per CLAUDE.md it owes
+`make test-failover`. It could not be run.
+
+`make cluster-deploy` deployed cleanly to both nodes (pre-flight PASS, "Deploy
+complete" on each) and then failed its own post-deploy gate: node0 is not
+primary for every RG, RG1 has NO primary, blocked by "userspace XSK liveness not
+proven". That gate says explicitly: *do NOT run an HA smoke against it and read
+the failure as an HA regression.*
+
+Attributed away from this change by three independent facts:
+
+1. the readiness gate first fires at **13:23:59Z**, ~2h14m BEFORE this deploy
+   (lock acquired 15:37:51Z), across 6 xpfd restarts;
+2. it is **node0-only** — node1 logs zero occurrences — while this build was
+   deployed to both, so a code defect would affect both;
+3. node0 has **no `reth1.0` device at all** (`ge-0-0-1` is UP; the RETH is
+   absent), which is why RG1 cannot prove liveness.
+
+So the fabric-ingress carve-out is reasoned and suite-green, but NOT
+smoke-verified. Recorded as a gap rather than presented as validated.

--- a/userspace-dp/src/afxdp/icmp_embed/nat_match_v4.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/nat_match_v4.rs
@@ -39,7 +39,19 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v4(
     // reply direction of a forward-NAT'd session. Recover the original
     // pre-NAT src + port from the forward key.
     if let Some(fwd) =
-        lookup_forward_nat_across_scopes(ctx.sessions, ctx.shared_nat_sessions, &reverse_key)
+        lookup_forward_nat_across_scopes(
+            ctx.sessions,
+            ctx.shared_nat_sessions,
+            &reverse_key,
+            // #7169: no ingress constraint here, and the reason is not
+            // that it is inconvenient. This path installs NO session — it
+            // uses the match only to recover the pre-NAT tuple for
+            // rewriting an embedded ICMP error — so there is no durable
+            // state to endorse a spoof. And an ICMP error may legitimately
+            // originate off-path from an intermediate router, so requiring
+            // it to arrive from the flow's egress zone would break PMTUD.
+            crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+        )
     {
         let nat = fwd.decision.nat;
         let original_src = fwd.key.src_ip;

--- a/userspace-dp/src/afxdp/icmp_embed/nat_match_v6.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/nat_match_v6.rs
@@ -97,7 +97,19 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v6(
     );
 
     if let Some(fwd) =
-        lookup_forward_nat_across_scopes(ctx.sessions, ctx.shared_nat_sessions, &reverse_key)
+        lookup_forward_nat_across_scopes(
+            ctx.sessions,
+            ctx.shared_nat_sessions,
+            &reverse_key,
+            // #7169: no ingress constraint here, and the reason is not
+            // that it is inconvenient. This path installs NO session — it
+            // uses the match only to recover the pre-NAT tuple for
+            // rewriting an embedded ICMP error — so there is no durable
+            // state to endorse a spoof. And an ICMP error may legitimately
+            // originate off-path from an intermediate router, so requiring
+            // it to arrive from the flow's egress zone would break PMTUD.
+            crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+        )
     {
         let nat = fwd.decision.nat;
         let original_src = fwd.key.src_ip;

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -1413,8 +1413,31 @@ pub(super) fn resolve_flow_session_decision(
         });
     }
 
-    let forward_match =
-        lookup_forward_nat_across_scopes(sessions, shared_nat_sessions, &flow.forward_key)?;
+    // #7169: the main packet path — the one that INSTALLS a reverse session
+    // from the match, making the adjudication durable. Revalidate the arrival
+    // zone against the session being synthesized.
+    //
+    // A fabric-ingress packet is exempt and must be: it arrives on the fabric
+    // link from the peer node, so its arrival zone is the fabric rather than
+    // the flow's logical ingress. Constraining it would break cross-chassis
+    // forwarding, which is a correctness break, not a hardening.
+    let reverse_ingress = if fabric_ingress {
+        crate::afxdp::shared_ops::ReverseIngress::Unconstrained
+    } else {
+        match forwarding.ifindex_to_zone_id.get(&ingress_ifindex).copied() {
+            Some(z) => crate::afxdp::shared_ops::ReverseIngress::Zone(z),
+            // Fail CLOSED. An unmapped arrival interface gives nothing to
+            // revalidate against, and treating that as "no constraint" would
+            // reopen the hole for exactly the traffic least accounted for.
+            None => crate::afxdp::shared_ops::ReverseIngress::Unzoned,
+        }
+    };
+    let forward_match = lookup_forward_nat_across_scopes(
+        sessions,
+        shared_nat_sessions,
+        &flow.forward_key,
+        reverse_ingress,
+    )?;
     let (resolved, reverse_installed) = install_reverse_session_from_forward_match(
         sessions,
         session_map_fd,

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -806,7 +806,16 @@ fn lookup_forward_nat_across_scopes_returns_shared_nat_entry() {
         .expect("shared nat lock")
         .insert(reply_key.clone(), entry.clone());
 
-    let hit = lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &reply_key)
+    let hit = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared_nat_sessions,
+        &reply_key,
+        // #7169: these cells predate the ingress revalidation and test
+        // TUPLE matching, which is a separate property. Unconstrained keeps
+        // each one asserting exactly what it asserted before; the new check
+        // has its own cells.
+        crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+    )
         .expect("shared forward nat hit");
     assert_eq!(hit.key, entry.key);
     assert_eq!(hit.decision, entry.decision);
@@ -858,7 +867,16 @@ fn lookup_forward_nat_across_scopes_prefers_shared_entry_over_fabric_wire_placeh
         .expect("shared nat lock")
         .insert(reply_key.clone(), shared_entry.clone());
 
-    let hit = lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &reply_key)
+    let hit = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared_nat_sessions,
+        &reply_key,
+        // #7169: these cells predate the ingress revalidation and test
+        // TUPLE matching, which is a separate property. Unconstrained keeps
+        // each one asserting exactly what it asserted before; the new check
+        // has its own cells.
+        crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+    )
         .expect("shared nat hit");
     assert_eq!(hit.key, shared_entry.key);
     assert_eq!(hit.decision, shared_entry.decision);
@@ -896,7 +914,16 @@ fn lookup_forward_nat_across_scopes_ignores_fabric_wire_placeholder_without_shar
     let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
 
     assert!(
-        lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &reply_key).is_none()
+        lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared_nat_sessions,
+        &reply_key,
+        // #7169: these cells predate the ingress revalidation and test
+        // TUPLE matching, which is a separate property. Unconstrained keeps
+        // each one asserting exactly what it asserted before; the new check
+        // has its own cells.
+        crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+    ).is_none()
     );
 }
 
@@ -930,7 +957,16 @@ fn lookup_forward_nat_across_scopes_returns_shared_canonical_reverse_entry() {
         .expect("shared nat lock")
         .insert(canonical_reply.clone(), entry.clone());
 
-    let hit = lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &canonical_reply)
+    let hit = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared_nat_sessions,
+        &canonical_reply,
+        // #7169: these cells predate the ingress revalidation and test
+        // TUPLE matching, which is a separate property. Unconstrained keeps
+        // each one asserting exactly what it asserted before; the new check
+        // has its own cells.
+        crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+    )
         .expect("shared canonical reverse hit");
     assert_eq!(hit.key, entry.key);
     assert_eq!(hit.decision, entry.decision);
@@ -7448,4 +7484,249 @@ fn delete_synced_frees_both_allocators_end_to_end_6211() {
          first-hit `break`, strands one of them"
     );
     assert_eq!(deleted_keys, vec![key], "control: the key was recorded (#6457)");
+}
+
+// ---------------------------------------------------------------------------
+// #7169: reverse-canonical matches are revalidated against the ARRIVAL zone.
+// ---------------------------------------------------------------------------
+
+/// One forward-NAT'd session in the shared scope, plus the reverse-canonical
+/// key that matches it. `test_metadata()` is ingress_zone 1 -> egress_zone 2, so
+/// a legitimate reply arrives in zone 2.
+fn nat_reverse_fixture_7169() -> (
+    SessionTable,
+    Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    SessionKey,
+) {
+    let sessions = SessionTable::new();
+    let key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4("10.0.61.5".parse().unwrap()),
+        dst_ip: IpAddr::V4("203.0.113.9".parse().unwrap()),
+        src_port: 40000,
+        dst_port: 443,
+    };
+    let decision = SessionDecision {
+        resolution: test_resolution(),
+        nat: NatDecision {
+            rewrite_src: Some(IpAddr::V4("198.51.100.8".parse().unwrap())),
+            ..NatDecision::default()
+        },
+    };
+    let entry = SyncedSessionEntry {
+        key: key.clone(),
+        decision,
+        metadata: test_metadata(),
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+        generation: 0,
+        session_id: 0,
+    };
+    let reply_key = reverse_session_key(&key, decision.nat);
+    let shared = Arc::new(Mutex::new(FastMap::default()));
+    shared
+        .lock()
+        .expect("shared nat lock")
+        .insert(reply_key.clone(), entry);
+    (sessions, shared, reply_key)
+}
+
+/// #7169 fail-on-revert: a reverse-canonical match must be REJECTED when the
+/// packet arrived in a zone the forward flow did not egress to.
+///
+/// The index is keyed on the PRE-NAT reply tuple, so a match establishes only
+/// that this 5-tuple equals a live session's private-side reply tuple. Before
+/// this check, that alone installed a reverse session carrying the ORIGINAL
+/// flow's zone pair — so a packet injected from any segment where the client's
+/// private address is routable was adjudicated in a zone it never arrived in,
+/// and the installed session then took the established fast path with no policy
+/// evaluation for the rest of the flow's life.
+///
+/// The reply must arrive from the zone the forward flow EGRESSED to (2 here);
+/// zone 7 is the attacker's segment.
+///
+/// FAIL-ON-REVERT: delete the `ReverseIngress::Zone` arm's equality test in
+/// `revalidate_reverse_ingress` (or make it return `Some(m)` unconditionally)
+/// and this goes RED.
+#[test]
+fn a_reverse_match_from_the_wrong_zone_is_rejected_7169() {
+    let (sessions, shared, reply_key) = nat_reverse_fixture_7169();
+
+    // Positive control FIRST: the same lookup from the RIGHT zone matches, so
+    // the rejection below is the ingress check and not a broken fixture.
+    let ok = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared,
+        &reply_key,
+        crate::afxdp::shared_ops::ReverseIngress::Zone(2),
+    );
+    assert!(
+        ok.is_some(),
+        "control: a reply arriving in the forward flow's EGRESS zone must match"
+    );
+
+    let hijack = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared,
+        &reply_key,
+        crate::afxdp::shared_ops::ReverseIngress::Zone(7),
+    );
+    assert!(
+        hijack.is_none(),
+        "a packet matching a session's pre-NAT reply tuple but arriving in a \
+         zone the flow never egressed to must NOT match. Accepting it installs \
+         a reverse session adjudicated in the original flow's zone pair, which \
+         subsequent packets then ride past policy entirely (#7169)"
+    );
+}
+
+/// #7169: an arrival interface with no zone mapping fails CLOSED.
+///
+/// This is the arm that would otherwise be the whole hole again. Resolving the
+/// zone with a map lookup makes "no entry" the natural default, and treating
+/// that as "no constraint" would exempt exactly the traffic least accounted
+/// for. `Unzoned` exists so that outcome cannot be reached by accident — it is
+/// a distinct state from the deliberate exemption below.
+#[test]
+fn an_unzoned_arrival_interface_matches_nothing_7169() {
+    let (sessions, shared, reply_key) = nat_reverse_fixture_7169();
+    let out = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared,
+        &reply_key,
+        crate::afxdp::shared_ops::ReverseIngress::Unzoned,
+    );
+    assert!(
+        out.is_none(),
+        "an unmapped arrival interface gives nothing to revalidate against, so \
+         no reverse match may be synthesized"
+    );
+}
+
+/// #7169: the deliberate exemption still works, and is distinguishable from
+/// `Unzoned`.
+///
+/// Without this the two could be collapsed into one "no constraint" state, and
+/// the ICMP embedded-error path (which installs no session, and where an error
+/// may legitimately originate off-path) would be broken by the fix — or, worse,
+/// `Unzoned` would be made permissive to keep it working.
+#[test]
+fn an_unconstrained_caller_is_exempt_7169() {
+    let (sessions, shared, reply_key) = nat_reverse_fixture_7169();
+    let out = lookup_forward_nat_across_scopes(
+        &sessions,
+        &shared,
+        &reply_key,
+        crate::afxdp::shared_ops::ReverseIngress::Unconstrained,
+    );
+    assert!(
+        out.is_some(),
+        "the ICMP embedded-error rewriters install no session and must keep \
+         matching; constraining them would break PMTUD"
+    );
+}
+
+/// #7169 / #7917: the synthesized reverse session's `ingress_ifindex` must stay
+/// 0 — "unobserved" — and must never be populated from the forward match.
+///
+/// #7169 was filed listing this zero as part of the defect. It is not, and the
+/// tempting repair is a regression: the forward flow's ingress is a PREDICTION
+/// of where a reply will arrive, not an OBSERVATION of where it did, so
+/// inheriting it makes the row confidently wrong. This guard exists because the
+/// issue text itself points at the wrong line.
+#[test]
+fn a_synthesized_reverse_records_no_ingress_ifindex_7169() {
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("afxdp")
+            .join("shared_ops.rs"),
+    )
+    .expect("shared_ops.rs must be readable");
+    let code: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Non-vacuity: if the builder moved or was renamed, the scan below proves
+    // nothing and must say so rather than pass.
+    assert!(
+        code.contains("fn build_reverse_session_from_forward_match"),
+        "build_reverse_session_from_forward_match not found — this guard is \
+         scanning for something that no longer exists"
+    );
+    assert!(
+        code.contains("ingress_ifindex: 0,"),
+        "the synthesized reverse session must record ingress_ifindex 0"
+    );
+    assert!(
+        !code.contains("ingress_ifindex: forward_match"),
+        "ingress_ifindex must NOT be inherited from the forward match: the \
+         forward ingress is where a reply was PREDICTED to arrive, not where it \
+         did (#7917). 0 means unobserved, which is truthful; a wrong interface \
+         is strictly worse than none (#6928)"
+    );
+}
+
+/// #7169 wiring guard: the MAIN packet path must resolve the arrival zone and
+/// hand it to the lookup.
+///
+/// The cells above drive `lookup_forward_nat_across_scopes` directly with an
+/// explicit `ReverseIngress`, so they bind the revalidation FUNCTION. They
+/// cannot see the thing that actually protects the dataplane: that
+/// `resolve_flow_session_decision` — the one caller that INSTALLS a reverse
+/// session from the match — passes a real zone rather than `Unconstrained`.
+/// Changing that one argument to `Unconstrained` reopens the hole completely
+/// and leaves every cell above green.
+///
+/// Source-shape because a behavioural cell would need to drive a ~20-argument
+/// function through a full session install; the property here is which argument
+/// the call site passes, which is exactly what source shape can state.
+/// Comments are stripped: this file names the symbols, and an unstripped scan
+/// would match the prose describing the invariant rather than the invariant.
+#[test]
+fn the_main_path_passes_a_resolved_arrival_zone_7169() {
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("afxdp")
+            .join("session_glue")
+            .join("mod.rs"),
+    )
+    .expect("session_glue/mod.rs must be readable");
+    let code: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Non-vacuity first: if the call moved or was renamed, everything below
+    // passes for free.
+    assert!(
+        code.contains("lookup_forward_nat_across_scopes("),
+        "session_glue/mod.rs no longer calls lookup_forward_nat_across_scopes — \
+         this guard is scanning for something that no longer exists"
+    );
+    assert!(
+        code.contains("ifindex_to_zone_id.get(&ingress_ifindex)"),
+        "the main path must resolve the ARRIVAL interface to a zone. Without \
+         this the reverse-canonical match is decided by tuple equality alone \
+         (#7169)"
+    );
+    assert!(
+        code.contains("ReverseIngress::Unzoned"),
+        "an unmapped arrival interface must fail CLOSED. If the resolution \
+         defaults to Unconstrained on a lookup miss, the check is bypassed for \
+         exactly the traffic least accounted for"
+    );
+    // The one exemption on this path is fabric ingress, and it must be
+    // conditional. An unconditional Unconstrained here is the whole hole.
+    assert!(
+        code.contains("if fabric_ingress {"),
+        "the only exemption on the installing path is fabric ingress, and it \
+         must be gated on it — an unconditional Unconstrained reopens #7169"
+    );
 }

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -699,7 +699,77 @@ pub(super) fn lookup_session_across_scopes(
         })
 }
 
+/// #7169: what the caller knows about where the packet being matched actually
+/// ARRIVED, so a reverse-canonical match can be revalidated against it.
+///
+/// The reverse-canonical index is keyed on a session's PRE-NAT reply tuple, so a
+/// match means only "this 5-tuple equals a live session's private-side reply
+/// tuple". Nothing about that establishes the packet came from where the reply
+/// was expected — and on the main path a match installs a reverse session
+/// carrying the original flow's zone pair, which then takes the established fast
+/// path with no policy evaluation. Tuple equality alone was deciding both.
+///
+/// Three states, deliberately, with no variant that silently means "skip":
+/// a lookup miss must not fail open into the same hole.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReverseIngress {
+    /// The zone the packet actually arrived in. A match is accepted only if the
+    /// forward session EGRESSED to this zone — a reply must come back from
+    /// where the flow went.
+    ///
+    /// Zone, not ifindex, on purpose: a zone can legitimately span interfaces,
+    /// so a reply may arrive on a different member (LAG, ECMP, a route change)
+    /// and still be the same flow. Ifindex equality would reject those. Zone is
+    /// also the granularity policy is written against, which is what the
+    /// synthesized session's metadata gets wrong.
+    Zone(u16),
+    /// The arrival interface has no zone mapping, so there is nothing to
+    /// revalidate against. Fails CLOSED: no reverse match is synthesized.
+    /// Distinct from `Unconstrained` precisely so an unmapped ifindex cannot
+    /// reach the same outcome as a deliberate exemption.
+    Unzoned,
+    /// The caller asserts no ingress constraint, and owes a reason at the call
+    /// site. Two hold today:
+    ///
+    /// * the ICMP embedded-error rewriters, which use the match only to recover
+    ///   a pre-NAT tuple and install NO session — and where an error may
+    ///   legitimately originate off-path (an intermediate router), so
+    ///   constraining the arrival zone would break PMTUD;
+    /// * a FABRIC-ingress packet, which arrives on the fabric link from the
+    ///   peer node rather than in its logical ingress zone, so its arrival zone
+    ///   is structurally not the flow's.
+    Unconstrained,
+}
+
+/// Apply the #7169 ingress revalidation to a candidate match.
+fn revalidate_reverse_ingress(
+    m: ForwardSessionMatch,
+    ingress: ReverseIngress,
+) -> Option<ForwardSessionMatch> {
+    match ingress {
+        ReverseIngress::Unconstrained => Some(m),
+        ReverseIngress::Unzoned => None,
+        // The reply must arrive from the zone the forward flow egressed to.
+        // On mismatch this returns NO MATCH rather than dropping: the packet
+        // then falls through to ordinary policy evaluation IN THE ZONE IT
+        // ACTUALLY ARRIVED IN, which is the correct adjudication. Dropping here
+        // would substitute one unconsidered verdict for another.
+        ReverseIngress::Zone(z) if m.metadata.egress_zone == z => Some(m),
+        ReverseIngress::Zone(_) => None,
+    }
+}
+
 pub(super) fn lookup_forward_nat_across_scopes(
+    sessions: &SessionTable,
+    shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    reply_key: &SessionKey,
+    ingress: ReverseIngress,
+) -> Option<ForwardSessionMatch> {
+    let m = lookup_forward_nat_across_scopes_inner(sessions, shared_nat_sessions, reply_key)?;
+    revalidate_reverse_ingress(m, ingress)
+}
+
+fn lookup_forward_nat_across_scopes_inner(
     sessions: &SessionTable,
     shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     reply_key: &SessionKey,
@@ -751,8 +821,29 @@ pub(super) fn build_reverse_session_from_forward_match(
             && now_secs <= ha_startup_grace_until_secs,
     );
     let metadata = SessionMetadata {
+        // #7169: this zone pair comes from the STORED forward session, i.e.
+        // from where the ORIGINAL flow went — not from where this packet
+        // arrived. That is safe only because the caller now revalidates the
+        // arrival zone against `metadata.egress_zone` before a match is
+        // returned (see `ReverseIngress`), so by the time this runs the two are
+        // necessarily equal. Remove that check and this line silently
+        // adjudicates a packet in a zone it never arrived in.
         ingress_zone: forward_match.metadata.egress_zone,
         egress_zone: forward_match.metadata.ingress_zone,
+        // #7917: DELIBERATELY 0, and not to be "fixed" by inheriting
+        // `forward_match.metadata.ingress_ifindex`.
+        //
+        // A synthesized reverse companion must not take the forward
+        // direction's ingress identity: the forward flow's ingress is a
+        // PREDICTION of where a reply will arrive, not an OBSERVATION of where
+        // it did. 0 means "unobserved", which is truthful; inheriting would
+        // make the row confidently wrong, which #6928 refused on the grounds
+        // that a wrong interface is strictly worse than none.
+        //
+        // #7169 was filed listing this zero as part of the defect. It is not.
+        // The defect was that nothing checked the ARRIVAL against the session
+        // being synthesized, which is a different repair — and the tempting one
+        // makes the record worse while leaving the hole open.
         ingress_ifindex: 0,
         ingress_vlan_id: 0,
         // Reverse companions are owned by the RG that currently owns the


### PR DESCRIPTION
Condition 1 (no uRPF anywhere; the omission is structural) is taken as settled
and not re-derived. The condition-2 topology judgement is
[answered in prose on the issue](https://github.com/psaab/xpf/issues/7169#issuecomment-5463132535)
**before** any code — verdict: worth fixing.

Two premises of that judgement were checkable, so I checked them rather than
asserting: a session hit **does** bypass policy (`poll_descriptor/mod.rs:408`
calls it "the established fast path"; policy evaluation lives in the
session-MISS block), so the installed reverse session is a *durable* bypass; and
the pre-NAT range is routable across internal segments by construction, since
inter-zone routing is what the firewall does.

The deciding argument, and the counter-argument, both stated: *"the attacker is
already internal"* is the assumption a **zone-based** firewall exists to deny,
and the escalation over plain spoofing is that the firewall's own session table
ends up asserting a zone pair it never observed. Against it: the attacker needs
the full 5-tuple including the ephemeral port, and this widens a main-path
signature.

## The fix

`ReverseIngress` has three states, and **no variant that silently means "skip"**:

- **`Zone(z)`** — must equal `forward_match.metadata.egress_zone`; a reply must
  come back from where the flow went. On mismatch the lookup returns **no
  match** rather than dropping, so the packet falls through to ordinary policy
  evaluation *in the zone it actually arrived in*. Dropping would substitute one
  unconsidered verdict for another.
- **`Unzoned`** — arrival interface with no zone mapping. **Fails closed.** It
  exists precisely so a map-lookup miss cannot reach the same outcome as a
  deliberate exemption; `.get(...).copied()` returning `None` would otherwise
  have bypassed the check for exactly the traffic least accounted for.
- **`Unconstrained`** — deliberate exemption, owing a reason at the call site.
  Two hold: the ICMP embedded-error rewriters (install **no** session, and an
  error may legitimately originate off-path — constraining it breaks PMTUD), and
  **fabric-ingress** packets, which arrive on the fabric link from the peer node
  rather than in their logical ingress zone.

**Zone, not ifindex**, deliberately: a zone can span interfaces, so a reply may
arrive on a different member (LAG, ECMP, route change) and still be the same
flow. Zone is also the granularity policy is written against — which is exactly
what the synthesized session's metadata gets wrong.

**`ingress_ifindex` stays 0**, with the reason now recorded at the site. The
issue lists that zero as part of the defect; it is not, and inheriting the
forward match's value is the #7917 regression — the forward ingress is a
*prediction* of where a reply will arrive, not an *observation* of where it did.

## Mutation matrix

| cell | edit | verdict | reds |
|------|------|---------|------|
| control | none | GREEN 4873 | — |
| m1 | `Zone(_) => Some(m)` (tuple equality alone) | RED | wrong-zone cell, alone |
| m2 | `Unzoned => Some(m)` (fail open) | RED | unzoned cell, alone |
| m3 | installing path passes `Unconstrained` unconditionally | RED | **the wiring guard, alone** |
| m4 | inherit `ingress_ifindex` from the forward match | RED | the #7917 guard, alone |

**m3 is why the wiring guard exists.** The other cells drive
`lookup_forward_nat_across_scopes` directly with an explicit `ReverseIngress` —
they bind the revalidation *function* and are structurally blind to whether the
*installing call site* passes a real zone. m3 reopens the hole completely and
reds only the source-shape guard.

## `make test-failover`: NOT RUN — and that is a gap, not a pass

This touches the session path (including the synced `shared_nat_sessions` scope)
and adds a fabric-ingress carve-out, so per CLAUDE.md it owes the failover
smoke. It could not be run.

`make cluster-deploy` deployed cleanly to **both** nodes (pre-flight PASS,
"Deploy complete" each) and then failed its own post-deploy gate: node0 not
primary for every RG, **RG1 has no primary**, blocked by *"userspace XSK
liveness not proven"*. That gate says explicitly: *do NOT run an HA smoke
against it and read the failure as an HA regression.*

Attributed away from this change by three independent facts:

1. the gate first fires at **13:23:59Z — 2h14m before** this deploy (lock
   15:37:51Z), across 6 xpfd restarts;
2. it is **node0-only** (node1 logs zero occurrences) while this build went to
   **both** nodes — a code defect would affect both;
3. node0 has **no `reth1.0` device at all** (`ge-0-0-1` is UP; the RETH is
   absent), which is why RG1 cannot prove liveness.

**The shared cluster needs attention independently of this PR** — it currently
cannot run any HA smoke. The fabric carve-out here is reasoned and suite-green
but **not** smoke-verified, recorded as a gap rather than presented as validated.

Reasoning in `docs/log/7169.md`.

Closes #7169