### PR TITLE
cluster: demote an unarmed node's RG weight instead of letting it hold mastership

### DIFF
--- a/pkg/cluster/dataplane_arm_track_7178_test.go
+++ b/pkg/cluster/dataplane_arm_track_7178_test.go
@@ -1,0 +1,76 @@
+package cluster
+
+import "testing"
+
+// #7178: a node whose forwarding dataplane is not armed must stop outbidding a
+// peer that IS armed — but must NOT demote itself out of the running.
+//
+// The daemon expresses "not armed" as redundancy-group weight debt through the
+// existing interface-monitor path, using DataplaneArmMonitorIface as a synthetic
+// monitor. What this file pins is the WEIGHT ARITHMETIC that decision rests on,
+// because the whole design is in the choice of cost:
+//
+//   - large enough that an armed peer at 255 wins the election, and
+//   - NOT large enough to reach 0, so a STANDALONE unarmed node stays primary.
+//
+// The second half is the part that is easy to get wrong and impossible to see
+// afterwards. Driving the weight to 0 would demote a lone node too, and there
+// the outcome differs in kind: nothing else takes the VIPs, so the only effect
+// is to remove the addresses an operator may be reaching the box on. #5275
+// already closed kernel transit forwarding on an unarmed node while deliberately
+// keeping management up — the node is a black hole for transit either way, and
+// demoting it standalone removes the repair path without removing the black hole.
+
+func TestUnarmedDataplaneDebtLeavesTheNodeEligible7178(t *testing.T) {
+	w := rgWeightFromDebt(DataplaneArmMonitorCost)
+	if w == 0 {
+		t.Fatalf("an unarmed dataplane drove the RG weight to 0. That demotes a STANDALONE "+
+			"node as well as a clustered one, and a lone node that gives up its VIPs does not "+
+			"become safe — it becomes absent, with nothing to take them and possibly no "+
+			"address left for the operator to reach it on (#7178). cost=%d weight=%d",
+			DataplaneArmMonitorCost, w)
+	}
+	if w != 1 {
+		t.Errorf("unarmed weight = %d, want exactly 1 — the floor, mirroring the VRRP "+
+			"track-interface priority-cost clamp of [1,254] where 'demoted' means the bottom "+
+			"of the range and never out of it", w)
+	}
+}
+
+// The other half: the debt must actually be enough to lose. A cost that left the
+// node competitive would satisfy the floor assertion above while never handing
+// over to the peer, which is the entire point of the change.
+func TestUnarmedNodeLosesToAnArmedPeer7178(t *testing.T) {
+	unarmed := rgWeightFromDebt(DataplaneArmMonitorCost)
+	armed := rgWeightFromDebt(0)
+	if armed != maxRedundancyGroupWeight {
+		t.Fatalf("precondition: an armed node with no monitor debt must carry the full "+
+			"weight, got %d", armed)
+	}
+	if unarmed >= armed {
+		t.Errorf("unarmed weight %d is not below armed weight %d, so an unarmed node would "+
+			"still outbid a peer that can actually forward — it would keep taking the RETH "+
+			"VIPs and attracting traffic it drops (#7178)", unarmed, armed)
+	}
+}
+
+// The synthetic monitor name must not be able to collide with a configured
+// track-interface entry, or a real interface going down would be conflated with
+// an unarmed dataplane and vice versa — two different faults sharing one debt
+// slot, with whichever wrote last winning.
+func TestDataplaneArmMonitorNameCannotCollide7178(t *testing.T) {
+	for _, illegal := range []string{"ge-0/0/0", "ge-0-0-0", "reth0", "reth0.50", "em0", "fxp0", ""} {
+		if DataplaneArmMonitorIface == illegal {
+			t.Fatalf("the synthetic monitor name %q collides with a nameable interface",
+				DataplaneArmMonitorIface)
+		}
+	}
+	// A Junos or Linux interface name never contains '/' twice nor leading
+	// underscores; the sentinel shape is what makes the collision impossible
+	// rather than merely unlikely.
+	if len(DataplaneArmMonitorIface) < 3 ||
+		DataplaneArmMonitorIface[0] != '_' || DataplaneArmMonitorIface[1] != '_' {
+		t.Errorf("the synthetic monitor name %q must be an obvious non-interface sentinel "+
+			"so it cannot be produced by any config path", DataplaneArmMonitorIface)
+	}
+}

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -633,6 +633,36 @@ func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int
 // (HeartbeatGroup.Weight is uint8, heartbeat.go).
 const maxRedundancyGroupWeight = 255
 
+// DataplaneArmMonitorIface is the synthetic interface-monitor name the daemon
+// uses to express "this node's forwarding dataplane is not armed" as
+// redundancy-group weight debt (#7178).
+//
+// It is deliberately not a legal Junos or Linux interface name, so it can never
+// collide with a configured `track-interface` entry, and it is exported so the
+// daemon writes ONE agreed key rather than a string literal on each side.
+const DataplaneArmMonitorIface = "__dataplane-arm__"
+
+// DataplaneArmMonitorCost is the weight debt an unarmed dataplane contributes:
+// enough to lose to any peer that IS armed, but NOT enough to reach weight 0.
+//
+// #7178: the floor is the design, not an implementation detail. A node whose
+// dataplane failed to arm forwards no transit (#5275 closes kernel forwarding)
+// while deliberately keeping management up, so on a cluster the right answer is
+// "let the peer have it" — which a large debt achieves, because the election is
+// RELATIVE and an armed peer at 255 outbids this node at 1.
+//
+// But driving the weight to 0 would also demote a STANDALONE unarmed node, and
+// there the outcome is different in kind: nothing else picks up the VIPs, so the
+// only effect is to remove the addresses an operator may be reaching the box on.
+// The node is a black hole for transit either way; demoting it there removes the
+// repair path without removing the black hole. Landing at 1 keeps a lone node
+// primary and lets a healthy peer win, from one rule rather than a special case.
+//
+// The floor of 1 also mirrors the VRRP `track-interface priority-cost` clamp of
+// [1,254]: that machinery already settled that "demoted" means the bottom of the
+// range, never out of it.
+const DataplaneArmMonitorCost = maxRedundancyGroupWeight - 1
+
 // rgWeightFromDebt converts a redundancy group's accumulated monitor debt into
 // its effective weight, bounded to [0, maxRedundancyGroupWeight].
 //

--- a/pkg/daemon/daemon_transit_gate.go
+++ b/pkg/daemon/daemon_transit_gate.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/psaab/xpf/pkg/cluster"
 	"log/slog"
 	"os"
 	"strings"
@@ -138,7 +139,42 @@ func (d *Daemon) DataplaneArmed() bool { return d.dataplaneArmed.Load() }
 func (d *Daemon) markDataplaneArmed(stage string) {
 	d.dataplaneArmed.Store(true)
 	writeTransitForwardSysctls(true)
+	d.applyDataplaneArmTrack(true)
 	slog.Info("dataplane armed; kernel transit forwarding enabled", "stage", stage)
+}
+
+// applyDataplaneArmTrack mirrors the arm state into redundancy-group weight so
+// a node that cannot forward stops outbidding a peer that can (#7178).
+//
+// Before this, a failed arm left the node fully eligible: it could win or retain
+// RG mastership, take the RETH VIPs from a peer with a WORKING dataplane, and go
+// on attracting traffic it then drops (#5275 closes kernel transit forwarding,
+// so the node is a black hole rather than an unpoliced forwarder). "Let the peer
+// have it" is the obvious answer on a cluster, and this is the mechanism that
+// expresses it.
+//
+// It rides the EXISTING interface-monitor debt path rather than adding a rule to
+// the election. The alternative — refusing MASTER outright — has to interact
+// with priority-0 takeover and the ungated masterDownTimer, which is where the
+// ~60ms failover budget lives; a synthetic monitor adds a debt CONTRIBUTOR and
+// no new path into electRG.
+//
+// The cost is sub-total ON PURPOSE (see cluster.DataplaneArmMonitorCost): the
+// node lands at weight 1, not 0, so an armed peer at 255 wins while a STANDALONE
+// unarmed node stays primary. Demoting a lone node would not make it safe, only
+// absent — nothing else takes the VIPs, and the operator may be reaching the box
+// on one.
+//
+// Idempotent and safe with no cluster configured: SetMonitorWeight is a no-op
+// for an unknown RG, and a nil manager short-circuits here.
+func (d *Daemon) applyDataplaneArmTrack(armed bool) {
+	if d.cluster == nil {
+		return
+	}
+	for _, rg := range d.cluster.GroupStates() {
+		d.cluster.SetMonitorWeight(rg.GroupID, cluster.DataplaneArmMonitorIface,
+			!armed, cluster.DataplaneArmMonitorCost)
+	}
 }
 
 // markDataplaneArmFailed records an arm FAILURE and closes kernel transit
@@ -151,6 +187,7 @@ func (d *Daemon) markDataplaneArmed(stage string) {
 func (d *Daemon) markDataplaneArmFailed(stage, remediation string, err error) {
 	d.dataplaneArmed.Store(false)
 	writeTransitForwardSysctls(false)
+	d.applyDataplaneArmTrack(false)
 	slog.Error("dataplane arm FAILED; kernel transit forwarding DISABLED (fail-closed, degraded): "+
 		"nothing adjudicates transit on this node, so it forwards none — management (SSH/CLI/gRPC/REST) "+
 		"stays up so the config can be corrected in-band",
@@ -177,6 +214,13 @@ func (d *Daemon) markDataplaneArmFailed(stage, remediation string, err error) {
 func (d *Daemon) markDataplaneNotArmed(stage, reason string) {
 	d.dataplaneArmed.Store(false)
 	writeTransitForwardSysctls(false)
+	// #7178: DELIBERATE and FAILED are the same fact to a peer — this node
+	// forwards no transit either way, so it must not outbid one that does. The
+	// distinction is why this logs at Info while the failure path logs at Error;
+	// it is not a reason to keep mastership. On a bootstrap boot there is no
+	// cluster yet and applyDataplaneArmTrack is a no-op; the case this covers is
+	// config-only mode on a node that already has a cluster configured.
+	d.applyDataplaneArmTrack(false)
 	slog.Info("dataplane not armed; kernel transit forwarding disabled (fail-closed)",
 		"stage", stage, "reason", reason)
 }

--- a/pkg/daemon/dataplane_arm_track_wiring_7178_test.go
+++ b/pkg/daemon/dataplane_arm_track_wiring_7178_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7178: the arm-state transitions must actually DRIVE the redundancy-group
+// weight, not merely have a helper that could.
+//
+// WHY THIS IS SEPARATE FROM THE ARITHMETIC TESTS. pkg/cluster pins the cost's
+// value — large enough to lose to an armed peer, small enough to leave the node
+// eligible. Those pass whether or not anything ever applies it. Deleting the
+// applyDataplaneArmTrack call from markDataplaneArmFailed leaves every one of
+// them green, because they exercise rgWeightFromDebt directly. The defect being
+// fixed lives in the WIRING — a node that failed to arm went on holding RG
+// mastership — so the wiring is what this file asserts.
+
+func armTrackManager(t *testing.T) *cluster.Manager {
+	t.Helper()
+	m := cluster.NewManager(0, 1)
+	m.UpdateConfig(&config.ClusterConfig{
+		RedundancyGroups: []*config.RedundancyGroup{{ID: 1, NodePriorities: map[int]int{0: 200}}},
+	})
+	return m
+}
+
+func rgWeight(t *testing.T, m *cluster.Manager, id int) int {
+	t.Helper()
+	for _, rg := range m.GroupStates() {
+		if rg.GroupID == id {
+			return rg.Weight
+		}
+	}
+	t.Fatalf("redundancy group %d not found", id)
+	return -1
+}
+
+func TestArmFailureDemotesRedundancyGroupWeight7178(t *testing.T) {
+	withTempTransitForwardSysctls(t, "1")
+
+	m := armTrackManager(t)
+	d := &Daemon{cluster: m}
+
+	// Precondition: a group with no monitor debt carries the full weight. Without
+	// this the assertion below could pass on a group that was never healthy.
+	if w := rgWeight(t, m, 1); w == 0 {
+		t.Fatalf("precondition: the group must start with a non-zero weight, got %d", w)
+	}
+	full := rgWeight(t, m, 1)
+
+	d.markDataplaneArmFailed("test", "test", errors.New("boom"))
+
+	got := rgWeight(t, m, 1)
+	if got >= full {
+		t.Fatalf("after an arm FAILURE the RG weight is %d, unchanged from %d. The node "+
+			"still outbids a peer that can forward, so it keeps taking the RETH VIPs and "+
+			"attracting traffic it drops (#7178)", got, full)
+	}
+	if got == 0 {
+		t.Errorf("the arm failure drove the weight to 0, which also demotes a STANDALONE "+
+			"node — nothing takes its VIPs and the operator may lose the address they reach "+
+			"it on. The cost is sub-total on purpose")
+	}
+}
+
+// The gate must FOLLOW the arm state, not be pinned off: a successful arm has to
+// clear the debt, or a node that recovered would stay demoted forever and could
+// never take back mastership after the peer fails.
+func TestSuccessfulArmClearsTheDemotion7178(t *testing.T) {
+	withTempTransitForwardSysctls(t, "1")
+
+	m := armTrackManager(t)
+	d := &Daemon{cluster: m}
+	full := rgWeight(t, m, 1)
+
+	d.markDataplaneArmFailed("test", "test", errors.New("boom"))
+	if rgWeight(t, m, 1) >= full {
+		t.Fatalf("precondition: the failure must demote before recovery can be observed")
+	}
+
+	d.markDataplaneArmed("test")
+
+	if got := rgWeight(t, m, 1); got != full {
+		t.Errorf("after a successful arm the RG weight is %d, want the full %d restored. A "+
+			"node that recovered but stays demoted can never take mastership back when the "+
+			"peer fails — a permanent single point of failure created by the fix", got, full)
+	}
+}
+
+// A daemon with no cluster configured must not panic. This is the standalone
+// non-cluster box, which is the common case.
+func TestArmTrackIsSafeWithoutACluster7178(t *testing.T) {
+	withTempTransitForwardSysctls(t, "1")
+	d := &Daemon{} // nil cluster
+	d.markDataplaneArmFailed("test", "test", errors.New("boom"))
+	d.markDataplaneArmed("test")
+}


### PR DESCRIPTION
A node whose forwarding dataplane failed to arm stayed **fully eligible for RG mastership**. It could win or retain the RETH VIPs from a peer with a *working* dataplane and keep advertising routes, so upstream neighbours went on steering traffic at it.

Since #5275 closed kernel transit forwarding on such a node, it does **not forward what it attracts**. It is a black hole that actively draws traffic — worse for availability than the unpoliced forwarding it replaced.

## Mechanism: a debt contributor, not a new election rule

A synthetic monitor (`cluster.DataplaneArmMonitorIface`) is marked down while the dataplane is unarmed, contributing weight debt through `SetMonitorWeight` exactly as a tracked interface does.

The alternative the issue raises — refusing MASTER outright — has to interact with priority-0 takeover and the ungated `masterDownTimer`, which is where the ~60ms failover budget lives. A debt contributor adds **no new path into `electRG`**.

## The cost is sub-total, and that IS the design

`DataplaneArmMonitorCost` leaves the node at weight **1, not 0**, because the election is relative:

| situation | weight | outcome |
|---|---|---|
| cluster, peer armed | us 1, peer 255 | **peer takes it** — the issue's own answer |
| cluster, both unarmed | 1 vs 1 | existing tie-break; neither can forward |
| **standalone** | 1 | **stays primary** |

**The standalone case is argued, not inherited** — the issue asks for exactly that. Driving the weight to 0 would demote a lone node too, and there the outcome differs *in kind*: nothing else picks up the VIPs, so the only effect is to remove the addresses an operator may be reaching the box on. `markDataplaneArmFailed` already keeps management up on purpose — *"management (SSH/CLI/gRPC/REST) stays up so the config can be corrected in-band"* — so the node is a black hole either way, and demoting it standalone removes the **repair path** without removing the black hole.

The floor of 1 also mirrors the VRRP `track-interface priority-cost` clamp of [1,254], where "demoted" already means the bottom of the range and never out of it.

`markDataplaneNotArmed` applies the same track: **DELIBERATE and FAILED are the same fact to a peer.** The distinction is why one logs at Info and the other at Error — not a reason to keep mastership.

## Tests split deliberately

`pkg/cluster` pins the weight **arithmetic** (the cost loses to an armed peer, and still leaves the node eligible). Those pass whether or not anything applies it.

`pkg/daemon` pins the **wiring**, because that is where the defect lives — deleting the `applyDataplaneArmTrack` call leaves every arithmetic test green while a failed arm goes on holding mastership. The **recovery** direction is asserted too: a node that demoted and never cleared would be a permanent single point of failure introduced by the fix.

**Mutation** — delete the wiring from `markDataplaneArmFailed`: **3227 collected, 2 named FAILs**, both daemon cells.

## Gates

- Full Go suite: **rc=0, 69 packages, 0 FAIL**
- **`make test-failover`: 17 passed, 0 failed**, iperf3 22.8 Gbps

## Scope note

Route advertisement follows RG ownership on a cluster, so demotion addresses it there. A standalone unarmed node keeps advertising **by design** under the decision above. If someone wants an unarmed node to withdraw routes *independently* of RG state, that is a separate decision with its own failure mode — a box that is up, manageable, and invisible to routing — and should be its own issue.

Closes #7178