### PR TITLE
cluster,docs: correct a stale #6682 claim propagated by #7175

### DIFF
--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -308,12 +308,27 @@ no encoder version has ever omitted them — so a payload that stops before them
 is malformed, not old. Before #7175 the decoder accepted one anyway, returning
 `ok=true` with every one of those fields left at **zero**.
 
-Zero is not "missing" here, it is a *value the standby forwards against*, and
-zone id 0 against zone id 0 is matched by a `from-zone any to-zone any permit`
-rule with no zone guard (#6682). So a truncated frame did not degrade to "no
-session" — it seeded one that a wildcard rule affirmatively permits, carrying no
-NAT and no policy attribution, which became live forwarding state on the next
-failover. The precondition is a malformed frame no legitimate encoder emits
+Zero is not "missing" here — these are *values the standby installs and carries*,
+and they become live forwarding state on the next failover. A decoder must not
+report success for input it did not decode.
+
+> **Correction.** An earlier version of this section claimed that zone id 0
+> against zone id 0 is matched by a `from-zone any to-zone any permit` rule with
+> no zone guard, citing #6682. That was the **problem statement of a closed
+> issue**, not current behaviour. **Two** mechanisms make it false: #3110 fenced
+> every rule tier against zone 0 — `policy.rs` records that the rule-tier block
+> "is skipped entirely when either zone id is 0, which correctly stops every rule
+> tier — zone-pair, from-any, to-any, both-any and junos-global — from matching"
+> — and #6682 then made an unzoned **ingress** an explicit deny. A zero zone pair
+> does **not** reach a wildcard permit.
+>
+> The corrected version was already recorded in this repo, at
+> `compiler_wireguard_plaintext_warn_5618_test.go`, before the superseded claim
+> was written here.
+>
+> The decode contract does not depend on that claim and is unchanged. What a
+> zero-zone session does downstream once installed is **not** established here
+> and should be measured rather than asserted. The precondition is a malformed frame no legitimate encoder emits
 (fabric corruption, a version-skewed or buggy peer, a compromised peer), which is
 narrow — and is exactly the case where fail-open decoding is worst, because the
 receiving node has no other check.

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -220,10 +220,16 @@ type SyncStats struct {
 	// MalformedRecordsDropped counts sync records REJECTED by the #7175 decode
 	// contract: a session record truncated before its policy/zone/NAT block, or
 	// a DHCP full-set push that did not decode completely. Before #7175 these
-	// decoded ok=true and installed partial state — a session with PolicyID 0
-	// and zone ids (0,0), which a `from-zone any to-zone any permit` rule
-	// matches with no zone guard (#6682), or a lease set silently truncated to
-	// a prefix. The rejection is now countable because the failure mode it
+	// decoded ok=true and installed partial state — a session whose SessionID,
+	// PolicyID, zone ids and NAT fields were all fabricated zeros, or a lease
+	// set silently truncated to a prefix.
+	//
+	// CORRECTION: this doc previously cited #6682 for the claim that zone pair
+	// (0,0) is matched by a wildcard permit. #3110 fenced every rule tier against
+	// zone 0 and #6682 made an unzoned ingress an explicit deny, so a wildcard
+	// never reaches a zero pair. The counter's
+	// purpose is unchanged — a silently skipped install is how corruption hides
+	// — but it does not rest on that claim. The rejection is now countable because the failure mode it
 	// replaces was invisible: nothing distinguished a corrupt frame from a
 	// legitimately small one.
 	MalformedRecordsDropped atomic.Uint64

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -427,12 +427,31 @@ func decodeSessionV4Payload(payload []byte) (dataplane.SessionKey, dataplane.Ses
 	// — the values the session MEANS — and no encoder version has ever omitted
 	// them (every length-gated extension sits after the counters block; see
 	// encodeSessionV4Payload). Accepting a short read here returned ok=true with
-	// all of them left at ZERO, and zero is not "missing": zone id 0 against
-	// zone id 0 is matched by a `from-zone any to-zone any permit` rule with no
-	// zone guard (#6682). So a truncated frame did not degrade to "no session" —
-	// it seeded one a wildcard rule affirmatively permits, carrying no NAT and
-	// no policy attribution, which became live forwarding state on the next
-	// failover.
+	// all of them left at ZERO, and zero is not "missing": these are values the
+	// standby installs and carries, and they become live forwarding state on the
+	// next failover.
+	//
+	// CORRECTION (was wrong in the original #7175 comment): this used to cite
+	// #6682 for the claim that zone id 0 against zone id 0 is matched by a
+	// `from-zone any to-zone any permit` rule with no zone guard. TWO mechanisms make it false, and both
+	// predate #7175: #3110 fenced every rule tier against zone 0, so a wildcard
+	// never reaches a zero pair in the first place, and #6682 then made an unzoned
+	// INGRESS an explicit deny before the implicit default. `policy.rs`'s own
+	// comment records the first — the rule-tier block "is skipped entirely when
+	// either zone id is 0, which correctly stops every rule tier ... from
+	// matching". The claim I cited was the PROBLEM STATEMENT of a closed issue.
+	//
+	// The corrected version was already written down in this repo, at
+	// compiler_wireguard_plaintext_warn_5618_test.go, before I asserted the
+	// superseded one.
+	//
+	// The fix stands on its own terms without it: a decoder must not report
+	// success for input it did not decode, and installing a session whose
+	// identity, policy attribution and NAT translation are all fabricated zeros
+	// is wrong state regardless of what any one downstream consumer then does
+	// with it. What is NOT established — and must not be asserted without
+	// measuring — is whether an installed zero-zone session's subsequent packets
+	// re-enter policy evaluation at all or take a session fast path.
 	if off+48 > len(payload) {
 		return key, val, false
 	}

--- a/pkg/cluster/sync_truncated_record_7175_test.go
+++ b/pkg/cluster/sync_truncated_record_7175_test.go
@@ -11,13 +11,26 @@ import (
 // #7175: a truncated-but-framed session-sync record must not decode ok=true
 // with its policy/zone/NAT fields left at zero.
 //
-// WHY ZERO IS NOT "MISSING". A zeroed PolicyID and zone ids are not absent
-// values, they are VALUES the standby forwards against, and zone id 0 against
-// zone id 0 is matched by a `from-zone any to-zone any permit` rule with no zone
-// guard (#6682). So the pre-fix behaviour did not degrade a truncated frame to
-// "no session" — it seeded one that a wildcard rule affirmatively permits,
-// carrying no NAT and no policy attribution, which became live forwarding state
-// on the next failover.
+// WHY ZERO IS NOT "MISSING". A zeroed SessionID, PolicyID, zone pair and NAT
+// tuple are not absent values — they are VALUES the standby installs and
+// carries, and they become live forwarding state on the next failover.
+//
+// CORRECTION to the original #7175 rationale: this said zone id 0 against zone
+// id 0 is matched by a `from-zone any to-zone any permit` rule with no zone
+// guard, citing #6682. That was the PROBLEM STATEMENT of a CLOSED issue, not
+// current behaviour. Two mechanisms make it false: #3110 fenced every rule
+// tier against zone 0, so a wildcard never reaches a zero pair, and #6682 then
+// made an unzoned INGRESS an explicit deny. The corrected version was ALREADY
+// written in this repo — compiler_wireguard_plaintext_warn_5618_test.go says
+// the older claim "was wrong" — before I asserted the superseded one.
+//
+// The assertions below are unchanged and still correct, because they never
+// depended on that claim: they assert that no ACCEPTED prefix may carry zeroed
+// forwarding fields, which is a property of the decoder. A decoder must not
+// report success for input it did not decode. What is deliberately NOT asserted
+// here is any downstream consequence of an installed zero-zone session — that
+// would need measuring, and asserting it unmeasured is how the original error
+// got in.
 //
 // WHY A FULL PREFIX SWEEP RATHER THAN A FEW BOUNDARY CASES. The property is not
 // "these particular lengths are rejected", it is "no accepted length yields
@@ -71,8 +84,8 @@ func TestTruncatedV4RecordNeverDecodesWithZeroedForwardingFields7175(t *testing.
 				"record must not be accepted with a zeroed policy id (#7175)", n, got.PolicyID, val.PolicyID)
 		}
 		if got.IngressZone != val.IngressZone || got.EgressZone != val.EgressZone {
-			t.Fatalf("prefix of %d bytes decoded ok=true with zones (%d,%d), want (%d,%d) — zone id 0 "+
-				"is matched by a from-zone any to-zone any permit rule with no zone guard (#6682)",
+			t.Fatalf("prefix of %d bytes decoded ok=true with zones (%d,%d), want (%d,%d) — a "+
+				"decoder must not report success for a record whose zone identity it never read",
 				n, got.IngressZone, got.EgressZone, val.IngressZone, val.EgressZone)
 		}
 		if got.NATSrcIP != val.NATSrcIP || got.NATDstIP != val.NATDstIP ||


### PR DESCRIPTION
**I asserted something false and it reached merged code, a test's stated reasoning, and the docs. This corrects all five sites.**

#7175's rationale claimed that zone id 0 against zone id 0 is matched by a `from-zone any to-zone any permit` rule with no zone guard, citing #6682. That is false at master. **I quoted the closed issue's PROBLEM STATEMENT as current behaviour.**

## Two mechanisms make it false, and both predate #7175

- **#3110** fenced every rule tier against zone 0 — so a wildcard never reaches a zero pair at all. `policy.rs` records it: the rule-tier block *"is skipped entirely when either zone id is 0, which correctly stops every rule tier — zone-pair, from-any, to-any, both-any and junos-global — from matching"*.
- **#6682** then made an unzoned **ingress** an explicit deny before the implicit default.

## The correction was already in this repo

`compiler_wireguard_plaintext_warn_5618_test.go` says outright that the older *"matches zone-pair (0,0) with no zone guard"* claim **"was wrong"**, and names both mechanisms. It was written before I asserted the superseded version. Citing a closed issue's problem statement without checking either its disposition or the tree is how the stale claim got in.

## How it was caught

A teammate I had handed the claim to **as a constraint** measured the evaluator directly:

```
(0,0)     under wildcard any->any  -> Deny
(lan,lan) under wildcard any->any  -> Permit
```

The second line is the control, and it is what makes the first mean something — it proves the wildcard rule was live and matching for configured zones, so the Deny at (0,0) is not a dropped rule or a fixture that failed to resolve `any`. It reported the contradiction rather than the benign reading I had told it to expect.

## What does NOT change

The #7175 fix and every one of its assertions, because **neither ever depended on the claim**. The decode contract is that a decoder must not report success for input it did not decode, and the tests assert that no *accepted* prefix carries zeroed forwarding fields — a property of the decoder alone. Only the severity narrative was wrong.

## What this deliberately does NOT do

**It does not substitute a new downstream consequence.** Whether an installed zero-zone session's subsequent packets re-enter policy evaluation or take a session fast path is **unmeasured**, and asserting it unmeasured is exactly how the original error got in. The replacement text says it is unestablished rather than guessing again.

Full Go suite: **rc=0, 69 packages, 0 FAIL**. Comments and docs only — no behaviour change.

Refs #7175, #6682