### PR TITLE
filter: stop matching a non-first fragment's synthetic ports (#7174 C19)

### DIFF
--- a/userspace-dp/src/filter/engine/matching.rs
+++ b/userspace-dp/src/filter/engine/matching.rs
@@ -206,20 +206,7 @@ pub(super) fn term_matches_v4(
     ) {
         return false;
     }
-    if !port_match(
-        term.source_port_constrained,
-        term.source_port_except,
-        &term.source_ports,
-        src_port,
-    ) {
-        return false;
-    }
-    if !port_match(
-        term.dest_port_constrained,
-        term.dest_port_except,
-        &term.dest_ports,
-        dst_port,
-    ) {
+    if !port_terms_match(term, extra, src_port, dst_port) {
         return false;
     }
     if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {
@@ -307,6 +294,72 @@ fn nets_match_v6(constrained: bool, except: bool, nets: &[PrefixV6], ip: Ipv6Add
 ///   plain positive membership; `except == true` matches every port NOT in the
 ///   set.
 #[inline(always)]
+/// #7174 (C19): a port constraint must not be evaluated against the SYNTHETIC
+/// ports of a non-first fragment.
+///
+/// A non-first fragment carries no L4 header and its ports arrive as 0. Matching
+/// that against a real `source-port` / `destination-port` term was already
+/// dubious; against a `*-port-except` term it INVERTED the verdict, because
+/// `port_match` is `matcher.matches(port) ^ except` — port 0 is not in the set,
+/// so the `except` arm returned TRUE and the fragment spuriously MATCHED.
+/// Concretely, `from destination-port-except 22; then discard;` discarded every
+/// non-first fragment of a port-22 flow.
+///
+/// THE GATE IS `is_fragment && !l4_present`, NOT `!l4_present` ALONE, AND THAT
+/// IS THE WHOLE DESIGN. `term_matches_v4/v6` is shared by two callers with
+/// different contracts:
+///
+///   - the COLD path builds `TermMatchExtra` from a real packet, so
+///     `l4_present` genuinely means "this packet has an L4 header";
+///   - the FLOW-CACHE path (`filter/engine/cache_sensitive.rs`) evaluates real
+///     cached flows with `TermMatchExtra::default()`, i.e. `l4_present: false`
+///     unconditionally, because the ports it passes come from the flow's
+///     5-tuple SessionKey and are real. `FilterTerm::has_per_packet_l4_match`
+///     spells out why ports are not in the cache-sensitive set: those conditions
+///     are the ones "not part of the 5-tuple SessionKey", and ports ARE part of
+///     it.
+///
+/// So gating on `!l4_present` alone would stop every port-constrained term
+/// matching on every cached flow — a large silent forwarding change. Measured:
+/// it reds 11+ tests across `cos_classify`, `frame` and `tests_bind_forward`.
+///
+/// `is_fragment` discriminates because it is L3-derived and valid regardless of
+/// `l4_present`: a non-first fragment carries `is_fragment: true, l4_present:
+/// false`, while a cached flow carries `false, false`. That pair is the only
+/// thing that separates "ports are synthetic" from "ports came from the key".
+///
+/// SCOPE, stated because it is narrower than "gate ports on l4_present": this
+/// fixes the fragment case. Other cold-path `!l4_present` shapes — a truncated
+/// ICMP or TCP header (`inspect.rs`: `l4_present` also drops for
+/// `l4_truncated_icmp` / `l4_truncated_tcp`) — are NOT covered, because they
+/// carry `is_fragment: false` and are indistinguishable here from a cached flow.
+/// Whether their ports are equally synthetic is a separate question that needs
+/// its own measurement; it is not silently included.
+fn port_terms_match(
+    term: &FilterTerm,
+    extra: TermMatchExtra<'_>,
+    src_port: u16,
+    dst_port: u16,
+) -> bool {
+    if (term.source_port_constrained || term.dest_port_constrained)
+        && extra.is_fragment
+        && !extra.l4_present
+    {
+        return false;
+    }
+    port_match(
+        term.source_port_constrained,
+        term.source_port_except,
+        &term.source_ports,
+        src_port,
+    ) && port_match(
+        term.dest_port_constrained,
+        term.dest_port_except,
+        &term.dest_ports,
+        dst_port,
+    )
+}
+
 fn port_match(constrained: bool, except: bool, matcher: &PortMatcher, port: u16) -> bool {
     if constrained && matches!(matcher, PortMatcher::Any) {
         // Constrained but no range survived parsing (every token unparseable).
@@ -350,20 +403,7 @@ pub(super) fn term_matches_v6(
     ) {
         return false;
     }
-    if !port_match(
-        term.source_port_constrained,
-        term.source_port_except,
-        &term.source_ports,
-        src_port,
-    ) {
-        return false;
-    }
-    if !port_match(
-        term.dest_port_constrained,
-        term.dest_port_except,
-        &term.dest_ports,
-        dst_port,
-    ) {
+    if !port_terms_match(term, extra, src_port, dst_port) {
         return false;
     }
     if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -10255,3 +10255,159 @@ fn no_production_caller_of_the_test_only_routing_instance_wrapper_7053() {
          by #7053 need revisiting — they say it is not on a production path"
     );
 }
+
+
+// ---------------------------------------------------------------------------
+// #7174 (C19): a non-first fragment's SYNTHETIC ports must not be matched
+// against a port-constrained term.
+//
+// A non-first fragment carries no L4 header; its ports arrive as 0. Against a
+// `*-port-except` term that INVERTED the verdict, because port_match is
+// `matcher.matches(port) ^ except` — 0 is not in the except set, so the term
+// spuriously MATCHED. `from destination-port-except 22; then discard;`
+// discarded every non-first fragment of a port-22 flow.
+//
+// THE THIRD CELL IS THE ONE THAT MATTERS. The obvious fix — gate ports on
+// `l4_present` the way tcp-flags / icmp-type already are — is WRONG, and
+// measured wrong: it reds 11+ tests. `term_matches_v4/v6` is shared with the
+// flow-cache path, which evaluates real cached flows with
+// `TermMatchExtra::default()` (l4_present: false) while passing ports that came
+// from the flow's 5-tuple SessionKey and are real. Gating on l4_present alone
+// stops every port-constrained term matching on every cached flow.
+//
+// `is_fragment` is what discriminates: L3-derived and valid regardless of
+// l4_present, so a non-first fragment is (true, false) while a cached flow is
+// (false, false).
+// ---------------------------------------------------------------------------
+
+fn dport_except_22_filter_7174(family: &str) -> Vec<FirewallFilterSnapshot> {
+    vec![FirewallFilterSnapshot {
+        name: "dport-except-7174".into(),
+        family: family.into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "deny-except-22".into(),
+            protocols: vec!["tcp".into()],
+            action: "discard".into(),
+            destination_ports_except: vec!["22".into()],
+            ..Default::default()
+        }],
+    }]
+}
+
+#[test]
+fn non_first_fragment_does_not_match_a_port_except_term_v4_7174() {
+    let state = make_filter_state(&dport_except_22_filter_7174("inet"), &[]);
+    // A non-first fragment: no L4 header, synthetic port 0, is_fragment set.
+    let frag = TermMatchExtra {
+        is_fragment: true,
+        l4_present: false,
+        ..Default::default()
+    };
+    let result = evaluate_filter(
+        &state,
+        "inet:dport-except-7174",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        0,
+        0,
+        0,
+        frag,
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "a non-first fragment has no ports, so a destination-port-except term must not \
+         match it. Matching turned `except 22` into a discard for every fragment of a \
+         port-22 flow, because 0 is not 22 (#7174 C19)"
+    );
+}
+
+#[test]
+fn non_first_fragment_does_not_match_a_port_except_term_v6_7174() {
+    let state = make_filter_state(&dport_except_22_filter_7174("inet6"), &[]);
+    let frag = TermMatchExtra {
+        is_fragment: true,
+        l4_present: false,
+        ..Default::default()
+    };
+    let result = evaluate_filter(
+        &state,
+        "inet6:dport-except-7174",
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        IpAddr::V6("2001:db8::2".parse().unwrap()),
+        PROTO_TCP,
+        0,
+        0,
+        0,
+        frag,
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "the v6 matcher is a structural copy of the v4 one, so a gate present in one and \
+         not the other is the failure mode (#7174 C19)"
+    );
+}
+
+// THE CONTROL. A cached flow presents l4_present: false with REAL ports taken
+// from its 5-tuple SessionKey, and is_fragment: false. It must still match.
+//
+// This is the assertion the obvious fix fails. Without it, gating ports on
+// l4_present alone passes both cells above while silently disabling port
+// filtering for every established flow.
+#[test]
+fn a_cached_flow_still_matches_a_port_term_despite_no_l4_present_7174() {
+    let state = make_filter_state(&dport_except_22_filter_7174("inet"), &[]);
+    // The flow-cache shape: TermMatchExtra::default() -> l4_present false,
+    // is_fragment false; ports supplied by the caller from the SessionKey.
+    let cached = TermMatchExtra::default();
+    let result = evaluate_filter(
+        &state,
+        "inet:dport-except-7174",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        54321,
+        12345,
+        0,
+        cached,
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Discard,
+        "a CACHED flow carries l4_present: false but REAL ports from its SessionKey, so a \
+         port-except term must still match. If this is Accept, ports were gated on \
+         l4_present alone and port filtering is now silently dead for every established \
+         flow — the mistake the narrow is_fragment gate exists to avoid (#7174 C19)"
+    );
+}
+
+// And the positive control for the fragment cells: the SAME filter must still
+// discard a real non-fragment packet on a non-excepted port. Without it, a
+// matcher that rejected everything would satisfy both fragment assertions.
+#[test]
+fn a_whole_packet_still_matches_the_port_except_term_7174() {
+    let state = make_filter_state(&dport_except_22_filter_7174("inet"), &[]);
+    let whole = TermMatchExtra {
+        l4_present: true,
+        ..Default::default()
+    };
+    let result = evaluate_filter(
+        &state,
+        "inet:dport-except-7174",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        54321,
+        12345,
+        0,
+        whole,
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Discard,
+        "port 12345 is not in the except list, so a whole packet must still be discarded — \
+         otherwise the fragment cells pass against a matcher that rejects everything"
+    );
+}


### PR DESCRIPTION
`port_match` ran unconditionally, **before** `per_packet_l4_matches` — which gates tcp-flags, icmp-type, icmp-code and is-fragment on `l4_present` but never gated ports. A non-first fragment carries no L4 header and its ports arrive as **0**, so a real port term was matched against a synthetic value.

Against a `*-port-except` term that **inverted the verdict**, because `port_match` is `matcher.matches(port) ^ except` and 0 is not in the set. Concretely: `from destination-port-except 22; then discard;` discarded **every non-first fragment of a port-22 flow.** It is the only wrong-answer row in its cohort.

## The gate is `is_fragment && !l4_present`, NOT `!l4_present` alone

**The issue's stated fix direction is wrong, and measured wrong.** `term_matches_v4/v6` is shared by two callers with different contracts:

- the **cold path** builds `TermMatchExtra` from a real packet, so `l4_present` means what it says;
- the **flow-cache path** (`filter/engine/cache_sensitive.rs`) evaluates *real cached flows* with `TermMatchExtra::default()` — `l4_present: false` unconditionally — while passing ports that came from the flow's **5-tuple SessionKey** and are real.

`FilterTerm::has_per_packet_l4_match` spells out why ports aren't in the cache-sensitive set: those conditions are the ones *"not part of the 5-tuple SessionKey"*, and **ports are part of it**. So gating on `l4_present` alone stops every port-constrained term matching on every cached flow.

`is_fragment` discriminates because it is L3-derived and valid regardless of `l4_present`: a non-first fragment is `(true, false)`, a cached flow is `(false, false)`. That pair is the only thing separating *"these ports are synthetic"* from *"these ports came from the key"*.

## Measured, not assumed: a fragment cannot reach the cached path

`parse_session_flow_from_bytes` refuses to build a `SessionFlow` for a non-first fragment at a **single chokepoint**, and its comment gives the purpose — the fragment stays flowless *"instead of polluting policy / **flow-cache** / session indexes"*. No flow means no flow-cache hit, so the cached path never needs this gate and must not receive it.

## Mutation matrix — the two cells localise disjointly

| mutation | collected | result |
|---|---|---|
| **A** — remove the gate (restore the defect) | 4876 | **2 FAIL**: both fragment cells. Control unaffected. |
| **B** — the issue's stated fix (`!l4_present` alone) | 4804 | **75 FAIL**, and of my four cells exactly **the control** |

**B is the one that matters.** `a_cached_flow_still_matches_a_port_term_despite_no_l4_present_7174` is the assertion the obvious fix fails — without it, a change that silently disabled port filtering for every established flow would pass both fragment cells. A fourth cell (whole packet still discarded on a non-excepted port) stops the fragment cells passing against a matcher that rejects everything.

## Scope, stated in the code rather than implied

This fixes the **fragment** case. The other cold-path `!l4_present` shapes — a truncated ICMP or TCP header — carry `is_fragment: false` and are indistinguishable here from a cached flow, so they are **not** covered. Whether their ports are equally synthetic needs its own measurement rather than being folded in silently.

## Gates

- `make test-rust`: **rc=0, 10 binaries, 4946 passed, 0 failed, 0 compile errors**
- Go: **69 packages, 0 FAIL**
- `make test-failover`: **17 passed, 0 failed**, iperf3 22.7 Gbps

Refs #7174