### PR TITLE
userspace: make the helper crash record renderable and non-stale

### DIFF
--- a/pkg/dataplane/userspace/helper_crash_record_7250_test.go
+++ b/pkg/dataplane/userspace/helper_crash_record_7250_test.go
@@ -1,0 +1,116 @@
+package userspace
+
+import (
+	"testing"
+	"time"
+)
+
+// #7250: the crash record must be renderable AND must not report things that
+// are no longer true.
+//
+// Two of its facts are DERIVED rather than stored, and that is the fix rather
+// than a style choice — a stored judgement about the present is exactly what
+// went stale. `Crashed` was read as both "the last exit was unexpected" and "a
+// restart is coming", and those diverge the moment an intentional stop advances
+// the process generation: the armed timer is orphaned, the record is
+// deliberately NOT cleared (the retry path depends on it as debt), and a
+// renderer would have reported a restart that will never fire.
+
+func TestRestartPendingIsFalseAfterAnIntentionalStop7250(t *testing.T) {
+	m := New()
+
+	// The shape a crash leaves behind: retry debt recorded, armed for the
+	// generation that died.
+	m.mu.Lock()
+	m.procGen = 7
+	m.proc = nil
+	m.helperCrash = HelperCrashRecord{
+		LastExitWasCrash: true,
+		Restarts:         1,
+		NextRestart:      time.Now().Add(time.Second),
+		restartGen:       7,
+	}
+	m.mu.Unlock()
+
+	// Precondition: while the generation still matches, a restart IS pending.
+	// Without this the assertion below could pass on a record that never
+	// reported pending in the first place.
+	if got := m.HelperCrashState(); !got.RestartPending {
+		t.Fatalf("precondition: a crash armed on the CURRENT generation must report "+
+			"RestartPending, got %+v", got)
+	}
+
+	// An intentional stop advances the generation, orphaning the armed timer.
+	m.mu.Lock()
+	m.procGen = 8
+	m.mu.Unlock()
+
+	got := m.HelperCrashState()
+	if got.RestartPending {
+		t.Error("RestartPending is still true after the generation advanced. The armed " +
+			"timer is fenced on the old generation and will never fire, so a status " +
+			"surface would tell an operator a restart is coming that is not (#7250)")
+	}
+	// And the OTHER fact must survive: the retry path reads it as debt, and
+	// clearing it turned TestRestartUsesTheCurrentConfigNotTheDeadGeneration5838
+	// red when it was tried.
+	if !got.LastExitWasCrash {
+		t.Error("LastExitWasCrash must NOT be cleared by a stop — ensureProcessLocked " +
+			"calls the same stopLocked when a spawn misses readiness, and the retry " +
+			"path depends on this flag")
+	}
+}
+
+// The crash-loop predicate is backoff-at-cap, not a raw restart count, because a
+// count is time-blind: twenty restarts over a week and twenty in a minute are
+// different situations a counter cannot distinguish.
+func TestCrashLoopingIsBackoffAtCapNotACount7250(t *testing.T) {
+	// One restart: escalating, not looping.
+	early := HelperCrashRecord{LastExitWasCrash: true, Restarts: 1}
+	if early.CrashLooping() {
+		t.Errorf("a single restart must not read as crash-looping: delay %v, cap %v",
+			helperRestartDelay(1), helperRestartBackoffMax)
+	}
+
+	// Enough restarts that the backoff has saturated.
+	att := 1
+	for helperRestartDelay(att) < helperRestartBackoffMax {
+		att++
+		if att > 64 {
+			t.Fatal("backoff never reached the cap; the predicate cannot be satisfied")
+		}
+	}
+	looping := HelperCrashRecord{LastExitWasCrash: true, Restarts: att}
+	if !looping.CrashLooping() {
+		t.Errorf("backoff at the cap (attempt %d, delay %v) must read as crash-looping",
+			att, helperRestartDelay(att))
+	}
+
+	// The control that stops this being "any record with enough restarts": a
+	// helper that recovered is not looping however many times it restarted.
+	recovered := HelperCrashRecord{LastExitWasCrash: false, Restarts: att}
+	if recovered.CrashLooping() {
+		t.Error("a record whose last exit was NOT a crash must never read as " +
+			"crash-looping, however high the restart count — otherwise the predicate " +
+			"latches on a box that recovered")
+	}
+}
+
+// Exit code and signal must be separable. Detail folds them into prose
+// ("exit status 101" / "killed by signal killed") that a renderer cannot parse
+// back apart, which is why the acceptance bullet asks for them separately.
+func TestExitCodeAndSignalAreSeparable7250(t *testing.T) {
+	crashed := HelperCrashRecord{ExitCode: 101, Signal: ""}
+	if crashed.ExitCode != 101 || crashed.Signal != "" {
+		t.Errorf("a normal exit must carry its code with no signal, got %+v", crashed)
+	}
+	killed := HelperCrashRecord{ExitCode: -1, Signal: "killed"}
+	if killed.ExitCode != -1 || killed.Signal == "" {
+		t.Errorf("a signalled exit must carry the signal and -1 for the code, got %+v", killed)
+	}
+	// Signal is the discriminator: exactly one of the two is meaningful, and a
+	// renderer needs a rule it can apply without parsing prose.
+	if crashed.Signal != "" || killed.Signal == "" {
+		t.Error("Signal must discriminate the two dispositions")
+	}
+}

--- a/pkg/dataplane/userspace/helper_crash_supervisor_5838_test.go
+++ b/pkg/dataplane/userspace/helper_crash_supervisor_5838_test.go
@@ -171,7 +171,7 @@ func TestHelperCrashIsReapedAndFailsClosed5838(t *testing.T) {
 	if proc != nil {
 		t.Error("m.proc is still set after the helper died; every `m.proc == nil` liveness test still reads TRUE")
 	}
-	if !crash.Crashed {
+	if !crash.LastExitWasCrash {
 		t.Error("no crash recorded for an unexpected exit")
 	}
 	if !strings.Contains(crash.Detail, "signal") {
@@ -256,7 +256,7 @@ func TestIntentionalStopDoesNotScheduleRestart5838(t *testing.T) {
 	m.mu.Lock()
 	crash := m.helperCrash
 	m.mu.Unlock()
-	if crash.Crashed {
+	if crash.LastExitWasCrash {
 		t.Errorf("an INTENTIONAL stop was recorded as a crash: %+v", crash)
 	}
 	if len(rec.snapshot()) != 0 {
@@ -293,7 +293,7 @@ func TestStaleWaiterCannotMutateNewerGeneration5838(t *testing.T) {
 	if sup != live {
 		t.Error("a stale waiter replaced the live generation's supervisor record")
 	}
-	if crash.Crashed {
+	if crash.LastExitWasCrash {
 		t.Errorf("a stale waiter recorded a crash against the live generation: %+v", crash)
 	}
 	if len(rec.snapshot()) != 0 {
@@ -359,7 +359,7 @@ func TestFailedRestartRetainsDebtAndStaysFailClosed5838(t *testing.T) {
 	m.mu.Lock()
 	crash := m.helperCrash
 	m.mu.Unlock()
-	if !crash.Crashed {
+	if !crash.LastExitWasCrash {
 		t.Error("a FAILED restart cleared the crash state; the node would advertise itself ready again")
 	}
 	if ready, _ := m.TakeoverReady(); ready {
@@ -566,7 +566,7 @@ func TestRestartUsesTheCurrentConfigNotTheDeadGeneration5838(t *testing.T) {
 	if oldSocket == newSocket {
 		t.Fatal("premise broken: the two configs are not distinguishable")
 	}
-	if !crash.Crashed {
+	if !crash.LastExitWasCrash {
 		t.Error("the failed restart cleared the crash state")
 	}
 	// It really did attempt a spawn with the NEW config: the attempt count grew

--- a/pkg/dataplane/userspace/helper_restart_after_stop_5838_test.go
+++ b/pkg/dataplane/userspace/helper_restart_after_stop_5838_test.go
@@ -3,7 +3,7 @@
 //
 // The supervisor added in #7228 arms a bounded-backoff restart after an
 // unexpected helper exit and fences the attempt on
-// `(m.procGen != gen || m.proc != nil || !m.helperCrash.Crashed)`. An
+// `(m.procGen != gen || m.proc != nil || !m.helperCrash.LastExitWasCrash)`. An
 // intentional stop satisfied none of those: `stopLocked` clears `m.proc` and
 // `m.procSup` but never advances `m.procGen` and never clears `m.helperCrash`.
 // And the stop that FOLLOWS a crash takes `stopLocked`'s `m.proc == nil` early
@@ -75,10 +75,10 @@ func TestHelperCrashRestartCancelledByIntentionalStop_5838(t *testing.T) {
 	// Crash it and let the supervisor reap and arm the restart.
 	_ = child.Process.Kill()
 	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) && !m.HelperCrashState().Crashed {
+	for time.Now().Before(deadline) && !m.HelperCrashState().LastExitWasCrash {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !m.HelperCrashState().Crashed {
+	if !m.HelperCrashState().LastExitWasCrash {
 		t.Fatal("supervisor never recorded the crash — the rest of this test would be vacuous")
 	}
 	mu.Lock()
@@ -93,7 +93,7 @@ func TestHelperCrashRestartCancelledByIntentionalStop_5838(t *testing.T) {
 	m.stopLocked()
 	m.mu.Unlock()
 
-	// NOTE: `HelperCrashState().Crashed` deliberately survives the stop. The
+	// NOTE: `HelperCrashState().LastExitWasCrash` deliberately survives the stop. The
 	// record is the retry debt `ensureProcessLocked`'s own failure path depends
 	// on (it calls stopLocked when a spawn misses its readiness wait), so
 	// clearing it here would make a failed restart forget it was retrying. What
@@ -162,10 +162,10 @@ func TestHelperCrashRestartStillRunsWithoutAStop_5838(t *testing.T) {
 
 	_ = child.Process.Kill()
 	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) && !m.HelperCrashState().Crashed {
+	for time.Now().Before(deadline) && !m.HelperCrashState().LastExitWasCrash {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !m.HelperCrashState().Crashed {
+	if !m.HelperCrashState().LastExitWasCrash {
 		t.Fatal("supervisor never recorded the crash")
 	}
 

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -105,7 +105,7 @@ type Manager struct {
 	procGen uint64
 	// helperCrash records the last UNEXPECTED helper exit for the operator and
 	// drives the restart backoff. Zero value means "no crash on record".
-	helperCrash helperCrashState
+	helperCrash HelperCrashRecord
 	// restartTimerFn overrides how a crash restart is armed. Production leaves
 	// it nil (time.AfterFunc); a test injects a synchronous or recording timer.
 	// Per-Manager, not a package var — see scheduleRestartTimer.

--- a/pkg/dataplane/userspace/process_supervisor.go
+++ b/pkg/dataplane/userspace/process_supervisor.go
@@ -90,25 +90,99 @@ func (g *helperGeneration) describeExit() string {
 	return fmt.Sprintf("exit status %d", g.state.ExitCode())
 }
 
-// helperCrashState is the operator-visible record of the last unexpected exit
+// exitCodeAndSignal returns the child's disposition as two separable values:
+// the exit status (or -1) and the signal name (or ""). #7250 — describeExit
+// folds both into one prose string that a renderer cannot take apart again.
+func (g *helperGeneration) exitCodeAndSignal() (int, string) {
+	if g.state == nil {
+		return -1, ""
+	}
+	if ws, ok := g.state.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		return -1, ws.Signal().String()
+	}
+	return g.state.ExitCode(), ""
+}
+
+// HelperCrashRecord is the operator-visible record of the last unexpected exit
 // and the backoff it drives.
-type helperCrashState struct {
-	// Crashed is set while the manager is between an unexpected exit and a
-	// successful restart. It is what makes the staleness observable instead of
-	// having to be inferred from a nil pointer.
-	Crashed bool
+//
+// #7250: EXPORTED, because the previous unexported `HelperCrashRecord` could be
+// returned but not NAMED by an out-of-package caller — and a status surface is
+// exactly such a caller. It could hold the value and not declare a variable, a
+// struct field or a parameter for it, which made the accessor unusable for the
+// thing it exists to feed. The type is named ...Record rather than ...State so
+// it does not collide with the Manager.HelperCrashState() accessor.
+type HelperCrashRecord struct {
+	// LastExitWasCrash is set while the manager is between an unexpected exit
+	// and a successful restart. It is what makes the staleness observable
+	// instead of having to be inferred from a nil pointer.
+	//
+	// #7250: renamed from `Crashed`, which was read as BOTH "the last exit was
+	// unexpected" and "a restart is coming" — two facts that diverge. This is
+	// the first one, and it is deliberately NOT cleared by an intentional stop:
+	// `ensureProcessLocked` calls the same `stopLocked` when a spawn misses its
+	// readiness wait, and the retry path depends on this flag as its debt
+	// (clearing it turned TestRestartUsesTheCurrentConfigNotTheDeadGeneration5838
+	// red). Use RestartPending for the other fact.
+	LastExitWasCrash bool
 	// Detail is the reaped disposition ("exit status 101", "killed by signal
-	// killed"). Never carries a secret.
+	// killed"). Never carries a secret. Kept for display; prefer ExitCode /
+	// Signal when deciding anything.
 	Detail string
+	// ExitCode is the child's exit status, or -1 when it was signalled or the
+	// status could not be read (#7250). Exactly one of ExitCode >= 0 and
+	// Signal != "" is meaningful, and Signal is the discriminator.
+	//
+	// Split out because Detail folded the two into one string, and a renderer
+	// cannot reliably take them apart again — "killed by signal killed" and
+	// "exit status 101" have no common grammar to parse.
+	ExitCode int
+	// Signal is the signal name when the child was killed by one, otherwise "".
+	Signal string
 	// PID is the dead child, kept so an operator can correlate with journald.
 	PID int
 	// At is when the exit was observed.
 	At time.Time
 	// Restarts counts consecutive restart ATTEMPTS since the last helper that
-	// reached readiness. It drives the backoff and is reset on success.
+	// reached readiness.
 	Restarts int
-	// NextRestart is the deadline the pending restart is scheduled for.
+	// NextRestart is when the armed retry is due. Only meaningful when
+	// RestartPending is true — after an intentional stop this is a time in the
+	// PAST with no timer behind it (#7250).
 	NextRestart time.Time
+	// RestartPending reports whether a retry is actually armed and will fire.
+	//
+	// #7250: DERIVED in HelperCrashState() from the live generation rather than
+	// stored, because a stored flag is exactly what went stale. An intentional
+	// stop advances procGen, which orphans the armed timer without clearing the
+	// crash record — so before this, a renderer would have reported a restart
+	// that was never going to happen.
+	RestartPending bool
+	// restartGen is the process generation the pending retry was armed for.
+	// Unexported: it is an internal fence, not something a renderer should see
+	// or construct.
+	restartGen uint64
+}
+
+// CrashLooping reports whether the helper should be treated as not coming back.
+//
+// #7250 asked for "a predicate an operator or a health surface can read", and
+// noted it needs deciding rather than plumbing. The decision: crash-looping is
+// BACKOFF AT THE CAP, not a raw restart count.
+//
+// A count threshold is time-blind — twenty restarts over a week and twenty in a
+// minute are different situations and a bare counter cannot tell them apart.
+// The backoff already encodes the time dimension: it doubles from
+// helperRestartBackoffBase and saturates at helperRestartBackoffMax, so reaching
+// the cap means the supervisor has exhausted its escalation and is now retrying
+// at its slowest rate. With the shipped 1s base and 60s cap that is roughly two
+// minutes of uninterrupted failure, and it does not fire for a helper that
+// crashed once an hour ago.
+//
+// Derived, never stored, for the same reason RestartPending is: a stored
+// judgement about the present is the thing that goes stale.
+func (r HelperCrashRecord) CrashLooping() bool {
+	return r.LastExitWasCrash && helperRestartDelay(r.Restarts) >= helperRestartBackoffMax
 }
 
 // Helper restart backoff. Bounded exponential from base to max, so a helper
@@ -224,12 +298,18 @@ func (m *Manager) handleUnexpectedHelperExitLocked(g *helperGeneration) {
 	m.proc = nil
 	m.resetAfterHelperGoneLocked()
 
-	m.helperCrash = helperCrashState{
-		Crashed:  true,
-		Detail:   detail,
-		PID:      pid,
-		At:       time.Now(),
-		Restarts: m.helperCrash.Restarts,
+	exitCode, signal := g.exitCodeAndSignal()
+	m.helperCrash = HelperCrashRecord{
+		LastExitWasCrash: true,
+		Detail:           detail,
+		ExitCode:         exitCode,
+		Signal:           signal,
+		PID:              pid,
+		At:               time.Now(),
+		Restarts:         m.helperCrash.Restarts,
+		// #7250: the generation this retry is fenced on, so
+		// HelperCrashState() can tell an armed restart from an orphaned one.
+		restartGen: g.gen,
 	}
 	m.scheduleHelperRestartLocked(g.gen)
 }
@@ -260,7 +340,7 @@ func (m *Manager) restartHelperAfterCrash(gen uint64) {
 	defer m.mu.Unlock()
 	// Fences: a newer generation exists (someone already restarted or Stop ran
 	// and respawned), or a helper is running again, or the crash was cleared.
-	if m.procGen != gen || m.proc != nil || !m.helperCrash.Crashed {
+	if m.procGen != gen || m.proc != nil || !m.helperCrash.LastExitWasCrash {
 		return
 	}
 	if err := m.ensureProcessLocked(m.cfg); err != nil {
@@ -274,7 +354,7 @@ func (m *Manager) restartHelperAfterCrash(gen uint64) {
 	}
 	slog.Info("userspace dataplane helper restarted after unexpected exit",
 		"attempts", m.helperCrash.Restarts)
-	m.helperCrash = helperCrashState{}
+	m.helperCrash = HelperCrashRecord{}
 	// The crash tore the 1 Hz reconcile loop down with the generation it was
 	// polling; the replacement needs its own.
 	m.ensureStatusLoopLocked()
@@ -282,8 +362,18 @@ func (m *Manager) restartHelperAfterCrash(gen uint64) {
 
 // HelperCrashState returns the last unexpected-exit record, for status
 // rendering and tests. The zero value means no crash is on record.
-func (m *Manager) HelperCrashState() helperCrashState {
+func (m *Manager) HelperCrashState() HelperCrashRecord {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.helperCrash
+	rec := m.helperCrash
+	// #7250: DERIVE RestartPending here rather than storing it. An armed retry
+	// is fenced on the generation that died; an intentional stop advances
+	// procGen and orphans the timer WITHOUT clearing the crash record, so a
+	// stored flag would report a restart that will never fire. The fence is the
+	// same one restartHelperAfterCrash applies, read at the moment the caller
+	// asks.
+	rec.RestartPending = rec.LastExitWasCrash &&
+		m.proc == nil &&
+		m.procGen == rec.restartGen
+	return rec
 }


### PR DESCRIPTION
#5838 shipped the supervisor but not its last acceptance bullet — *"operational status exposes exit code/signal, restart count, last exit/restart timestamps, backoff deadline, and crash-loop reason"*. The data existed and **nothing could render it**. This is the data half; the `show` surface follows.

Four defects, all of which had to be fixed *before* a renderer was possible.

## 1. The accessor returned an unexported type

`HelperCrashState()` returned `helperCrashState`. An out-of-package caller — which is what any status surface is — could hold the value but not **name** it, so it could not declare a variable, a struct field, or a parameter for it. Now `HelperCrashRecord`, named `...Record` so it doesn't collide with the accessor.

## 2. Exit code and signal were one prose string

`Detail` folded them: `"exit status 101"` / `"killed by signal killed"`. Those have **no common grammar**, so a renderer cannot take them apart again. Now separate fields, with `Signal` as the discriminator — exactly one of `ExitCode >= 0` and `Signal != ""` is meaningful. `Detail` is kept for display.

## 3. `Crashed` meant two things that diverge

It was read as both *"the last exit was unexpected"* and *"a restart is coming"*. An intentional stop advances `procGen`, orphaning the armed timer **without clearing the record** — deliberately, because `ensureProcessLocked` calls the same `stopLocked` when a spawn misses readiness and the retry path depends on the flag as its debt. So the record reported a pending restart with a `NextRestart` **in the past and no timer behind it**.

The flag is now `LastExitWasCrash` — what it always recorded — and **`RestartPending` is derived** in the accessor from the live generation, using the same fence `restartHelperAfterCrash` applies. A stored flag is precisely what went stale, which is why the second fact is computed rather than written down.

## 4. `CrashLooping` — a decision, and the issue said so

**Backoff at the cap, not a restart count.** A count is time-blind: twenty restarts over a week and twenty in a minute are different situations a counter cannot distinguish. The backoff already encodes time — it doubles from `helperRestartBackoffBase` and saturates at `helperRestartBackoffMax` — so reaching the cap means the supervisor has exhausted its escalation and is retrying at its slowest rate. With the shipped 1s base and 60s cap that is ~2 minutes of uninterrupted failure, and it does **not** fire for a helper that crashed once an hour ago.

Derived, never stored, for the same reason `RestartPending` is.

## Tests — each with the control that makes it mean something

- `RestartPending` is asserted **true before** the generation advances, so the after-assertion isn't passing on a record that never reported pending in the first place.
- `CrashLooping` is asserted **false for a recovered helper with a high restart count**, so the predicate cannot latch on a box that came back.

**Mutation** — store `RestartPending` instead of deriving it: **1991 collected, 1 named FAIL** (`TestRestartPendingIsFalseAfterAnIntentionalStop7250`).

## Gate

Full Go suite: **rc=0, 69 packages, 0 FAIL**. Go-only, no cluster smoke owed — no behaviour change on any forwarding path, and the one production reader of the renamed flag (the restart fence) keeps identical semantics.

Refs #7250 — items 1–4. The `show` renderer is the remaining half.