### PR TITLE
userspace-dp: budget the worker command drain so the rings get serviced

### DIFF
--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -1035,14 +1035,20 @@ directly:
   recovery keeps the committed queue and loses nothing, a capacity drop
   discards a command, and the two have opposite remediations.
   - The expected steady-state value is **0**, and not because the queue
-    is roomy: the consumer drains the WHOLE deque in one
-    `core::mem::take` per poll, so a sustained producer cannot outrun
-    it. A rising counter therefore does not mean "busy" — it means a
-    worker has STOPPED draining. `spawn_supervised_worker` catches a
+    is roomy: what a producer has to outrun is the consumer's
+    ~1 µs/command PROCESSING rate, which no control-plane producer
+    sustains. A rising counter therefore does not mean "busy" — it means
+    a worker has STOPPED draining. `spawn_supervised_worker` catches a
     `worker_loop` panic, sets `runtime_atomics.dead = true` and lets the
     thread exit, but the worker RECORD is never removed and producers
     fan out over `records.values()` with no `dead` check, so they keep
     enqueueing into a queue nothing will drain.
+    - #6929 originally justified this as "the consumer drains the WHOLE
+      deque in one `core::mem::take` per poll". **That is no longer how
+      the drain works** — see the bounded prefix drain below — but the
+      conclusion is unchanged, because it never rested on the drain
+      granularity. The bounded drain absorbs the same commands/second
+      and simply revisits the queue ~16x more often.
   - It refuses the NEWEST rather than evicting the oldest. The queue
     carries ordered state transitions (`UpsertSynced` then
     `DeleteSynced` for one key), so dropping from the front would apply
@@ -1054,6 +1060,40 @@ directly:
     (`session_glue/tests.rs`, `newflow_contention_tests.rs`) are
     excluded on purpose; they drive the consumer and routing them
     through the cap would change what they exercise.
+- `drain_bounded_into` is how a worker consumes that queue (#7201).
+  `apply_worker_commands` takes a **bounded prefix** of at most
+  `WORKER_COMMAND_DRAIN_BUDGET` (256) commands into a worker-owned
+  recycled scratch deque, dispatches those, and leaves the remainder in
+  the shared queue for the next poll.
+  - **It is a ring-service budget, not a fairness knob.** The worker
+    does not touch its AF_XDP RX/TX rings while it dispatches commands,
+    so batch size is wall-clock time the rings go unserviced. Draining
+    a full 4096-command queue measured **3.85 ms** — a LOWER bound, at
+    `session_map_fd = -1` where the `bpf_map_update_elem` calls fail at
+    the fd check without paying the kernel-side insert. A 4096-slot RX
+    ring (`ring_entries`, `server/lifecycle.rs`) fills in ~1.97 ms at
+    25 Gbps with 1500 B frames. The burst arrives at RG activation, the
+    moment the node has just become forwarding-authoritative — hence
+    "availability defect", not "allocation nit". 256 is the slice
+    `sessions.drain_deltas(256)` already uses in the same loop, and
+    bounds the unserviced window to ~256 µs.
+  - The slice is a contiguous FRONT prefix, so FIFO and every ordering
+    group survive a split by construction. The `UpsertSynced` →
+    `DeleteSynced` transitions the queue carries are the reason a
+    quota-filling or back-taking budget would be wrong.
+  - **The backlog signal feeds `did_work`.** `WorkerCommandResults`
+    carries `commands_backlogged`, and `worker/loop_body` seeds
+    `did_work` from it. This is load-bearing, not bookkeeping:
+    `did_work` is otherwise set only by `poll_binding` (packet work), so
+    a budget WITHOUT this wiring is a regression rather than a partial
+    fix — on a promoted standby with no traffic yet, `idle_iters` passes
+    `IDLE_SPIN_ITERS` and each remaining slice waits behind a 1 ms
+    `poll(2)`, turning a bounded 3.85 ms stall into ~16 ms of drain. A
+    source-level guard pins that seed line.
+  - Replacing `core::mem::take(&mut *pending)` also ends the zero-cap
+    regrow: the take moved the producers' buffer out and left the shared
+    deque at capacity 0, so the producers reallocated it under the lock
+    on every pass.
 - `try_lock_recover` keeps WouldBlock as a skip (`None`) — only the
   Poisoned arm changes behavior.
 

--- a/userspace-dp/src/afxdp/session_glue/README.md
+++ b/userspace-dp/src/afxdp/session_glue/README.md
@@ -29,6 +29,50 @@ sees the same sessions the userspace path is processing.
   so the eBPF data-display surface mirrors the live userspace
   session table.
 
+## Command ingest is budgeted (`apply_worker_commands`, #7201)
+
+`apply_worker_commands` is the worker's consumer for its
+`Arc<Mutex<VecDeque<WorkerCommand>>>` queue. It does **not** drain the
+whole queue.
+
+Each pass takes a contiguous FRONT prefix of at most
+`worker_queue::WORKER_COMMAND_DRAIN_BUDGET` (256) commands into a
+caller-owned scratch deque (`drain_bounded_into`), dispatches exactly
+those, and returns `WorkerCommandResults.commands_backlogged` if the
+shared queue still holds more.
+
+Why, and what a change here must not break:
+
+- **Every command is a session-table mutation plus a BPF-map publish
+  syscall, and the worker does not touch its AF_XDP rings until the
+  dispatch loop ends.** Batch size is therefore unserviced ring time.
+  Draining the full #6929 queue cap of 4096 measured 3.85 ms against an
+  RX ring that fills in ~1.97 ms at 25 Gbps — and the burst arrives at
+  RG activation. Before #7201 this was `core::mem::take` of the whole
+  deque and one uninterrupted `for` loop.
+- **The prefix is contiguous and taken from the front,** so FIFO and the
+  ordering groups survive a split by construction. The queue carries
+  ordered state transitions (`UpsertSynced` then `DeleteSynced` for one
+  key); a budget that filled its quota by skipping, or took from the
+  back, would invert a key's state.
+  `apply_worker_commands_dispatch_order_pin_with_demote_dedup` pins the
+  order within one batch;
+  `apply_worker_commands_7201_preserves_dispatch_order_across_a_budget_split`
+  pins it across the seam.
+- **`commands_backlogged` must reach `did_work` in
+  `worker/loop_body`.** It is not a statistic. `did_work` is otherwise
+  set only by `poll_binding`, so dropping this makes the budget worse
+  than the defect: a promoted standby with no traffic yet runs
+  `idle_iters` past `IDLE_SPIN_ITERS` and puts every remaining slice
+  behind a 1 ms `poll(2)` in Interrupt mode.
+- **The scratch deque is worker-owned and recycled** — entered empty,
+  left empty. It is what removed the zero-capacity regrow: `mem::take`
+  handed the worker the producers' allocation and left the shared deque
+  at capacity 0 for the producers to rebuild under the lock every pass.
+- Export acks stay monotonic across a split: `worker/loop_body` stores
+  `exported_sequences.iter().max()` per pass, and FIFO makes each pass's
+  max strictly greater than the last.
+
 ## Terminal-filtered session teardown (`delete_terminal_filtered_session`, #5622)
 
 When an *established* LocalDelivery session re-evaluates a terminal gate

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -282,6 +282,36 @@ pub(super) struct WorkerCommandResults {
     /// no `BindingWorker` access — the outer poll loop in `worker.rs`
     /// dispatches based on this flag.
     pub vacate_all_shared_exact_slots: bool,
+    /// #7201: the shared queue still held commands after this call's
+    /// [`WORKER_COMMAND_DRAIN_BUDGET`] slice was taken.
+    ///
+    /// The worker loop MUST fold this into `did_work`. It is not a statistic:
+    /// `did_work` is set only by `poll_binding`, so without this the loop
+    /// classifies a budget-split drain as IDLE, and on a node with no traffic
+    /// yet — the standby that has just been promoted, which is exactly when the
+    /// RG-activation burst arrives — `idle_iters` passes `IDLE_SPIN_ITERS` and
+    /// every remaining slice waits behind a 1 ms `poll(2)` in Interrupt mode.
+    /// The budget would then have replaced a bounded 3.85 ms stall with ~16 ms
+    /// of drain.
+    pub commands_backlogged: bool,
+}
+
+impl WorkerCommandResults {
+    /// The no-work result: nothing dispatched, nothing left behind.
+    ///
+    /// `commands_backlogged: false` is load-bearing, not a filler default — it
+    /// is what keeps an empty or lock-contended pass out of `did_work`.
+    pub(super) fn empty() -> Self {
+        WorkerCommandResults {
+            cancelled_keys: Vec::new(),
+            deleted_synced_keys: Vec::new(),
+            exported_sequences: Vec::new(),
+            export_owner_rgs: Vec::new(),
+            shaped_tx_requests: Vec::new(),
+            vacate_all_shared_exact_slots: false,
+            commands_backlogged: false,
+        }
+    }
 }
 
 fn force_live_redirect_for_worker_synced_entry(
@@ -687,6 +717,12 @@ pub(super) fn apply_worker_commands(
     // in the worker loop. A peer-synced reservation is held by every worker, so
     // a release must drop THIS worker's bit rather than free the port outright.
     worker_id: u32,
+    // #7201: worker-owned, recycled across calls. The drain moves its bounded
+    // slice in here instead of `mem::take`-ing the shared deque, so the shared
+    // deque keeps its allocation (the producers hold the lock; they were paying
+    // to regrow it from zero capacity on every pass) and this buffer keeps its
+    // own. Entered empty and left empty — the dispatch loop below drains it.
+    scratch: &mut VecDeque<WorkerCommand>,
 ) -> WorkerCommandResults {
     // Hot path: try_lock avoids blocking on the mutex when another thread
     // holds it (rare) and avoids the cost of lock+unlock on empty queues
@@ -695,29 +731,26 @@ pub(super) fn apply_worker_commands(
     // policy, worker_queue.rs) and the recovered deque is processed as
     // normal — treating poison as absence-of-work made the worker
     // permanently deaf to coordinator commands.
-    let pending = match worker_queue::try_lock_recover(commands) {
+    //
+    // #7201: this takes a BOUNDED PREFIX, not the whole deque. Every command is
+    // a session-table mutation plus a BPF-map publish syscall, and the worker
+    // does not touch its AF_XDP rings until the loop below finishes — so an
+    // unbounded drain is unserviced ring time. See
+    // `worker_queue::WORKER_COMMAND_DRAIN_BUDGET` for the measurement and the
+    // ring arithmetic that fix the slice size.
+    let commands_backlogged = match worker_queue::try_lock_recover(commands) {
         Some(mut pending) => {
             if pending.is_empty() {
-                return WorkerCommandResults {
-                    cancelled_keys: Vec::new(),
-                    deleted_synced_keys: Vec::new(),
-                    exported_sequences: Vec::new(),
-                    export_owner_rgs: Vec::new(),
-                    shaped_tx_requests: Vec::new(),
-                    vacate_all_shared_exact_slots: false,
-                };
+                return WorkerCommandResults::empty();
             }
-            core::mem::take(&mut *pending)
+            worker_queue::drain_bounded_into(&mut pending, scratch)
         }
         None => {
-            return WorkerCommandResults {
-                cancelled_keys: Vec::new(),
-                deleted_synced_keys: Vec::new(),
-                exported_sequences: Vec::new(),
-                export_owner_rgs: Vec::new(),
-                shaped_tx_requests: Vec::new(),
-                vacate_all_shared_exact_slots: false,
-            };
+            // Could not take the lock this pass. The queue is not known to be
+            // empty — a producer holds it — but reporting a backlog here would
+            // pin the loop to `did_work` on nothing more than lock contention,
+            // so leave it to the next pass, which is one poll away.
+            return WorkerCommandResults::empty();
         }
     };
     // Sample monotonic time ONCE per tick so every handler sees the same
@@ -742,7 +775,7 @@ pub(super) fn apply_worker_commands(
     let mut export_owner_rgs: Vec<i32> = Vec::new();
     let mut shaped_tx_requests = Vec::new();
     let mut vacate_all_shared_exact_slots = false;
-    for cmd in pending {
+    for cmd in scratch.drain(..) {
         match cmd {
             WorkerCommand::DemoteOwnerRGS { owner_rgs } => {
                 commands::handle_demote_owner_rgs(
@@ -881,6 +914,7 @@ pub(super) fn apply_worker_commands(
         export_owner_rgs,
         shaped_tx_requests,
         vacate_all_shared_exact_slots,
+        commands_backlogged,
     }
 }
 

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -6,6 +6,21 @@
 // session_glue/mod.rs.
 
 use super::*;
+use crate::afxdp::worker_queue::WORKER_COMMAND_DRAIN_BUDGET;
+
+// #7201: `apply_worker_commands` now drains a BOUNDED PREFIX
+// (`WORKER_COMMAND_DRAIN_BUDGET` = 256) into a caller-owned scratch deque
+// instead of `core::mem::take`-ing the whole queue, so the worker returns to its
+// AF_XDP rings between slices.
+//
+// Every call below passes a FRESH `&mut VecDeque::new()`, i.e. exactly one
+// bounded pass. That is deliberate and it is not a weakening: no fixture in this
+// file queues anywhere near 256 commands (all 20 command pushes are flat — none
+// sits inside a loop), so one pass drains each batch completely and every cell
+// asserts precisely what it asserted before the budget existed. The budget's own
+// behaviour — the split, the FIFO/order preservation across a split, the
+// backlog signal, the scratch recycling — is covered by the dedicated cells at
+// the end of this file, which queue PAST the budget on purpose.
 use crate::filter::Filter;
 use crate::test_zone_ids::*;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -1843,6 +1858,7 @@ fn apply_worker_commands_replaces_stale_local_session_for_inactive_owner_rg() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     let hit = sessions.lookup(&key, 2_000_000, 0x10).expect("synced hit");
@@ -1910,6 +1926,7 @@ fn apply_worker_commands_preserves_local_session_for_active_owner_rg() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     let hit = sessions.lookup(&key, 2_000_000, 0x10).expect("live hit");
@@ -1968,6 +1985,7 @@ fn apply_worker_commands_demotes_local_owner_rg_sessions_to_sync_import() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     let Some((_decision, _metadata, origin)) = sessions.entry_with_origin(&key) else {
@@ -2009,6 +2027,7 @@ fn demoted_local_session_promotes_as_synced_on_failback_lookup() {
         &inactive_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -2297,6 +2316,7 @@ fn export_owner_rg_command_does_not_overflow_ring_unbounded() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     // (a) the command recorded the owner RG and sequence.
@@ -2398,6 +2418,7 @@ fn apply_worker_commands_exports_owner_rg_forward_sessions_without_teardown() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -2471,6 +2492,7 @@ fn apply_worker_commands_does_not_export_missing_neighbor_seed_sessions() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -2521,6 +2543,7 @@ fn apply_worker_commands_demote_owner_rg_returns_cancelled_keys() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     assert_eq!(results.exported_sequences, Vec::<u64>::new());
@@ -2762,6 +2785,7 @@ fn apply_worker_commands_demotes_local_owner_rg_sessions_and_cancels_keys() {
         &BTreeMap::new(),
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert_eq!(results.cancelled_keys, vec![key.clone()]);
@@ -2803,6 +2827,7 @@ fn apply_worker_commands_demote_owner_rg_rewrites_resolution_to_fabric_redirect(
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert_eq!(results.cancelled_keys, vec![key.clone()]);
@@ -2881,6 +2906,7 @@ fn apply_worker_commands_demote_split_reverse_owner_rg_rewrites_to_fabric_redire
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert_eq!(results.cancelled_keys, vec![reverse_key.clone()]);
@@ -2961,6 +2987,7 @@ fn apply_worker_commands_refresh_split_reverse_owner_rg_rewrites_to_forward_cand
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -3049,6 +3076,7 @@ fn apply_worker_commands_refresh_split_reverse_owner_rg_updates_stale_indexed_se
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -3137,6 +3165,7 @@ fn apply_worker_commands_refresh_owner_rg_updates_reverse_session_owned_by_other
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -3225,6 +3254,7 @@ fn apply_worker_commands_refresh_owner_rg_rewrites_remote_reverse_session_on_pee
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -3308,6 +3338,7 @@ fn apply_worker_commands_refresh_owner_rg_rewrites_shared_promote_reverse_on_pee
         &ha_state,
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert!(results.cancelled_keys.is_empty());
@@ -3360,6 +3391,7 @@ fn export_owner_rg_sessions_skips_locally_demoted_entries() {
         &BTreeMap::new(),
         &Arc::new(ShardedNeighborMap::new()),
         0,
+        &mut VecDeque::new(),
     );
 
     assert_eq!(results.exported_sequences, vec![11]);
@@ -4621,6 +4653,7 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     // ── (a) Exports preserved ───────────────────────────────────────────────
@@ -4779,6 +4812,7 @@ fn apply_worker_commands_demote_dedup_is_linear_not_quadratic() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
     let elapsed = start.elapsed();
 
@@ -4865,6 +4899,7 @@ fn apply_worker_commands_recovers_poisoned_queue_and_processes_commands() {
         &ha_state,
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     );
 
     // The queued command was processed (NOT the empty "deaf" result the
@@ -5356,6 +5391,7 @@ fn apply_upsert_local_pair(
         &BTreeMap::new(),
         &dynamic_neighbors,
         0,
+        &mut VecDeque::new(),
     )
 }
 
@@ -7729,4 +7765,204 @@ fn the_main_path_passes_a_resolved_arrival_zone_7169() {
         "the only exemption on the installing path is fabric ingress, and it \
          must be gated on it — an unconditional Unconstrained reopens #7169"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #7201: `apply_worker_commands` consults the drain budget.
+// ---------------------------------------------------------------------------
+//
+// The cells in `worker_queue_tests.rs` exercise `drain_bounded_into` DIRECTLY,
+// so all of them stay green if this function is reverted to
+// `core::mem::take(&mut *pending)` — they assert a property of the helper, not
+// of the ingest path. These cells drive the ingest path and are the ones that
+// red on that revert.
+
+/// Queue `n` distinct `ExportOwnerRGSessions` commands, sequences `0..n`.
+///
+/// `ExportOwnerRGSessions` is the probe because `exported_sequences` records one
+/// entry per command IN DISPATCH ORDER, so a batch of them makes the loop's
+/// traversal order directly observable — which is what acceptance criterion 2
+/// needs, and what a `cancelled_keys` set (deduped) or a bool flag could not
+/// show.
+fn queue_exports(commands: &Arc<Mutex<VecDeque<WorkerCommand>>>, n: usize) {
+    let mut pending = commands.lock().expect("commands lock");
+    for sequence in 0..n as u64 {
+        pending.push_back(WorkerCommand::ExportOwnerRGSessions {
+            sequence,
+            owner_rgs: vec![1],
+        });
+    }
+}
+
+fn apply_once(
+    commands: &Arc<Mutex<VecDeque<WorkerCommand>>>,
+    sessions: &mut SessionTable,
+    scratch: &mut VecDeque<WorkerCommand>,
+) -> WorkerCommandResults {
+    apply_worker_commands(
+        commands,
+        sessions,
+        -1,
+        -1,
+        -1,
+        &ForwardingState::default(),
+        &BTreeMap::new(),
+        &Arc::new(ShardedNeighborMap::default()),
+        0,
+        scratch,
+    )
+}
+
+#[test]
+fn apply_worker_commands_7201_stops_at_the_budget_and_leaves_the_rest_queued() {
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    let mut sessions = SessionTable::new();
+    let mut scratch = VecDeque::new();
+    let over = WORKER_COMMAND_DRAIN_BUDGET + 44;
+    queue_exports(&commands, over);
+
+    let results = apply_once(&commands, &mut sessions, &mut scratch);
+
+    assert_eq!(
+        results.exported_sequences.len(),
+        WORKER_COMMAND_DRAIN_BUDGET,
+        "one call dispatched {} commands, not the {WORKER_COMMAND_DRAIN_BUDGET}-command \
+         budget. Each command is a session-table mutation plus a BPF-map publish and \
+         the worker does not touch its AF_XDP rings until the loop ends, so an \
+         unbounded drain is unserviced ring time at RG activation (#7201).",
+        results.exported_sequences.len()
+    );
+    assert_eq!(
+        commands.lock().expect("lock").len(),
+        44,
+        "the undispatched remainder must stay in the shared queue"
+    );
+    assert!(
+        results.commands_backlogged,
+        "a split batch reported no backlog, so the worker loop may go idle with \
+         an RG-activation burst still queued"
+    );
+    assert!(
+        scratch.is_empty(),
+        "the scratch buffer must be returned EMPTY — the caller reuses it across \
+         every pass, so a leftover command would be re-dispatched next call"
+    );
+}
+
+#[test]
+fn apply_worker_commands_7201_preserves_dispatch_order_across_a_budget_split() {
+    // Acceptance criterion 2. A budget that capped the count but took from the
+    // back, or filled its quota by skipping, would satisfy the cell above and
+    // still invert the UpsertSynced-then-DeleteSynced transitions the queue
+    // carries for one key.
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    let mut sessions = SessionTable::new();
+    let mut scratch = VecDeque::new();
+    // Three passes, and a final partial one, so the assertion covers a boundary
+    // that is not merely the first split.
+    let total = WORKER_COMMAND_DRAIN_BUDGET * 3 + 7;
+    queue_exports(&commands, total);
+
+    let mut observed: Vec<u64> = Vec::with_capacity(total);
+    let mut per_pass_max: Vec<u64> = Vec::new();
+    let mut passes = 0;
+    loop {
+        let results = apply_once(&commands, &mut sessions, &mut scratch);
+        passes += 1;
+        if let Some(max) = results.exported_sequences.iter().copied().max() {
+            per_pass_max.push(max);
+        }
+        observed.extend(results.exported_sequences.iter().copied());
+        if !results.commands_backlogged {
+            break;
+        }
+        assert!(passes < 16, "drain did not terminate");
+    }
+
+    assert_eq!(
+        passes, 4,
+        "expected the batch to split across 4 passes at a {WORKER_COMMAND_DRAIN_BUDGET} \
+         budget; a different count means the budget is not the thing bounding the drain"
+    );
+    assert_eq!(
+        observed,
+        (0..total as u64).collect::<Vec<_>>(),
+        "dispatch order was not preserved across the budget split. FIFO and the \
+         ordering groups must survive a split; the pin in \
+         `apply_worker_commands_dispatch_order_pin_with_demote_dedup` covers one \
+         batch, this covers the seam between batches."
+    );
+
+    // Export-ack semantics. `worker/loop_body` stores
+    // `exported_sequences.iter().max()` into `session_export_ack` once per pass,
+    // so a split is only safe if each pass's max is strictly greater than the
+    // last — otherwise the ack the HA peer reads goes BACKWARDS mid-burst.
+    assert_eq!(per_pass_max.len(), passes);
+    assert!(
+        per_pass_max.windows(2).all(|w| w[0] < w[1]),
+        "per-pass export-ack maxima are not strictly increasing ({per_pass_max:?}); \
+         `session_export_ack` is a plain store, so a non-monotonic split would \
+         retract an ack the peer already observed"
+    );
+}
+
+#[test]
+fn apply_worker_commands_7201_does_not_zero_the_shared_queue_capacity() {
+    // Acceptance criterion 3, driven through the ingest path rather than the
+    // helper: the old `core::mem::take(&mut *pending)` moved the producers'
+    // buffer out and left the shared deque at capacity zero, so the producers
+    // regrew it from nothing while holding the lock.
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    let mut sessions = SessionTable::new();
+    let mut scratch = VecDeque::new();
+    // Under the budget: the queue ends EMPTY either way, so capacity is the only
+    // thing that distinguishes a prefix drain from `mem::take`.
+    queue_exports(&commands, 8);
+    let grown = commands.lock().expect("lock").capacity();
+    assert!(grown >= 8, "precondition: the queue actually allocated");
+
+    let results = apply_once(&commands, &mut sessions, &mut scratch);
+    assert_eq!(results.exported_sequences.len(), 8);
+    assert!(!results.commands_backlogged);
+
+    let queue = commands.lock().expect("lock");
+    assert!(queue.is_empty());
+    assert!(
+        queue.capacity() >= grown,
+        "the shared queue came back at capacity {} (was {grown}) — `mem::take` \
+         leaves it at zero and the producers pay to regrow it under the lock on \
+         every pass",
+        queue.capacity()
+    );
+}
+
+#[test]
+fn apply_worker_commands_7201_empty_and_contended_passes_report_no_backlog() {
+    // The backlog flag drives `did_work`, so a spurious `true` pins a worker to
+    // a hot loop on a core it should have yielded.
+    let commands: Arc<Mutex<VecDeque<WorkerCommand>>> = Arc::new(Mutex::new(VecDeque::new()));
+    let mut sessions = SessionTable::new();
+    let mut scratch = VecDeque::new();
+
+    let results = apply_once(&commands, &mut sessions, &mut scratch);
+    assert!(
+        !results.commands_backlogged,
+        "an empty queue reported a backlog"
+    );
+
+    // Lock held elsewhere: the drain cannot run, and must NOT claim work.
+    queue_exports(&commands, WORKER_COMMAND_DRAIN_BUDGET + 1);
+    let held = commands.lock().expect("hold the lock");
+    let results = apply_once(&commands, &mut sessions, &mut scratch);
+    assert!(
+        results.exported_sequences.is_empty(),
+        "a contended pass dispatched commands"
+    );
+    assert!(
+        !results.commands_backlogged,
+        "a pass that could not take the lock claimed a backlog — the queue is \
+         genuinely non-empty here, but reporting it would pin `did_work` on lock \
+         contention alone, and the next poll is one iteration away"
+    );
+    drop(held);
 }

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -299,6 +299,15 @@ pub(crate) fn worker_loop(
     // prevent.
     let mut idle_poll_degraded = false;
     let mut poll_start = 0usize;
+    // #7201: the recycled landing buffer for `apply_worker_commands`'s bounded
+    // prefix drain. Owned here, outside the loop, because the point is that it
+    // is REUSED: the drain it replaces did `core::mem::take(&mut *pending)`,
+    // which handed the worker the producers' allocation and left the SHARED
+    // deque at zero capacity for the producers to regrow under the lock on every
+    // pass. Sized to the budget once; entered and left empty each call, so it
+    // settles at that capacity and never reallocates.
+    let mut command_scratch: VecDeque<WorkerCommand> =
+        VecDeque::with_capacity(crate::afxdp::worker_queue::WORKER_COMMAND_DRAIN_BUDGET);
     let mut shared_recycles = Vec::with_capacity((RX_BATCH_SIZE as usize).saturating_mul(2));
     // #5468: per-drain-cycle aggregate lossless-wedge latch. `flush_session_deltas`
     // bounds each individual lossless send to `WORKER_LOSSLESS_QUEUE_BUDGET`, but
@@ -849,16 +858,10 @@ pub(crate) fn worker_loop(
                 ha_runtime.as_ref(),
                 &dynamic_neighbors,
                 worker_id,
+                &mut command_scratch,
             )
         } else {
-            WorkerCommandResults {
-                cancelled_keys: Vec::new(),
-                deleted_synced_keys: Vec::new(),
-                exported_sequences: Vec::new(),
-                export_owner_rgs: Vec::new(),
-                shaped_tx_requests: Vec::new(),
-                vacate_all_shared_exact_slots: false,
-            }
+            WorkerCommandResults::empty()
         };
         let WorkerCommandResults {
             cancelled_keys,
@@ -867,6 +870,7 @@ pub(crate) fn worker_loop(
             export_owner_rgs,
             shaped_tx_requests,
             vacate_all_shared_exact_slots,
+            commands_backlogged,
         } = command_results;
         // #941 Work item C: HA-demotion vacate. The
         // VacateAllSharedExactSlots WorkerCommand cannot be processed
@@ -1051,7 +1055,16 @@ pub(crate) fn worker_loop(
                 forwarding = Arc::new(updated);
             }
         }
-        let mut did_work = false;
+        // #7201: a command backlog IS work. `apply_worker_commands` drains at
+        // most `WORKER_COMMAND_DRAIN_BUDGET` per pass so the AF_XDP rings get
+        // serviced between slices; the remainder is only reachable if this loop
+        // comes straight back. Left out of `did_work` — which `poll_binding`
+        // alone would set — a promoted standby with no traffic yet runs
+        // `idle_iters` past `IDLE_SPIN_ITERS` and puts every remaining slice
+        // behind a 1 ms `poll(2)`, so the budget would trade a bounded 3.85 ms
+        // stall for ~16 ms of drain. Seeded here rather than OR-ed after the
+        // sweep so there is one assignment to reason about.
+        let mut did_work = commands_backlogged;
         let mut dbg_poll = DebugPollCounters::default();
         // #1620: read the cold-path sample mask from forwarding state once
         // per poll cycle (rather than per-binding) — it's a daemon-wide

--- a/userspace-dp/src/afxdp/worker_queue.rs
+++ b/userspace-dp/src/afxdp/worker_queue.rs
@@ -35,10 +35,24 @@ pub(in crate::afxdp) static WORKER_COMMAND_QUEUE_POISON_RECOVERIES: AtomicU64 = 
 
 /// #6929: the per-worker command-queue capacity.
 ///
-/// WHY A CAP IS NEEDED AT ALL, since the consumer cannot be outrun. The worker
-/// drain takes the WHOLE deque in one `core::mem::take` (`session_glue::mod.rs`),
-/// so no sustained producer can outpace it — every poll empties the queue. The
-/// unbounded case is not a rate mismatch, it is a consumer that has STOPPED:
+/// WHY A CAP IS NEEDED AT ALL. #6929 justified this cap by observing that the
+/// consumer could not be outrun: the drain took the WHOLE deque in one
+/// `core::mem::take`, so every poll emptied the queue however fast the producer
+/// ran. **That is no longer how the drain works** — #7201 replaced the
+/// take-everything drain with a bounded prefix drain
+/// ([`drain_bounded_into`]), so a poll now removes at most
+/// [`WORKER_COMMAND_DRAIN_BUDGET`] commands and a backlog can persist across
+/// polls.
+///
+/// The cap's justification survives that change, because it never rested on the
+/// drain granularity. What governs whether the cap is reached is the consumer's
+/// PROCESSING rate (~1 µs/command, measured in #7201), not how many commands one
+/// `mem::take` moved: a producer faster than ~1 command/µs reaches the cap under
+/// either drain, and a slower one reaches it under neither. The bounded drain
+/// revisits the queue ~16x more often for the same absorbed throughput.
+///
+/// The unbounded case was never a rate mismatch anyway — it is a consumer that
+/// has STOPPED:
 ///
 ///   - `spawn_supervised_worker` catches a `worker_loop` panic, sets
 ///     `runtime_atomics.dead = true` and lets the thread exit;
@@ -91,6 +105,60 @@ pub(in crate::afxdp) fn push_bounded(
     }
     pending.push_back(cmd);
     true
+}
+
+/// #7201: the most commands one `apply_worker_commands` call may process before
+/// returning to the worker loop.
+///
+/// THIS IS A RING-SERVICE BUDGET, NOT A FAIRNESS KNOB. The worker does not touch
+/// its AF_XDP RX/TX rings while it is applying commands, so the batch size is
+/// wall-clock time the rings go unserviced. `ring_entries` defaults to 4096
+/// (`server/lifecycle.rs`), and at 25 Gbps with 1500 B frames (~2.08 Mpps) a
+/// 4096-slot RX ring fills in ~1.97 ms. A drain of the full
+/// [`MAX_PENDING_WORKER_COMMANDS`] measured 3.85 ms — already past that, and a
+/// LOWER bound, since the measurement ran with `session_map_fd = -1` so the
+/// `bpf_map_update_elem` calls failed at the fd check without paying the
+/// kernel-side hash insert (a forward `publish_live_session_entry` issues up to
+/// four real map updates). That burst arrives at RG activation, the moment the
+/// node has just become forwarding-authoritative.
+///
+/// 256 is the same slice `sessions.drain_deltas(256)` already takes in this
+/// loop, so the worker keeps one batch granularity rather than two. At the
+/// measured ~1 µs/command it bounds the unserviced window to ~256 µs — an order
+/// of magnitude under the ring's fill time, with margin for the real map
+/// syscalls the measurement could not pay.
+pub(in crate::afxdp) const WORKER_COMMAND_DRAIN_BUDGET: usize = 256;
+
+/// Move at most [`WORKER_COMMAND_DRAIN_BUDGET`] commands from the front of
+/// `pending` into `scratch`, returning whether `pending` still holds a backlog.
+///
+/// PREFIX, NOT FILTER. The slice is contiguous and taken from the FRONT, so FIFO
+/// and every ordering group inside the batch survive by construction — there is
+/// no ordering rule for a split to violate that a whole-batch drain would have
+/// honoured. A budget that skipped or reordered commands to fill a quota is what
+/// would break `apply_worker_commands_dispatch_order_pin_with_demote_dedup`.
+///
+/// `scratch` is worker-owned and recycled across calls; it is drained by the
+/// caller, so it keeps its allocation. This is what replaces the
+/// `core::mem::take(&mut *pending)` the drain used to do — that left the SHARED
+/// deque at zero capacity on every pass, forcing the producers (which hold the
+/// lock) to reallocate it from scratch each time.
+///
+/// The caller MUST treat a `true` return as work for the worker loop's idle
+/// regulation. `did_work` in `worker/loop_body` is set only by `poll_binding`,
+/// so a backlog left behind by this budget is invisible to it; on a node with no
+/// traffic yet — the standby that has just been told to take over — `idle_iters`
+/// passes `IDLE_SPIN_ITERS` and each remaining slice lands behind a 1 ms
+/// `poll(2)` in Interrupt mode. That would convert a bounded 3.85 ms stall into
+/// ~16 ms of drain, which is worse than the defect this budget exists to fix.
+#[inline]
+pub(in crate::afxdp) fn drain_bounded_into(
+    pending: &mut VecDeque<WorkerCommand>,
+    scratch: &mut VecDeque<WorkerCommand>,
+) -> bool {
+    let take = pending.len().min(WORKER_COMMAND_DRAIN_BUDGET);
+    scratch.extend(pending.drain(..take));
+    !pending.is_empty()
 }
 
 /// Lock a worker-command queue, recovering and CLEARING poison.

--- a/userspace-dp/src/afxdp/worker_queue_tests.rs
+++ b/userspace-dp/src/afxdp/worker_queue_tests.rs
@@ -535,3 +535,168 @@ fn worker_queue_6929_the_wiring_scan_can_actually_see_a_bare_push_back() {
         hits[0]
     );
 }
+
+// ---------------------------------------------------------------------------
+// #7201: the bounded prefix drain.
+// ---------------------------------------------------------------------------
+//
+// The defect: `apply_worker_commands` took the WHOLE deque in one
+// `core::mem::take` and dispatched every command in one uninterrupted loop,
+// never touching its AF_XDP rings until the batch was done. Measured at the
+// #6929 cap of 4096 commands that is 3.85 ms of unserviced rings — a LOWER
+// bound (the measurement ran at `session_map_fd = -1`, so the map syscalls
+// failed at the fd check without paying the kernel-side insert) — against a
+// 4096-slot RX ring that fills in ~1.97 ms at 25 Gbps with 1500 B frames. The
+// burst arrives at RG activation, when the node has just become
+// forwarding-authoritative.
+//
+// A survives-assertion is a FLOOR here just as it was for #6929: draining N
+// commands and checking they all arrive passes identically with NO budget. Every
+// cell below therefore queues PAST the budget and asserts what is left behind.
+
+/// The budget must be a strict fraction of the queue capacity.
+///
+/// Compile-time, because the failure it prevents is silent: at
+/// `WORKER_COMMAND_DRAIN_BUDGET >= MAX_PENDING_WORKER_COMMANDS` the drain can
+/// never leave a remainder, so every behavioural cell below still passes while
+/// the budget has quietly become the take-everything drain it replaced.
+const _: () = assert!(WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS);
+
+#[test]
+fn worker_queue_7201_drain_takes_the_budget_and_reports_the_remainder() {
+    let mut q: VecDeque<WorkerCommand> = VecDeque::new();
+    let mut scratch: VecDeque<WorkerCommand> = VecDeque::new();
+    let over = WORKER_COMMAND_DRAIN_BUDGET + 44;
+    for i in 0..over {
+        assert!(push_bounded(&mut q, export_command(i as u64)));
+    }
+
+    let backlogged = drain_bounded_into(&mut q, &mut scratch);
+    assert_eq!(
+        scratch.len(),
+        WORKER_COMMAND_DRAIN_BUDGET,
+        "the drain took {} commands instead of the {WORKER_COMMAND_DRAIN_BUDGET}-command \
+         budget — an unbounded drain holds the AF_XDP rings for the whole batch",
+        scratch.len()
+    );
+    assert_eq!(
+        q.len(),
+        44,
+        "the remainder must stay in the SHARED queue for the next pass"
+    );
+    assert!(
+        backlogged,
+        "a drain that left 44 commands behind reported no backlog — the worker \
+         loop reads this to decide whether it may go idle, so a false here parks \
+         the rest of an RG-activation burst behind a 1 ms poll(2) each"
+    );
+
+    // FIFO, and a contiguous PREFIX: not merely 256 of the 300.
+    let taken: Vec<u64> = scratch.iter().map(export_sequence).collect();
+    assert_eq!(
+        taken,
+        (0..WORKER_COMMAND_DRAIN_BUDGET as u64).collect::<Vec<_>>(),
+        "the budget must take the FRONT slice in order; reordering or skipping \
+         breaks the UpsertSynced-then-DeleteSynced transitions the queue carries"
+    );
+    let left: Vec<u64> = q.iter().map(export_sequence).collect();
+    assert_eq!(
+        left,
+        (WORKER_COMMAND_DRAIN_BUDGET as u64..over as u64).collect::<Vec<_>>(),
+        "the remainder must be the untouched suffix, still in order"
+    );
+
+    // Second pass finishes it and clears the backlog signal.
+    scratch.clear();
+    let backlogged = drain_bounded_into(&mut q, &mut scratch);
+    assert_eq!(scratch.len(), 44);
+    assert!(
+        !backlogged,
+        "an emptied queue still reported a backlog — the worker would never go \
+         idle, spinning a pinned core forever"
+    );
+}
+
+#[test]
+fn worker_queue_7201_drain_leaves_the_shared_queue_its_allocation() {
+    // The allocation half of the finding. `core::mem::take(&mut *pending)`
+    // handed the worker the producers' buffer and left the SHARED deque at
+    // capacity zero, so the producers — which hold the lock — reallocated it
+    // from nothing on every single pass.
+    let mut q: VecDeque<WorkerCommand> = VecDeque::new();
+    let mut scratch: VecDeque<WorkerCommand> = VecDeque::new();
+    for i in 0..WORKER_COMMAND_DRAIN_BUDGET {
+        push_bounded(&mut q, export_command(i as u64));
+    }
+    let grown = q.capacity();
+    assert!(grown >= WORKER_COMMAND_DRAIN_BUDGET);
+
+    drain_bounded_into(&mut q, &mut scratch);
+    assert!(
+        q.is_empty(),
+        "precondition: this cell drains the queue completely, so the capacity \
+         it then checks is a RETAINED allocation and not merely an unread tail"
+    );
+    assert!(
+        q.capacity() >= grown,
+        "the drain shrank the shared queue from {grown} to {} — `mem::take` \
+         zeroes it, which is exactly the regrow this replaces",
+        q.capacity()
+    );
+}
+
+#[test]
+fn worker_queue_7201_did_work_consumes_the_backlog_signal() {
+    // `commands_backlogged` is only worth returning if the worker loop acts on
+    // it, and the consumer is a local `did_work` inside a 1500-line function —
+    // no unit fixture can reach it, so the wiring is bound as a source-level
+    // agreement (the #6929 pattern).
+    //
+    // WHY THIS MATTERS MORE THAN IT LOOKS. `did_work` is set ONLY by
+    // `poll_binding`, i.e. by packet work. Command work does not set it. So a
+    // budget WITHOUT this wiring is a REGRESSION, not a partial fix: on a node
+    // with no traffic yet — the standby that has just been promoted, which is
+    // precisely when the RG-activation burst arrives — `idle_iters` runs past
+    // `IDLE_SPIN_ITERS` and every remaining slice waits behind a 1 ms `poll(2)`
+    // in Interrupt mode, turning a bounded 3.85 ms stall into ~16 ms of drain.
+    let path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/afxdp/worker/loop_body/mod.rs");
+    let src = std::fs::read_to_string(&path).expect("read worker loop_body");
+    // Comments blanked so this cannot be satisfied by the prose above the line
+    // it is looking for — that comment names `did_work` and `commands_backlogged`
+    // in exactly the shape being matched.
+    let code = blank_comments_and_strings(&src);
+    assert!(
+        code.contains("commands_backlogged"),
+        "precondition: the guard read a tree with no `commands_backlogged` in \
+         it at all, so its agreement check below would pass vacuously"
+    );
+
+    let seeds: Vec<&str> = code
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("let mut did_work"))
+        .collect();
+    assert_eq!(
+        seeds.len(),
+        1,
+        "expected exactly one `did_work` seed to reason about; found {seeds:?}"
+    );
+    assert_eq!(
+        seeds[0], "let mut did_work = commands_backlogged;",
+        "the worker loop no longer seeds `did_work` from the command backlog. A \
+         `let mut did_work = false;` here reverts #7201 to a pure regression: the \
+         budget still splits the batch, but the loop classifies the split passes \
+         as IDLE and parks each remaining slice behind a 1 ms poll(2)."
+    );
+
+    // The destructure must actually bind the field — a `..` rest pattern would
+    // compile, leave `commands_backlogged` unbound, and take the seed line with
+    // it, so pinning the seed alone is not enough.
+    assert!(
+        code.contains("commands_backlogged,\n        } = command_results;")
+            || code.contains("commands_backlogged,\n    } = command_results;"),
+        "`commands_backlogged` must be destructured out of WorkerCommandResults \
+         at the call site, not dropped by a `..` rest pattern"
+    );
+}


### PR DESCRIPTION
Closes #7201

## The premise moved; the defect did not

**Verified at `origin/master` before writing code, and one of #7201's two
quantitative claims is stale.**

`0c6e9aee5` (#6929, "bound the per-worker command queues and count the drops")
landed after #7201 was filed and capped every producer at
`MAX_PENDING_WORKER_COMMANDS = 4096`. I re-verified the cap rather than trusting
the commit message: across `userspace-dp/src`, the only `push_back` onto a
`WorkerCommand` deque outside test fixtures is the one *inside* `push_bounded`
itself. Both HA producers #7201 names are converted —
`activate_owner_rgs_prewarm` (`shared_ops.rs:444,481`) and
`replay_synced_sessions` → `replicate_session_upsert`
(`session_glue/mod.rs:987,1006`).

So the batch ceiling is **4096 commands, not `2 * worker_count *
DEFAULT_MAX_SESSIONS`** — two orders of magnitude below the filed figure. The
issue's first acceptance criterion ("a burst at or near the documented entry
ceiling") is a claim about pre-#6929 behaviour and is re-derived here against the
4096 that actually exists. The correction is posted on the issue.

**The defect survives at that size.** The two cited loci were intact, shifted ~5
lines: `core::mem::take(&mut *pending)` and `for cmd in pending`, no command
budget, no time budget, no yield.

Measured, not argued. Release build, `apply_worker_commands` with N
`UpsertSynced`, `session_map_fd = -1`:

| N | total | per command |
|---|---|---|
| 256 | 273.7 µs | 1.07 µs |
| 1024 | 889.2 µs | 868 ns |
| **4096** | **3.85 ms** | 940 ns |

3.85 ms is a **lower bound** — at `fd = -1` each `bpf_map_update_elem` fails at
the fd check without paying the kernel-side hash insert, and a forward
`publish_live_session_entry` issues up to four real map updates. Against it:
`ring_entries` defaults to 4096 (`server/lifecycle.rs:511`), and a 4096-slot RX
ring fills in **~1.97 ms** at 25 Gbps with 1500 B frames. The stall already
exceeds the ring, and the burst arrives at RG activation — the moment the node
has just become forwarding-authoritative.

One correction to the issue's reasoning: `chunked_drain_as_you_export!` is *not*
prior art for yielding to the rings. It chunks so `drain_and_flush_all!` can
empty the **session-delta ring** between chunks (#2653), i.e. to avoid *losing
deltas*. The conclusion transfers; the stated reason does not.

## The fix

- **Bounded front prefix.** `drain_bounded_into` moves at most
  `WORKER_COMMAND_DRAIN_BUDGET = 256` commands from the shared deque into a
  worker-owned recycled scratch; the remainder stays queued. 256 is the slice
  `sessions.drain_deltas(256)` already takes in the same loop, and bounds the
  unserviced window to ~256 µs.
- **Ordering is preserved by construction.** The slice is a contiguous FRONT
  prefix, so FIFO and the ordering groups survive a split — there is no ordering
  rule for the split to violate that a whole-batch drain honoured. This is what
  keeps the `UpsertSynced` → `DeleteSynced` transitions for one key from
  inverting.
- **The backlog signal is the load-bearing half.** `did_work` in
  `worker/loop_body` is set **only** by `poll_binding` — command work never set
  it. A budget *without* this wiring is a **regression, not a partial fix**: on a
  promoted standby with no traffic yet (exactly when the burst arrives),
  `idle_iters` passes `IDLE_SPIN_ITERS` and each remaining slice waits behind a
  1 ms `poll(2)` in Interrupt mode — trading a bounded 3.85 ms stall for ~16 ms
  of drain. `WorkerCommandResults.commands_backlogged` seeds `did_work`.
- **The zero-cap regrow is gone.** `mem::take` moved the producers' buffer out
  and left the shared deque at capacity 0 for the producers to rebuild under the
  lock every pass.
- **#6929's doc claim is corrected in place.** Its cap was justified with "the
  consumer drains the WHOLE deque in one `core::mem::take`, so no sustained
  producer can outpace it". This change falsifies that sentence. The cap's
  justification survives — what a producer must outrun is the consumer's
  ~1 µs/command *processing* rate, not the drain granularity; the bounded drain
  absorbs the same commands/second and revisits the queue ~16x more often.

Docs updated in the same change: `src/afxdp/README.md` (queue section) and
`src/afxdp/session_glue/README.md` (new "Command ingest is budgeted" section).

## Mutation matrix

Every cell runs the **full suite** (`make test-rust`, `--test-threads=1`), never
under a `-run` filter, with a per-cell `CARGO_TARGET_DIR`. Collected counts are
non-zero and named FAILs are counted from `^test .* \.\.\. FAILED`, so a build
break cannot be scored as a red. (Cells collect 4884 rather than the clean run's
4953 because `make test-rust` stops after the `--bins` target fails, skipping the
small integration binaries — expected, and well above zero.)

| # | Mutation (one line each, restoring what shipped) | collected | named reds |
|---|---|---|---|
| 1 | ingest path back to `core::mem::take` of the whole deque | 4884 | **3** |
| 2 | `let mut did_work = commands_backlogged` → `= false` | 4884 | **1** |
| 3 | drain the SUFFIX instead of the front prefix | 4884 | **2** |
| 4 | `drain_bounded_into` always reports no backlog | 4884 | **3** |
| 5 | `pending.shrink_to_fit()` after the drain (restores the zero-cap regrow) | 4884 | **2** |
| 6 | `WORKER_COMMAND_DRAIN_BUDGET` 256 → 4095 | 4884 | **1** |
| 7 | `WORKER_COMMAND_DRAIN_BUDGET` = `MAX_PENDING_WORKER_COMMANDS` | — | compile-time, see below |

**Cell 1 is the one that matters, and it is why the tests are split across two
files.** It reds only:

```
apply_worker_commands_7201_stops_at_the_budget_and_leaves_the_rest_queued
apply_worker_commands_7201_preserves_dispatch_order_across_a_budget_split
apply_worker_commands_7201_does_not_zero_the_shared_queue_capacity
```

— and leaves all three `worker_queue_7201_*` cells **green**. Those exercise
`drain_bounded_into` directly, so they cannot see whether the ingest path calls
it. That is the concrete demonstration that a helper test passes whether or not
production is wired to the helper.

**Cell 2 is the mirror image**: it reds only
`worker_queue_7201_did_work_consumes_the_backlog_signal`, the source-level guard,
while every behavioural cell stays green. The `did_work` seed is a local inside a
1500-line function that no unit fixture can reach, so without that guard a
regression which makes the budget *worse than the defect* would ship green.

**Cell 3** reds the order-across-split cell, proving that assertion is not
vacuous. **Cell 5** reds both capacity cells — helper and ingest path — binding
acceptance criterion 3 at both levels.

**Cell 7 is a compile-time cell and it found a real defect in this PR.** The
`BUDGET < CAP` assert was originally written into `worker_queue_tests.rs`, so it
only evaluated under `cfg(test)`. Verified rather than assumed: with the budget
set to the cap, `cargo build` **succeeded**, and only `cargo test --no-run`
reported

```
error[E0080]: evaluation panicked: assertion failed:
WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS
```

It is now beside the constant it constrains (second commit), and re-verified: a
plain `cargo build` fails at `worker_queue.rs:141`, and builds clean at 256.

**Cell 6 turned out to test something better than intended.** 4095 still satisfies
the `BUDGET < CAP` compile-time assert, so the const alone does not catch it — but
the behavioural cell does, because at a budget of 4095 against a cap of 4096 the
queue can never hold `budget + 44` and the drain leaves 1 rather than 44. So the
const assert and the behavioural cell are complementary rather than redundant:
the const rejects `>= CAP`, the cell rejects a budget close enough to the cap to
be pathological.

One honest limitation: the ingest-path cells are written in terms of
`WORKER_COMMAND_DRAIN_BUDGET` rather than a literal `256`, so they track the
constant by design and cell 6 does not red them. That is deliberate — pinning the
literal would make every cell a change-detector for the tuning value — and it is
why cell 6 exists to cover the constant itself.

## Gates

- **`make test-rust`** at the tip (`--bins --tests`, `--test-threads=1`):
  **4953 collected, 0 named FAILs**. The doc guards run in that set
  (`cos_doc_drift_guard ... ok`), which is what validates the README edits.
- **`make test-failover`** on `loss:xpf-userspace-fw0/fw1`, under the #1875 lock:
  **17 passed, 0 failed**, `PASS iperf3 throughput: 23.0000 Gbps (>= 1.0 Gbps)`.
  No CoS fixture was applied, so there is nothing to clear and no capped-smoke
  risk.

### The deploy gate failed first, and it is not this branch — filed as #7962

`cluster-deploy`'s post-deploy reassert failed on this branch (RG2 secondary on
both nodes, `userspace XSK liveness not proven`). Two closed issues match that
symptom exactly (#7688, #7939), but I did not rest on them, because the failing
gate is about the Rust helper and this is a Rust helper change. The A/B:

| Run | Build | Reassert |
|-----|-------|----------|
| 1 | this branch | FAILED |
| 2 | **base `05c656a09`, unmodified** | **passed** |
| 3 | this branch, from the healthy cluster | FAILED, identically |

2:1 reads like a regression in this branch. It is not, and the disproof is not an
argument:

- Checked later with **no traffic driven and no further deploys**, the cluster had
  converged on its own under this build — all three RGs `primary`,
  `Takeover ready: yes`. It reaches the correct state; it just takes longer than
  the reassert waits.
- The reassert's budget is `15 x 2s` = **30s**; the degraded-promotion fallback it
  depends on is `DefaultDegradedPromoteTimeout` = **120s**. On an idle cluster the
  fallback is the only path to convergence, because
  `shouldAutoProveIdleStandbyXSKLocked` requires `!hasActiveDataRGLocked()` and
  node0 holds RG1. 30s < 120s, so the gate fails by construction.
- Run 2 passed because it deployed onto a cluster already converged from the
  preceding soak, so the reassert saw the RGs primary immediately.

Ruled out on the mechanism side too: worker threads idle at **0-9% CPU** under
this build (no busy-spin from the `did_work` seeding), `maybe_wake_rx` is driven
from the poll path with its own timers rather than the idle `poll(2)` this change
can skip (so no fill-ring starvation), and **whenever the command queue is empty
this change's path is byte-identical to base** — `has_commands` is false,
`commands_backlogged` is false, `did_work` seeds `false` — which is exactly the
state an idle cluster is in.

The 30s/120s gap is a tooling defect independent of #7201 and is filed separately
as **#7962**; it is the likely engine behind the recurring #7688/#7939 class.
