### PR TITLE
userspace-dp: hold the drain-budget invariant in a production build

### DIFF
--- a/userspace-dp/src/afxdp/worker_queue.rs
+++ b/userspace-dp/src/afxdp/worker_queue.rs
@@ -129,6 +129,17 @@ pub(in crate::afxdp) fn push_bounded(
 /// syscalls the measurement could not pay.
 pub(in crate::afxdp) const WORKER_COMMAND_DRAIN_BUDGET: usize = 256;
 
+/// The budget must be a strict fraction of the queue capacity.
+///
+/// Compile-time, and deliberately HERE rather than in the test module: the
+/// failure it prevents is silent. At
+/// `WORKER_COMMAND_DRAIN_BUDGET >= MAX_PENDING_WORKER_COMMANDS` the drain can
+/// never leave a remainder, so every behavioural cell for #7201 still passes
+/// while the budget has quietly become the take-everything drain it replaced.
+/// An invariant over two production constants has to hold in a production
+/// build, not only under `cfg(test)`.
+const _: () = assert!(WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS);
+
 /// Move at most [`WORKER_COMMAND_DRAIN_BUDGET`] commands from the front of
 /// `pending` into `scratch`, returning whether `pending` still holds a backlog.
 ///

--- a/userspace-dp/src/afxdp/worker_queue_tests.rs
+++ b/userspace-dp/src/afxdp/worker_queue_tests.rs
@@ -554,14 +554,6 @@ fn worker_queue_6929_the_wiring_scan_can_actually_see_a_bare_push_back() {
 // commands and checking they all arrive passes identically with NO budget. Every
 // cell below therefore queues PAST the budget and asserts what is left behind.
 
-/// The budget must be a strict fraction of the queue capacity.
-///
-/// Compile-time, because the failure it prevents is silent: at
-/// `WORKER_COMMAND_DRAIN_BUDGET >= MAX_PENDING_WORKER_COMMANDS` the drain can
-/// never leave a remainder, so every behavioural cell below still passes while
-/// the budget has quietly become the take-everything drain it replaced.
-const _: () = assert!(WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS);
-
 #[test]
 fn worker_queue_7201_drain_takes_the_budget_and_reports_the_remainder() {
     let mut q: VecDeque<WorkerCommand> = VecDeque::new();


### PR DESCRIPTION
Follow-up to #7959 (merged). Same defect class the parent PR's mutation matrix
was built to catch, in the parent PR's own test scaffolding.

## What is wrong on master

#7959 added a compile-time invariant tying the new drain budget to the queue cap:

```rust
const _: () = assert!(WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS);
```

It was written into `worker_queue_tests.rs`, which is a `#[cfg(test)]` module, so
it only ever evaluates under `cargo test`. Both operands are production
constants.

**Verified rather than assumed** — this is exactly the "ask what the instrument
would report if the thing were false" check. With the budget set to the cap:

- `cargo build` **succeeded**. The invariant did not fire.
- only `cargo test --no-run` reported it:

```
error[E0080]: evaluation panicked: assertion failed:
WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS
 --> src/afxdp/worker_queue_tests.rs:563:15
```

## Why it matters

The failure this invariant prevents is silent. At `BUDGET >= CAP` the drain can
never leave a remainder, so `commands_backlogged` is always false and the budget
has quietly become the take-everything drain it replaced — while **every
behavioural cell for #7201 still passes**. That is precisely why the invariant
was written as a compile-time assert rather than a test, and it should therefore
hold in the build that ships, not only in the test build.

## The change

Move it beside the constant it constrains, in `worker_queue.rs`. Re-verified
after the move, with the budget set to the cap:

```
error[E0080]: evaluation panicked: assertion failed:
WORKER_COMMAND_DRAIN_BUDGET < MAX_PENDING_WORKER_COMMANDS
 --> src/afxdp/worker_queue.rs:141:15
```

and a clean `cargo build` at 256.

No behaviour change: a satisfied `const _: () = assert!(..)` compiles to nothing.

## Gate

`make test-rust` on the tree this commit was authored against: **4953 collected,
0 named FAILs**, doc guards included (`cos_doc_drift_guard ... ok`).

Also worth recording, since #7959's cell 6 measured it: `4095` satisfies this
assert and is still pathological against a cap of 4096. The const rejects
`>= CAP`; the behavioural cell
`worker_queue_7201_drain_takes_the_budget_and_reports_the_remainder` rejects a
budget close enough to the cap to misbehave. They are complementary, and neither
alone is sufficient.
