### PR TITLE
slowpath: wait for the TUN instead of spinning on EAGAIN (#7174 M05)

### DIFF
--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -818,6 +818,15 @@ const NONBLOCK_WOULDBLOCK_RETRY_BUDGET: u32 = 1024;
 /// errno and is non-fatal in the WG/GRE write predicates.
 const WOULDBLOCK_EXHAUSTED_ERRNO: i32 = libc::ENOBUFS;
 
+/// #7174 M05: how long one WouldBlock wait blocks on POLLOUT, in milliseconds.
+///
+/// Short on purpose. `NONBLOCK_WOULDBLOCK_RETRY_BUDGET` bounds how MANY waits a
+/// single packet may make, so this bounds how long each one costs — and the
+/// product is the worst case a genuinely wedged device can hold the delivery
+/// thread. A longer slice would swap the CPU-burn this fixes for
+/// head-of-line blocking, which is the same defect wearing different clothes.
+const NONBLOCK_WOULDBLOCK_POLL_SLICE_MS: i32 = 1;
+
 /// Write one whole packet to a NON-BLOCKING packet-oriented fd (the WG/GRE
 /// local-delivery TUN devices, opened `O_NONBLOCK`).
 ///
@@ -852,9 +861,14 @@ const WOULDBLOCK_EXHAUSTED_ERRNO: i32 = libc::ENOBUFS;
 /// (mirroring `libc::write`: a byte count on success, `-1` with `errno` set on
 /// error). It is a seam so the short-count / EINTR / EAGAIN behaviour is
 /// unit-testable without a real non-blocking fd.
-fn write_packet_atomic_nonblocking<F>(len: usize, mut writer: F) -> io::Result<()>
+fn write_packet_atomic_nonblocking<F, W>(
+    len: usize,
+    mut writer: F,
+    mut wait_writable: W,
+) -> io::Result<()>
 where
     F: FnMut(usize) -> isize,
+    W: FnMut(),
 {
     let mut wouldblock_retries: u32 = 0;
     loop {
@@ -876,6 +890,22 @@ where
                     if wouldblock_retries > NONBLOCK_WOULDBLOCK_RETRY_BUDGET {
                         return Err(io::Error::from_raw_os_error(WOULDBLOCK_EXHAUSTED_ERRNO));
                     }
+                    // #7174 M05: WAIT for the device instead of asking it again
+                    // immediately. This arm used to be a bare `continue`, so a
+                    // full TUN queue produced up to
+                    // NONBLOCK_WOULDBLOCK_RETRY_BUDGET back-to-back EAGAIN
+                    // syscalls before the packet was dropped — a tight spin
+                    // burning a core under sustained backpressure, and doing it
+                    // once per dropped packet.
+                    //
+                    // The wait is INJECTED rather than done here because this
+                    // function is deliberately fd-free so it can be unit-tested
+                    // without a real non-blocking device (#2438). Keeping that
+                    // property is why it is a second closure and not a poll()
+                    // call: a test supplies a counting no-op and can assert the
+                    // wait actually happened, which a poll buried in here could
+                    // not be asked about.
+                    wait_writable();
                     continue;
                 }
                 _ => return Err(err),
@@ -903,12 +933,40 @@ where
 /// Replaces std `Write::write_all`, whose stream-resume loop corrupts a packet
 /// device on a short count.
 pub(crate) fn write_packet_nonblocking(fd: i32, bytes: &[u8]) -> io::Result<()> {
-    write_packet_atomic_nonblocking(bytes.len(), |buf_len| {
-        // SAFETY: `bytes` is a valid slice for `buf_len` bytes; `fd` is the TUN
-        // fd owned by the caller's thread. Always writes from offset 0 — a TUN
-        // write is one packet, never a partial-offset resubmit.
-        unsafe { libc::write(fd, bytes.as_ptr().cast::<libc::c_void>(), buf_len) }
-    })
+    write_packet_atomic_nonblocking(
+        bytes.len(),
+        |buf_len| {
+            // SAFETY: `bytes` is a valid slice for `buf_len` bytes; `fd` is the
+            // TUN fd owned by the caller's thread. Always writes from offset 0
+            // — a TUN write is one packet, never a partial-offset resubmit.
+            unsafe { libc::write(fd, bytes.as_ptr().cast::<libc::c_void>(), buf_len) }
+        },
+        || {
+            // #7174 M05: block briefly until the device can accept a write,
+            // instead of re-asking immediately. POLLOUT is the primitive that
+            // answers exactly the question EAGAIN raised.
+            //
+            // The slice is deliberately SHORT (1 ms). The retry budget bounds
+            // the number of waits, so the slice bounds the worst case a wedged
+            // device can cost this delivery thread — 1 ms x budget — and a
+            // longer slice would trade a CPU-burn problem for a
+            // head-of-line-blocking one. Under real backpressure the kernel
+            // routing stack drains the TUN in far less than a slice, so the
+            // common case returns immediately and adds no latency.
+            //
+            // A poll error is deliberately ignored: it degrades to the previous
+            // immediate-retry behaviour, which is bounded by the same budget, so
+            // there is nothing safer to do here than try the write again.
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLOUT,
+                revents: 0,
+            };
+            // SAFETY: `pfd` is a valid, initialised pollfd for the caller-owned
+            // fd; poll does not retain the pointer.
+            unsafe { libc::poll(&mut pfd, 1, NONBLOCK_WOULDBLOCK_POLL_SLICE_MS) };
+        },
+    )
 }
 
 pub(crate) fn open_tun(name: &str) -> Result<(std::fs::File, String), String> {

--- a/userspace-dp/src/slowpath_tests.rs
+++ b/userspace-dp/src/slowpath_tests.rs
@@ -549,7 +549,7 @@ fn nb_full_write_succeeds_single_call() {
         calls += 1;
         assert_eq!(buf_len, len, "writer must always be handed the full packet");
         buf_len as isize
-    });
+    }, || {});
     assert!(res.is_ok());
     assert_eq!(calls, 1, "a full write must not loop");
 }
@@ -569,7 +569,7 @@ fn nb_short_write_drops_no_remainder() {
     let res = write_packet_atomic_nonblocking(len, |buf_len| {
         observed_lens.push(buf_len);
         40 // partial: 40 of 100
-    });
+    }, || {});
     let err = res.unwrap_err();
     assert_eq!(
         err.raw_os_error(),
@@ -607,7 +607,7 @@ fn nb_wouldblock_retries_whole_packet() {
         } else {
             buf_len as isize
         }
-    });
+    }, || {});
     assert!(res.is_ok(), "WouldBlock must retry, not drop");
     assert_eq!(
         observed_lens,
@@ -632,7 +632,7 @@ fn nb_eintr_retries_whole_packet() {
         } else {
             buf_len as isize
         }
-    });
+    }, || {});
     assert!(res.is_ok(), "EINTR must retry, not fail");
     assert_eq!(
         observed_lens,
@@ -659,7 +659,7 @@ fn nb_wouldblock_budget_is_bounded_and_drops() {
         }
         set_errno(libc::EAGAIN);
         -1
-    });
+    }, || {});
     let err = res.unwrap_err();
     assert_eq!(
         err.raw_os_error(),
@@ -681,7 +681,7 @@ fn nb_hard_error_preserves_errno() {
     let res = write_packet_atomic_nonblocking(100, |_| {
         set_errno(libc::EBADF);
         -1
-    });
+    }, || {});
     assert_eq!(
         res.unwrap_err().raw_os_error(),
         Some(libc::EBADF),
@@ -1106,4 +1106,82 @@ fn transient_outcome_does_not_demote_write_mode() {
         "status.mode must remain io_uring when no terminal failure occurred"
     );
     assert_eq!(status.snapshot().injected_packets, 1);
+}
+
+/// #7174 M05: every WouldBlock retry must WAIT for the device, not re-ask
+/// immediately.
+///
+/// The arm used to be a bare `continue`, so a full TUN queue produced up to
+/// NONBLOCK_WOULDBLOCK_RETRY_BUDGET back-to-back EAGAIN syscalls before the
+/// packet was dropped — a tight spin that burns a core under sustained
+/// backpressure, once per dropped packet.
+///
+/// WHY THIS ASSERTS THE WAIT COUNT RATHER THAN TIMING. The wait is injected as
+/// a closure precisely so it is observable: a poll() buried inside the function
+/// could not be asked whether it happened, and a timing assertion would be a
+/// flake on a loaded box. Counting the injected waits binds the WIRING — remove
+/// the `wait_writable()` call and this reds, while every pre-existing
+/// WouldBlock test stays green because they only ever asserted the retry count.
+#[test]
+fn nb_wouldblock_waits_between_retries_7174() {
+    let len = 100usize;
+    let mut writes = 0usize;
+    let mut waits = 0usize;
+    // Two EAGAINs, then success.
+    let res = write_packet_atomic_nonblocking(
+        len,
+        |buf_len| {
+            writes += 1;
+            if writes <= 2 {
+                unsafe { *libc::__errno_location() = libc::EAGAIN };
+                return -1;
+            }
+            buf_len as isize
+        },
+        || waits += 1,
+    );
+    assert!(res.is_ok(), "the write must succeed once the device drains");
+    assert_eq!(writes, 3, "two EAGAINs then one successful write");
+    assert_eq!(
+        waits, 2,
+        "each WouldBlock must be followed by a wait — one per retry. Zero waits \
+         means the arm is spinning on the device again (#7174 M05)"
+    );
+}
+
+/// Control: a write that succeeds first time must NOT wait. Without this, a
+/// change that waited unconditionally would satisfy the cell above while adding
+/// a poll to every single packet on the fast path.
+#[test]
+fn nb_successful_write_does_not_wait_7174() {
+    let mut waits = 0usize;
+    let res = write_packet_atomic_nonblocking(100, |buf_len| buf_len as isize, || waits += 1);
+    assert!(res.is_ok());
+    assert_eq!(
+        waits, 0,
+        "a write that never blocked must not poll — waiting unconditionally would \
+         put a syscall on every packet"
+    );
+}
+
+/// And the budget still bounds a genuinely wedged device: persistent EAGAIN
+/// must terminate rather than wait forever, with one wait per retry.
+#[test]
+fn nb_wedged_device_still_terminates_with_bounded_waits_7174() {
+    let mut waits = 0usize;
+    let res = write_packet_atomic_nonblocking(
+        100,
+        |_| {
+            unsafe { *libc::__errno_location() = libc::EAGAIN };
+            -1
+        },
+        || waits += 1,
+    );
+    assert!(res.is_err(), "a permanently wedged device must give up, not hang");
+    assert!(
+        waits as u32 <= NONBLOCK_WOULDBLOCK_RETRY_BUDGET + 1,
+        "waits must be bounded by the retry budget — the budget is what stops the \
+         wait becoming an unbounded block, which would trade a CPU-burn for a \
+         head-of-line stall. got {waits}"
+    );
 }


### PR DESCRIPTION
The `WouldBlock` arm of `write_packet_atomic_nonblocking` was a **bare `continue`**. A full TUN queue therefore produced up to `NONBLOCK_WOULDBLOCK_RETRY_BUDGET` (1024) back-to-back EAGAIN syscalls before the packet was dropped — a tight spin, paid **once per dropped packet**, so sustained backpressure pegs a core asking a device that has already said no.

It now waits on `POLLOUT` between retries — the primitive that answers exactly the question EAGAIN raised.

## Why the wait is injected rather than polled inline

`write_packet_atomic_nonblocking` is deliberately **fd-free** so the short-count / EINTR behaviour is unit-testable without a real non-blocking device (#2438). Preserving that is the reason for the second closure — and it buys something beyond testability: **the wait becomes observable**, so a test can assert it happened. A `poll()` buried in the function could not be asked.

## The slice is short on purpose

1 ms. The retry budget bounds how **many** waits one packet may make; the slice bounds what **each** costs; the product is the worst case a wedged device can hold the delivery thread. A longer slice would trade the CPU-burn this fixes for **head-of-line blocking** — the same defect wearing different clothes. Under real backpressure the kernel routing stack drains the TUN in far less than a slice, so the common case returns immediately and adds no latency.

A poll error is ignored deliberately: it degrades to the previous immediate-retry behaviour, which the same budget still bounds, so there is nothing safer to do than try the write again.

## Three tests — the second and third are what make the first mean anything

| cell | binds |
|---|---|
| `nb_wouldblock_waits_between_retries_7174` | the **wiring** — one wait per retry |
| `nb_successful_write_does_not_wait_7174` | a first-time-successful write must **not** wait, so waiting unconditionally can't pass by adding a syscall to every packet |
| `nb_wedged_device_still_terminates_with_bounded_waits_7174` | a permanently wedged device still terminates, waits bounded by the budget |

**Mutation** — remove the `wait_writable()` call: **4897 collected, 1 named FAIL** (`nb_wouldblock_waits_between_retries_7174`). Every pre-existing WouldBlock test stays green, because they only ever asserted the *retry* count — which is exactly why the new cell was needed.

## One process note

The first edit patched the `where`-clause of `write_packet_atomic`, the **blocking sibling** — the two carry near-identical `where F: FnMut(usize) -> isize` clauses and an unscoped search took the first. The compiler caught it immediately, but it is the ambiguous-anchor shape (the edit applied cleanly to the wrong subject), and the fix was to **scope each replacement to its own function** rather than to make the anchor longer.

## Gates

- `make test-rust`: **rc=0, 4966 passed, 0 failed, 0 compile errors**
- Go: **69 packages, 0 FAIL**

Rust change moves the helper binary; this is the WG/GRE local-delivery path rather than the AF_XDP transit fast path, so a cluster smoke is not strictly owed — say if you want one and I will run it.

Refs #7174