### PR TITLE
show chassis forwarding: render the helper crash/restart state

### DIFF
--- a/pkg/cli/cli_show_chassis.go
+++ b/pkg/cli/cli_show_chassis.go
@@ -101,6 +101,21 @@ func (a forwardingStatusCLIUserspaceDataPlane) Status() (dpuserspace.ProcessStat
 	return a.cli.userspaceDataplaneStatus()
 }
 
+// HelperCrashState feeds fwdstatus's #7250 crash block.
+//
+// It resolves the backend directly rather than going through
+// `userspaceDataplaneStatus()`, because that helper returns a ProcessStatus and
+// the crash record is Manager-owned state that is NOT part of it — a crash
+// clears the cached status, so routing this through the status path would make
+// the block blank in the one case it exists for.
+func (a forwardingStatusCLIUserspaceDataPlane) HelperCrashState() (dpuserspace.HelperCrashRecord, bool) {
+	provider, ok := a.cli.dpProbe().(cliUserspaceCrashProvider)
+	if !ok {
+		return dpuserspace.HelperCrashRecord{}, false
+	}
+	return provider.HelperCrashState()
+}
+
 func (c *CLI) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
 	if c == nil {
 		return nil

--- a/pkg/cli/cli_show_chassis_adapter_test.go
+++ b/pkg/cli/cli_show_chassis_adapter_test.go
@@ -109,3 +109,69 @@ func TestForwardingStatusDataplaneUsesUserspaceStatusAdapter(t *testing.T) {
 		t.Fatalf("Status() = %#v, want injected userspace status", got)
 	}
 }
+
+// --- #7250: the crash accessor must be WIRED, not merely implemented -------
+//
+// pkg/fwdstatus's own cells exercise Build + Format directly, so every one of
+// them stays green if this adapter loses its HelperCrashState method — they
+// assert a property of the renderer, not of the wiring. This is the cell that
+// reds on that deletion.
+
+type forwardingStatusCLICrashTestDP struct {
+	*forwardingStatusCLIUserspaceTestDP
+
+	rec        dpuserspace.HelperCrashRecord
+	known      bool
+	crashCalls int
+}
+
+func (f *forwardingStatusCLICrashTestDP) HelperCrashState() (dpuserspace.HelperCrashRecord, bool) {
+	f.crashCalls++
+	return f.rec, f.known
+}
+
+func TestForwardingStatusCLIAdapterExposesTheCrashAccessor7250(t *testing.T) {
+	base := &forwardingStatusCLITestDP{loaded: true}
+	dp := &forwardingStatusCLICrashTestDP{
+		forwardingStatusCLIUserspaceTestDP: &forwardingStatusCLIUserspaceTestDP{
+			forwardingStatusCLITestDP: base,
+		},
+		known: true,
+		rec: dpuserspace.HelperCrashRecord{
+			LastExitWasCrash: true,
+			RestartPending:   true,
+			ExitCode:         101,
+			PID:              4242,
+			Restarts:         3,
+		},
+	}
+
+	c := &CLI{dp: dp}
+	acc := c.forwardingStatusDataplane()
+	if acc == nil {
+		t.Fatal("forwardingStatusDataplane returned nil for a userspace backend")
+	}
+
+	// The accessor fwdstatus.Build probes for. If the adapter does not satisfy
+	// this, Build silently leaves HelperCrashKnown false and the crash block
+	// never renders — with no compile error anywhere.
+	probe, ok := acc.(interface {
+		HelperCrashState() (dpuserspace.HelperCrashRecord, bool)
+	})
+	if !ok {
+		t.Fatal("the CLI forwarding-status adapter does not expose HelperCrashState, so " +
+			"fwdstatus.Build's probe misses and `show chassis forwarding` renders no " +
+			"crash block however healthy the renderer is (#7250)")
+	}
+
+	got, known := probe.HelperCrashState()
+	if !known {
+		t.Fatal("adapter reported the crash state as unknown for a backend that answers it")
+	}
+	if got.ExitCode != 101 || got.PID != 4242 || got.Restarts != 3 {
+		t.Errorf("adapter did not pass the record through unchanged: %+v", got)
+	}
+	if dp.crashCalls == 0 {
+		t.Error("adapter never called through to the backend")
+	}
+}

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -80,6 +80,18 @@ type cliUserspaceStatusProvider interface {
 	Status() (dpuserspace.ProcessStatus, error)
 }
 
+// cliUserspaceCrashProvider is the #7250 helper-crash accessor.
+//
+// SEPARATE from cliUserspaceStatusProvider rather than folded into it: the
+// crash record is Manager state that outlives the helper process, whereas
+// ProcessStatus is the helper's own published status and is CLEARED when the
+// helper dies. Widening the status interface would also have forced every
+// existing implementor — including test fakes — to grow a method they have no
+// use for.
+type cliUserspaceCrashProvider interface {
+	HelperCrashState() (dpuserspace.HelperCrashRecord, bool)
+}
+
 // cliUserspaceControlProvider extends the status provider with the
 // mutating control operations used by `request chassis cluster
 // data-plane userspace ...` (the sole CLI consumer, handled in

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -699,19 +699,34 @@ would blackhole every flow handed to it.
     `ExitCode >= 0` discriminator, so a renderer keyed on the record
     alone prints "exit code 0" for a helper that never crashed. Same
     discipline as `BufferKnown` beside `BufferPercent`.
-  - The verdict row is **tri-state**, pairing the crash-loop verdict with
-    `RestartPending`. `CrashLooping()` stays true after an intentional
-    stop — `LastExitWasCrash` survives a stop by design and `Restarts`
-    survives with it — so a bare "CRASH LOOPING" banner would reassert at
-    the surface exactly the conflation #7250's data half removed from the
-    data.
+  - The headline is one of **four named states** over
+    (`RestartPending` x `CrashLooping()`), and **`RestartPending` picks
+    it**. `CrashLooping()` stays true after an intentional stop —
+    `LastExitWasCrash` survives a stop by design and `Restarts` survives
+    with it — so a helper that is merely stopped is headlined
+    **"stopped — after a crash loop"**, with the loop history as
+    subordinate detail. An operator reads the first line and acts on it,
+    and "CRASH LOOPING" on a stopped helper sends them hunting a crash
+    that is not currently happening. Same shape as
+    `firewallEffectiveLiveness`, whose third arm carries an explicit
+    reason rather than a flag.
+  - The crash-loop **reason** is **derived, not stored**.
+    `CrashLooping()` is
+    `LastExitWasCrash && helperRestartDelay(Restarts) >= helperRestartBackoffMax`,
+    so the reason is fully determined by the restart count plus the
+    schedule reaching its ceiling, and is rendered as
+    "restart backoff reached its maximum after N restarts". A reason
+    computed from visible inputs cannot drift from the predicate it
+    explains, which a string captured at decision time can.
 
-Still open from #5838's acceptance bullet: it asks for "last exit/**restart**
-timestamps" and a crash-loop **reason**. There is no last-restart timestamp,
-and there cannot be one inside this record — it is wiped wholesale on a
-successful restart — so the surface renders the last **exit** time, the restart
-**count**, and the next-restart deadline instead. `Detail` is the reason for the
-exit, not for the loop.
+**#5838's acceptance bullet is NOT fully closed, and the surface says so.**
+The crash-loop *reason* is satisfied by derivation (above). The **last-restart
+timestamp is not, and cannot be** with this data model: `restartHelperAfterCrash`
+zeroes the whole record on a successful restart, so such a field would be wiped
+by the very event it records. That makes it a question about where crash history
+lives rather than a field addition — tracked in **#7967**, not folded silently
+into the rendering change. Do not mark the bullet done: every other named field
+renders a row, so the missing one is invisible from the output.
 
 ## Armed-state admission contract (#2114 A3)
 

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -669,10 +669,49 @@ would blackhole every flow handed to it.
   capability / event-stream readiness gates all still run before
   forwarding is re-armed.
 
-Not covered here, tracked separately: the operator-facing surface for
-the crash record (exit code/signal, restart count, backoff deadline and
-crash-loop reason are recorded in `helperCrashState` but not yet
-rendered by any `show` command), and a named crash-loop state.
+- **Named crash-loop state (#7250).** `HelperCrashRecord.CrashLooping()`
+  is the predicate an operator or a health surface reads as "this helper
+  is not coming back". It is **backoff at the cap**, not a raw restart
+  count: a count is time-blind, and twenty restarts over a week and
+  twenty in a minute are different situations. With the shipped 1s base
+  and 60s cap it trips at seven consecutive attempts.
+- **Operator surface (#7250).** `show chassis forwarding` renders the
+  crash block, via `pkg/fwdstatus` so the in-process CLI and the remote
+  `cli` binary share one implementation. It was chosen over the other
+  candidates because it is the surface that owns the `State` row, and
+  during a crash loop `State  Unknown` was the *only* thing an operator
+  saw — `resetAfterHelperGoneLocked` clears the cached `ProcessStatus`,
+  so every other surface degrades to a generic "unavailable" and none of
+  them can separate "crashed and retrying" from "never started" from
+  "intentionally stopped".
+
+  Three properties of that render are load-bearing:
+
+  - It is **silent when there is nothing to report**. A successful
+    restart assigns a fresh `HelperCrashRecord{}`, so a recovered helper
+    holds the zero value and there is no episode to describe. It follows
+    that the surface describes the **current** crash episode, never a
+    history — once the helper recovers, the exit that preceded it is
+    gone from the record.
+  - `ForwardingStatus.HelperCrashKnown` gates every field, and is **not**
+    redundant with `LastExitWasCrash`. A zero `HelperCrashRecord` is
+    byte-identical to a healthy one, and `ExitCode: 0` satisfies the
+    `ExitCode >= 0` discriminator, so a renderer keyed on the record
+    alone prints "exit code 0" for a helper that never crashed. Same
+    discipline as `BufferKnown` beside `BufferPercent`.
+  - The verdict row is **tri-state**, pairing the crash-loop verdict with
+    `RestartPending`. `CrashLooping()` stays true after an intentional
+    stop — `LastExitWasCrash` survives a stop by design and `Restarts`
+    survives with it — so a bare "CRASH LOOPING" banner would reassert at
+    the surface exactly the conflation #7250's data half removed from the
+    data.
+
+Still open from #5838's acceptance bullet: it asks for "last exit/**restart**
+timestamps" and a crash-loop **reason**. There is no last-restart timestamp,
+and there cannot be one inside this record — it is wiped wholesale on a
+successful restart — so the surface renders the last **exit** time, the restart
+**count**, and the next-restart deadline instead. `Detail` is the reason for the
+exit, not for the loop.
 
 ## Armed-state admission contract (#2114 A3)
 

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -602,6 +602,25 @@ func (a *LegacyDataPlaneAdapter) Status() (ProcessStatus, error) {
 	return m.Status()
 }
 
+// HelperCrashState returns the manager's helper crash record (#7250).
+//
+// Returns ok=false when there is no manager to ask, deliberately rather than
+// returning a zero record: a zero HelperCrashRecord is EXACTLY what a healthy
+// helper looks like, so collapsing "no manager" into it would render an
+// unreachable dataplane as a clean one. Same comma-ok shape as CachedStatus
+// below, for the same reason.
+//
+// This delegate exists because `dataplane.Unwrap()` hands a status surface
+// THIS adapter, not the bare *Manager — so without it the accessor the #7250
+// data half exported is unreachable from pkg/cli and pkg/grpcapi.
+func (a *LegacyDataPlaneAdapter) HelperCrashState() (HelperCrashRecord, bool) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return HelperCrashRecord{}, false
+	}
+	return m.HelperCrashState(), true
+}
+
 // CachedStatus returns the last control-socket-captured ProcessStatus
 // without issuing a new request (#3970). Returns ok=false when the
 // manager is unavailable or no status has been captured yet.

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -15,7 +15,39 @@ fixed-width table.
 
 ## Callers
 
-`pkg/grpcapi` (show command), `pkg/daemon` (status sampling).
+`pkg/grpcapi` (show command), `pkg/cli` (in-process console), `pkg/daemon`
+(status sampling). Both show frontends render from THIS package precisely so
+one recorded fact cannot render two different ways.
+
+## Helper crash block (#7250)
+
+`Build` probes the dataplane for
+`HelperCrashState() (userspace.HelperCrashRecord, bool)` — an anonymous
+interface, matching the existing `Status()` probe, so `DataPlaneAccessor` stays
+the two-method surface every caller and test already implements.
+
+Three things about it are easy to break:
+
+- The probe is **not** gated on `Status()` succeeding. A crash runs
+  `resetAfterHelperGoneLocked` → `clearLastStatusLocked`, so `Status()` starts
+  erroring — which is the exact case the block exists to explain. Gating it the
+  way the Buffer% block is gated would blank the crash surface whenever a
+  helper crashed. (`isUserspace` is a type assertion, not a `Status()` outcome,
+  which is what keeps the probe reachable across a crash.)
+- `HelperCrashKnown` is **not** redundant with `LastExitWasCrash`. A zero
+  `HelperCrashRecord` is byte-identical to a healthy one, and `ExitCode: 0`
+  satisfies the `ExitCode >= 0` discriminator, so a renderer keyed on the
+  record alone prints "exit code 0" for a helper that never crashed. Same
+  discipline as `BufferKnown` beside `BufferPercent`.
+- `Format` renders **nothing** when there is no episode. The record is wiped on
+  a successful restart, so the block reports the current crash episode, never a
+  history.
+
+Both frontends must expose the accessor on their `forwardingStatus*Userspace*`
+adapter or the probe silently misses with **no compile error** —
+`cli_show_chassis_adapter_test.go` and `server_show_forwarding_adapter_test.go`
+each carry a cell that reds on that deletion, because this package's own tests
+cannot see the wiring.
 
 ## Dependencies
 

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -41,7 +41,16 @@ Three things about it are easy to break:
   discipline as `BufferKnown` beside `BufferPercent`.
 - `Format` renders **nothing** when there is no episode. The record is wiped on
   a successful restart, so the block reports the current crash episode, never a
-  history.
+  history. #5838's "last restart timestamp" is unbacked for that reason and is
+  tracked in #7967; every other field it names renders a row.
+- The headline is four named states over (`RestartPending` x `CrashLooping`),
+  and `RestartPending` picks it — a stopped helper reads "stopped", never
+  "CRASH LOOPING", because the loop predicate stays true after an intentional
+  stop.
+- `Format` is exported and takes a flat struct, so its guards must hold for
+  structs `Build` did not produce. Two mutations escaped the first matrix
+  because every cell reached the guard *through* `Build`, which sanitizes on the
+  way in; the cells that catch them construct `ForwardingStatus` directly.
 
 Both frontends must expose the accessor on their `forwardingStatus*Userspace*`
 adapter or the probe silently misses with **no compile error** —

--- a/pkg/fwdstatus/builder.go
+++ b/pkg/fwdstatus/builder.go
@@ -210,6 +210,41 @@ func Build(
 		}
 	}
 
+	// --- Helper crash/restart record (#7250) ---------------------
+	//
+	// Probed as an anonymous interface, matching the Status() probe above, so
+	// DataPlaneAccessor stays the two-method surface every caller and test
+	// already implements.
+	//
+	// This is deliberately NOT gated on `usErr == nil`. The crash record lives
+	// on the Manager, not in the helper's published status, and a crash runs
+	// `resetAfterHelperGoneLocked` -> `clearLastStatusLocked` so `Status()`
+	// starts erroring — which is precisely the case this block exists to
+	// explain. Gating it the way the Buffer% block above is gated would make
+	// the crash surface go blank exactly when a helper crashed.
+	//
+	// `isUserspace` is a type assertion rather than a Status() outcome, so it
+	// stays true across a crash; that is what keeps this reachable.
+	if dp != nil && isUserspace {
+		if acc, ok := dp.(interface {
+			HelperCrashState() (userspace.HelperCrashRecord, bool)
+		}); ok {
+			if rec, known := acc.HelperCrashState(); known {
+				fs.HelperCrashKnown = true
+				fs.LastExitWasCrash = rec.LastExitWasCrash
+				fs.RestartPending = rec.RestartPending
+				fs.HelperCrashLooping = rec.CrashLooping()
+				fs.HelperExitCode = rec.ExitCode
+				fs.HelperSignal = rec.Signal
+				fs.HelperExitDetail = rec.Detail
+				fs.HelperPID = rec.PID
+				fs.HelperLastExit = rec.At
+				fs.HelperRestarts = rec.Restarts
+				fs.HelperNextRestart = rec.NextRestart
+			}
+		}
+	}
+
 	// --- State ---------------------------------------------------
 	switch {
 	case dp == nil || !dp.IsLoaded():

--- a/pkg/fwdstatus/fwdstatus.go
+++ b/pkg/fwdstatus/fwdstatus.go
@@ -6,6 +6,7 @@ package fwdstatus
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -63,6 +64,67 @@ type ForwardingStatus struct {
 	BufferFollowupRef int     // GitHub issue number printed in place of buffer %.
 	Uptime            time.Duration
 
+	// --- Helper crash/restart state (#7250) ----------------------
+	//
+	// #5838's last acceptance bullet: "operational status exposes exit
+	// code/signal, restart count, last exit/restart timestamps, backoff
+	// deadline, and crash-loop reason". Before this, a crash-looping helper
+	// rendered as `State  Unknown` and NOTHING else — every surface degraded
+	// to a generic "unavailable" because `resetAfterHelperGoneLocked` clears
+	// the cached status, so an operator could not tell "crashed and retrying"
+	// from "never started" from "intentionally stopped".
+	//
+	// HelperCrashKnown gates every field below, and it is NOT redundant with
+	// LastExitWasCrash. It is the same discipline BufferKnown applies above:
+	// a zero HelperCrashRecord is byte-identical to a healthy one, and
+	// `ExitCode: 0` satisfies the `ExitCode >= 0` discriminator, so a
+	// renderer that keyed on the record alone would print "exit code 0" for a
+	// helper that never crashed. False means "could not ask" (no manager, not
+	// the userspace path); it is not a claim that the helper is well.
+	HelperCrashKnown bool
+
+	// LastExitWasCrash is the historical fact: the last helper exit was
+	// unexpected. It deliberately SURVIVES an intentional stop, because the
+	// supervisor's retry path reads it as debt.
+	LastExitWasCrash bool
+
+	// RestartPending reports whether a retry is actually ARMED. Distinct from
+	// LastExitWasCrash on purpose: after an intentional stop the first is
+	// true and this is false, and rendering the first as though it were the
+	// second is the exact defect the #7250 data half fixed. Never render a
+	// restart deadline without this.
+	RestartPending bool
+
+	// HelperCrashLooping is HelperCrashRecord.CrashLooping() — backoff at the
+	// cap, not a restart count. Read as "this helper is not coming back".
+	HelperCrashLooping bool
+
+	// HelperExitCode is the child's exit status, or -1 when it was signalled.
+	// Exactly one of HelperExitCode >= 0 and HelperSignal != "" is
+	// meaningful, and HelperSignal is the discriminator.
+	HelperExitCode int
+	HelperSignal   string
+
+	// HelperExitDetail is the reaped disposition as prose ("exit status
+	// 101"). Display only — the split fields above are what a decision reads.
+	HelperExitDetail string
+
+	// HelperPID is the dead child, kept so an operator can correlate the row
+	// with journald.
+	HelperPID int
+
+	// HelperLastExit is when the exit was observed; zero when none.
+	HelperLastExit time.Time
+
+	// HelperRestarts counts consecutive restart ATTEMPTS since the last
+	// helper that reached readiness.
+	HelperRestarts int
+
+	// HelperNextRestart is when the armed retry is due. Only meaningful when
+	// RestartPending — after an intentional stop the underlying record
+	// carries a time in the PAST with no timer behind it.
+	HelperNextRestart time.Time
+
 	// (Cluster peer rendering moved to the gRPC handler in #879.
 	// fwdstatus now produces pure single-block output; the handler
 	// composes node0:/node1: blocks externally.)
@@ -109,10 +171,85 @@ func Format(fs *ForwardingStatus) string {
 
 	writeRow(&b, "Uptime:", formatUptime(fs.Uptime))
 
+	writeHelperCrash(&b, fs)
+
 	// (#879: cluster framing — node0:/node1: headers, peer block —
 	// is composed by the gRPC handler on top of this single-node
 	// output. fwdstatus stays a pure single-block formatter.)
 	return b.String()
+}
+
+// writeHelperCrash renders the helper crash/restart block (#7250).
+//
+// SILENT WHEN THERE IS NOTHING TO REPORT, by design. The record is cleared
+// wholesale on a successful restart (`restartHelperAfterCrash` assigns a fresh
+// HelperCrashRecord{}), so a healthy or recovered helper holds the zero value
+// and there is no episode to describe. `State` already reports helper health;
+// this block is an exception report, and printing "Helper last exit: none" on
+// every healthy box would be the confusing empty record rather than a useful
+// one. Same convention as writeEventStreamSection's early return and
+// FormatSYNCookieCounterRows returning "" when no counter fired.
+//
+// It follows that this surface describes the CURRENT crash episode, not a
+// history: once the helper recovers, the exit that preceded it is gone from the
+// record and cannot be rendered. Correlate with journald via the PID row.
+func writeHelperCrash(b *strings.Builder, fs *ForwardingStatus) {
+	// HelperCrashKnown first: a zero HelperCrashRecord is byte-identical to a
+	// healthy one, so without this gate an unreachable manager and a
+	// never-crashed helper are the same render.
+	if !fs.HelperCrashKnown {
+		return
+	}
+	if !fs.LastExitWasCrash && !fs.RestartPending {
+		return
+	}
+
+	// The verdict row is TRI-STATE, not a crash-looping boolean, because
+	// CrashLooping() stays true after an intentional stop: LastExitWasCrash
+	// survives a stop (the retry path reads it as debt) and Restarts survives
+	// with it, so the predicate keeps reporting "not coming back" when the
+	// real reason is "stopped", not "backoff exhausted". Pairing the verdict
+	// with RestartPending is what keeps those apart — a bare CRASH LOOPING
+	// banner here would re-create at the surface exactly the conflation the
+	// #7250 data half removed from the data.
+	switch {
+	case fs.HelperCrashLooping && fs.RestartPending:
+		writeRow(b, "Helper", "CRASH LOOPING — retrying at the backoff cap")
+	case fs.RestartPending:
+		writeRow(b, "Helper", "crashed — restart pending")
+	default:
+		// LastExitWasCrash with no armed retry: the generation the timer was
+		// fenced on has been superseded, which is what an intentional stop
+		// does. Say so rather than implying a restart is coming.
+		writeRow(b, "Helper", "last exit was a crash — no restart armed")
+	}
+
+	if !fs.HelperLastExit.IsZero() {
+		writeRow(b, "Helper last exit", fs.HelperLastExit.Format(time.RFC3339))
+	}
+
+	// Signal is the discriminator: exactly one of the two is meaningful, and
+	// ExitCode is -1 when the child was signalled. Rendering both would print
+	// "exit code -1" beside a signal name.
+	if fs.HelperSignal != "" {
+		writeRow(b, "Helper exit signal", fs.HelperSignal)
+	} else if fs.HelperExitCode >= 0 {
+		writeRow(b, "Helper exit code", strconv.Itoa(fs.HelperExitCode))
+	}
+	if fs.HelperExitDetail != "" {
+		writeRow(b, "Helper exit detail", fs.HelperExitDetail)
+	}
+	if fs.HelperPID != 0 {
+		writeRow(b, "Helper last PID", strconv.Itoa(fs.HelperPID))
+	}
+	writeRow(b, "Helper restart attempts", strconv.Itoa(fs.HelperRestarts))
+
+	// Only meaningful when a retry is armed. After an intentional stop the
+	// record carries a deadline in the PAST with no timer behind it, so
+	// printing it unconditionally would promise a restart that never comes.
+	if fs.RestartPending && !fs.HelperNextRestart.IsZero() {
+		writeRow(b, "Helper next restart", fs.HelperNextRestart.Format(time.RFC3339))
+	}
 }
 
 // writeRow writes a `  <label>   <value>\n` line with a fixed

--- a/pkg/fwdstatus/fwdstatus.go
+++ b/pkg/fwdstatus/fwdstatus.go
@@ -193,6 +193,10 @@ func Format(fs *ForwardingStatus) string {
 // It follows that this surface describes the CURRENT crash episode, not a
 // history: once the helper recovers, the exit that preceded it is gone from the
 // record and cannot be rendered. Correlate with journald via the PID row.
+//
+// #5838's "last restart timestamp" is NOT rendered and cannot be: the record is
+// zeroed on a successful restart, so no such field could survive inside it.
+// Tracked in #7967 rather than papered over.
 func writeHelperCrash(b *strings.Builder, fs *ForwardingStatus) {
 	// HelperCrashKnown first: a zero HelperCrashRecord is byte-identical to a
 	// healthy one, so without this gate an unreachable manager and a
@@ -204,24 +208,44 @@ func writeHelperCrash(b *strings.Builder, fs *ForwardingStatus) {
 		return
 	}
 
-	// The verdict row is TRI-STATE, not a crash-looping boolean, because
-	// CrashLooping() stays true after an intentional stop: LastExitWasCrash
-	// survives a stop (the retry path reads it as debt) and Restarts survives
-	// with it, so the predicate keeps reporting "not coming back" when the
-	// real reason is "stopped", not "backoff exhausted". Pairing the verdict
-	// with RestartPending is what keeps those apart — a bare CRASH LOOPING
-	// banner here would re-create at the surface exactly the conflation the
-	// #7250 data half removed from the data.
+	// FOUR NAMED STATES over (RestartPending x HelperCrashLooping), not a
+	// crash-looping boolean with qualifiers.
+	//
+	// CrashLooping() stays true after an intentional stop — LastExitWasCrash
+	// survives a stop because the retry path reads it as debt, and Restarts
+	// survives with it — so the predicate keeps reporting "not coming back"
+	// when the real reason is "stopped", not "backoff exhausted".
+	//
+	// RestartPending therefore picks the HEADLINE and the loop verdict only
+	// refines it. An operator reads the first line and acts on it, so
+	// "CRASH LOOPING" on a stopped helper sends them hunting a crash that is
+	// not currently happening. "stopped, after a crash loop" is its own state
+	// rather than a qualifier bolted onto the loop state, following
+	// firewallEffectiveLiveness, whose third arm carries an explicit reason
+	// instead of a flag.
 	switch {
-	case fs.HelperCrashLooping && fs.RestartPending:
-		writeRow(b, "Helper", "CRASH LOOPING — retrying at the backoff cap")
+	case fs.RestartPending && fs.HelperCrashLooping:
+		writeRow(b, "Helper", "CRASH LOOPING — retrying at the backoff maximum")
 	case fs.RestartPending:
 		writeRow(b, "Helper", "crashed — restart pending")
+	case fs.HelperCrashLooping:
+		writeRow(b, "Helper", "stopped — after a crash loop, no restart armed")
 	default:
-		// LastExitWasCrash with no armed retry: the generation the timer was
-		// fenced on has been superseded, which is what an intentional stop
-		// does. Say so rather than implying a restart is coming.
-		writeRow(b, "Helper", "last exit was a crash — no restart armed")
+		writeRow(b, "Helper", "stopped — last exit was a crash, no restart armed")
+	}
+
+	// The crash-loop REASON, #5838's last-named field, rendered as a
+	// DERIVATION rather than a stored string.
+	//
+	// CrashLooping() is `LastExitWasCrash && helperRestartDelay(Restarts) >=
+	// helperRestartBackoffMax`, so the reason is fully determined by inputs
+	// already on this struct: the restart count, and the fact that the
+	// schedule reached its ceiling. Deriving it here cannot drift from the
+	// predicate it explains, which a string captured at decision time can.
+	if fs.HelperCrashLooping {
+		writeRow(b, "Helper crash-loop reason",
+			fmt.Sprintf("restart backoff reached its maximum after %d restarts",
+				fs.HelperRestarts))
 	}
 
 	if !fs.HelperLastExit.IsZero() {

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -716,6 +716,43 @@ func TestUnknownCrashStateRendersNothingRatherThanHealth7250(t *testing.T) {
 	}
 }
 
+// Format is EXPORTED and takes a flat struct, so it must be correct for any
+// ForwardingStatus it is handed — not only for one Build produced.
+//
+// This cell exists because a mutation ESCAPED without it. Deleting
+// `if !fs.HelperCrashKnown { return }` from writeHelperCrash left the whole
+// suite green, because every other cell reaches that gate THROUGH Build, and
+// Build never populates LastExitWasCrash/RestartPending unless known is true —
+// so the renderer's second gate absorbed the mutation and the first one was
+// never actually bound. The record fields are set here directly, which is the
+// only way to reach the site the production path sanitizes on the way in.
+func TestFormatDoesNotRenderAnUnvouchedRecordEvenIfPopulated7250(t *testing.T) {
+	fs := &ForwardingStatus{
+		State:            StateUnknown,
+		HelperCrashKnown: false, // "could not ask" — NOT a claim of health
+		// Populated as if a crash had been recorded. A caller that set these
+		// without vouching for them must not get a crash render.
+		LastExitWasCrash:  true,
+		RestartPending:    true,
+		HelperExitCode:    101,
+		HelperPID:         4242,
+		HelperRestarts:    3,
+		HelperNextRestart: time.Now().Add(time.Second),
+	}
+	out := Format(fs)
+	for _, unwanted := range []string{
+		"Helper exit code", "4242", "Helper restart attempts",
+		"Helper next restart", "restart pending",
+	} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("Format rendered %q from a record the caller did not vouch for "+
+				"(HelperCrashKnown=false). The renderer must gate on that flag itself; "+
+				"relying on Build to sanitize leaves Format wrong for every other "+
+				"caller.\n--- got ---\n%s", unwanted, out)
+		}
+	}
+}
+
 // A dataplane with no crash accessor at all — every pre-#7250 implementor, and
 // the eBPF path. Build must not panic and must not invent a crash.
 func TestDataPlaneWithoutTheCrashAccessorIsTolerated7250(t *testing.T) {
@@ -802,6 +839,33 @@ func TestSignalAndExitCodeAreRenderedExclusively7250(t *testing.T) {
 	if strings.Contains(signalled, "Helper exit code") {
 		t.Errorf("signalled exit ALSO rendered an exit code; ExitCode is -1 here, so the "+
 			"row would read \"exit code -1\".\n--- got ---\n%s", signalled)
+	}
+
+	// The `else` in the render is only OBSERVABLE when both fields are set at
+	// once — and the producer never does that (`exitCodeAndSignal` returns
+	// (-1, sig) or (code, "")), so the two cells above pass identically with
+	// the discriminator removed. A second escaped mutation found exactly that:
+	// the fixtures used the values production emits, so the guard they were
+	// written for was never exercised.
+	//
+	// Format is exported and takes a flat struct, so it owes a defined answer
+	// for a state its usual producer cannot construct. Signal wins.
+	both := Format(&ForwardingStatus{
+		State:            StateUnknown,
+		HelperCrashKnown: true,
+		LastExitWasCrash: true,
+		RestartPending:   true,
+		HelperSignal:     "killed",
+		HelperExitCode:   101, // contradictory on purpose
+		HelperRestarts:   1,
+	})
+	if !strings.Contains(both, "Helper exit signal") {
+		t.Errorf("signal must win when both are set.\n--- got ---\n%s", both)
+	}
+	if strings.Contains(both, "Helper exit code") {
+		t.Errorf("both an exit signal and an exit code were rendered. Signal is the "+
+			"discriminator — exactly one of the two is meaningful — so rendering both "+
+			"tells an operator the helper did two contradictory things.\n--- got ---\n%s", both)
 	}
 
 	exited := base(userspace.HelperCrashRecord{

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -583,3 +583,235 @@ func TestHeartbeatsHealthy(t *testing.T) {
 // (Cluster-mode rendering moved to the gRPC handler in #879;
 // fwdstatus.Build no longer takes a clusterMode flag. Cluster
 // composition tests live in pkg/grpcapi/.)
+
+// --- #7250: the helper crash/restart block ---------------------------
+//
+// #5838's last acceptance bullet asked operational status to expose exit
+// code/signal, restart count, timestamps, backoff deadline and a crash-loop
+// verdict. Before this, a crash-looping helper rendered as `State  Unknown`
+// and nothing else, because `resetAfterHelperGoneLocked` clears the cached
+// ProcessStatus and every surface degraded to a generic "unavailable".
+
+// fakeCrashDP is a userspace dataplane that also answers the #7250 crash
+// accessor. Separate from fakeUserspaceDP so the cells below can assert what
+// Build does when the accessor is ABSENT — which is what every pre-#7250
+// implementor looks like, and what the eBPF path looks like today.
+type fakeCrashDP struct {
+	fakeUserspaceDP
+	rec   userspace.HelperCrashRecord
+	known bool
+}
+
+func (f *fakeCrashDP) HelperCrashState() (userspace.HelperCrashRecord, bool) {
+	return f.rec, f.known
+}
+
+// crashBuild runs Build against a helper whose Status() errors, which is the
+// real post-crash shape: the supervisor clears the cached status, so a crash
+// and a "helper never started" look identical to every other surface.
+func crashBuild(t *testing.T, dp DataPlaneAccessor) *ForwardingStatus {
+	t.Helper()
+	fs, err := Build(dp, freshProcReader(), time.Now(), SamplerSnapshot{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return fs
+}
+
+func TestHelperCrashBlockIsRenderedWhenTheHelperCrashed7250(t *testing.T) {
+	now := time.Now()
+	dp := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{
+			fakeDP: fakeDP{loaded: true},
+			err:    errors.New("userspace dataplane helper not running"),
+		},
+		known: true,
+		rec: userspace.HelperCrashRecord{
+			LastExitWasCrash: true,
+			RestartPending:   true,
+			Detail:           "exit status 101",
+			ExitCode:         101,
+			PID:              4242,
+			At:               now.Add(-30 * time.Second),
+			Restarts:         3,
+			NextRestart:      now.Add(4 * time.Second),
+		},
+	}
+	fs := crashBuild(t, dp)
+
+	// Build must carry the record across. Asserted separately from the render
+	// so a failure says which half broke.
+	if !fs.HelperCrashKnown {
+		t.Fatal("Build did not consult the crash accessor; the block cannot render")
+	}
+	if fs.HelperExitCode != 101 || fs.HelperRestarts != 3 || fs.HelperPID != 4242 {
+		t.Errorf("Build dropped crash fields: %+v", fs)
+	}
+
+	out := Format(fs)
+	for _, want := range []string{
+		"Helper",
+		"restart pending",
+		"Helper exit code",
+		"101",
+		"Helper last PID",
+		"4242",
+		"Helper restart attempts",
+		"Helper next restart",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("crash render is missing %q.\n--- got ---\n%s", want, out)
+		}
+	}
+	// The whole point: this is the surface whose ONLY output during a crash
+	// loop used to be `State  Unknown`.
+	if !strings.Contains(out, "State") {
+		t.Error("State row vanished")
+	}
+}
+
+// The zero-value trap. A never-crashed HelperCrashRecord is byte-identical to a
+// healthy one AND has ExitCode == 0, which satisfies the `ExitCode >= 0`
+// discriminator — so a renderer keyed on the record alone prints "exit code 0"
+// for a helper that never crashed. This is the same hazard BufferKnown exists
+// for, and it is why HelperCrashKnown is not redundant with LastExitWasCrash.
+func TestHealthyHelperRendersNoCrashBlockAndNoExitCodeZero7250(t *testing.T) {
+	dp := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{fakeDP: fakeDP{loaded: true}},
+		known:           true,
+		rec:             userspace.HelperCrashRecord{}, // never crashed
+	}
+	out := Format(crashBuild(t, dp))
+
+	if strings.Contains(out, "Helper exit code") {
+		t.Errorf("a helper that never crashed rendered an exit code — ExitCode 0 "+
+			"satisfies the `ExitCode >= 0` discriminator, so the block must gate on "+
+			"the record being an actual crash.\n--- got ---\n%s", out)
+	}
+	if strings.Contains(out, "Helper restart attempts") {
+		t.Errorf("healthy helper rendered a restart row.\n--- got ---\n%s", out)
+	}
+	if strings.Contains(out, "CRASH LOOPING") {
+		t.Errorf("healthy helper rendered a crash-loop verdict.\n--- got ---\n%s", out)
+	}
+}
+
+// An unreachable manager must not render as a healthy helper. `known=false`
+// carries "could not ask", which is NOT a claim that the helper is well.
+func TestUnknownCrashStateRendersNothingRatherThanHealth7250(t *testing.T) {
+	dp := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{fakeDP: fakeDP{loaded: true}},
+		known:           false,
+		// A populated record that must NOT leak through the known=false gate.
+		rec: userspace.HelperCrashRecord{LastExitWasCrash: true, Restarts: 9, PID: 77},
+	}
+	fs := crashBuild(t, dp)
+	if fs.HelperCrashKnown {
+		t.Error("known=false leaked through as HelperCrashKnown")
+	}
+	out := Format(fs)
+	if strings.Contains(out, "77") || strings.Contains(out, "Helper restart attempts") {
+		t.Errorf("a record the accessor refused to vouch for was rendered anyway.\n"+
+			"--- got ---\n%s", out)
+	}
+}
+
+// A dataplane with no crash accessor at all — every pre-#7250 implementor, and
+// the eBPF path. Build must not panic and must not invent a crash.
+func TestDataPlaneWithoutTheCrashAccessorIsTolerated7250(t *testing.T) {
+	dp := &fakeUserspaceDP{fakeDP: fakeDP{loaded: true}}
+	fs := crashBuild(t, dp)
+	if fs.HelperCrashKnown {
+		t.Error("a dataplane with no HelperCrashState method reported a known crash state")
+	}
+	if strings.Contains(Format(fs), "Helper restart attempts") {
+		t.Error("crash block rendered for a dataplane that cannot report one")
+	}
+}
+
+// The conflation the #7250 data half removed from the DATA must not be
+// reintroduced at the SURFACE. After an intentional stop LastExitWasCrash is
+// still true (the retry path reads it as debt) and Restarts survives with it,
+// so CrashLooping() keeps reporting "not coming back" while NO retry is armed.
+// The render must not promise a restart, and must not show a deadline that has
+// no timer behind it.
+func TestStoppedHelperIsNotRenderedAsRestartPending7250(t *testing.T) {
+	now := time.Now()
+	dp := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{
+			fakeDP: fakeDP{loaded: true},
+			err:    errors.New("userspace dataplane helper not running"),
+		},
+		known: true,
+		rec: userspace.HelperCrashRecord{
+			LastExitWasCrash: true,
+			RestartPending:   false,                 // stop advanced procGen; timer orphaned
+			Restarts:         12,                    // deep enough that CrashLooping() is true
+			NextRestart:      now.Add(-time.Minute), // in the PAST, no timer behind it
+			ExitCode:         101,
+		},
+	}
+	fs := crashBuild(t, dp)
+
+	// Precondition: without this the assertions below could pass on a record
+	// that never reported crash-looping in the first place.
+	if !fs.HelperCrashLooping {
+		t.Fatalf("precondition: Restarts=%d must put CrashLooping() at the backoff cap; "+
+			"got HelperCrashLooping=false", fs.HelperRestarts)
+	}
+
+	out := Format(fs)
+	if strings.Contains(out, "restart pending") {
+		t.Errorf("a helper with no armed retry was rendered as restart-pending — this is "+
+			"the LastExitWasCrash/RestartPending conflation #7958 removed from the data, "+
+			"reintroduced at the surface.\n--- got ---\n%s", out)
+	}
+	if strings.Contains(out, "Helper next restart") {
+		t.Errorf("rendered a restart deadline with no timer behind it; after an "+
+			"intentional stop NextRestart is a time in the past.\n--- got ---\n%s", out)
+	}
+	if !strings.Contains(out, "no restart armed") {
+		t.Errorf("the render must SAY that no retry is armed rather than staying "+
+			"silent about it.\n--- got ---\n%s", out)
+	}
+}
+
+// Signal is the discriminator: exactly one of ExitCode >= 0 and Signal != "" is
+// meaningful, and ExitCode is -1 when the child was signalled. Rendering both
+// would print "exit code -1" beside a signal name.
+func TestSignalAndExitCodeAreRenderedExclusively7250(t *testing.T) {
+	base := func(rec userspace.HelperCrashRecord) string {
+		dp := &fakeCrashDP{
+			fakeUserspaceDP: fakeUserspaceDP{
+				fakeDP: fakeDP{loaded: true},
+				err:    errors.New("helper not running"),
+			},
+			known: true,
+			rec:   rec,
+		}
+		return Format(crashBuild(t, dp))
+	}
+
+	signalled := base(userspace.HelperCrashRecord{
+		LastExitWasCrash: true, RestartPending: true,
+		Signal: "killed", ExitCode: -1, Restarts: 1,
+	})
+	if !strings.Contains(signalled, "Helper exit signal") || !strings.Contains(signalled, "killed") {
+		t.Errorf("signalled exit did not render the signal.\n--- got ---\n%s", signalled)
+	}
+	if strings.Contains(signalled, "Helper exit code") {
+		t.Errorf("signalled exit ALSO rendered an exit code; ExitCode is -1 here, so the "+
+			"row would read \"exit code -1\".\n--- got ---\n%s", signalled)
+	}
+
+	exited := base(userspace.HelperCrashRecord{
+		LastExitWasCrash: true, RestartPending: true,
+		ExitCode: 101, Restarts: 1,
+	})
+	if !strings.Contains(exited, "Helper exit code") || !strings.Contains(exited, "101") {
+		t.Errorf("exited helper did not render the exit code.\n--- got ---\n%s", exited)
+	}
+	if strings.Contains(exited, "Helper exit signal") {
+		t.Errorf("exited helper rendered a signal row.\n--- got ---\n%s", exited)
+	}
+}

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -811,6 +811,113 @@ func TestStoppedHelperIsNotRenderedAsRestartPending7250(t *testing.T) {
 		t.Errorf("the render must SAY that no retry is armed rather than staying "+
 			"silent about it.\n--- got ---\n%s", out)
 	}
+	// The HEADLINE must be "stopped", not the loop verdict. An operator reads
+	// the first line and acts on it, and "CRASH LOOPING" here sends them
+	// hunting a crash that is not currently happening.
+	if strings.Contains(out, "CRASH LOOPING") {
+		t.Errorf("a stopped helper was headlined as CRASH LOOPING. The loop predicate "+
+			"is true here (backoff is at the cap and LastExitWasCrash survives a stop), "+
+			"but the actionable fact is that nothing is retrying.\n--- got ---\n%s", out)
+	}
+	if !strings.Contains(out, "stopped") {
+		t.Errorf("a helper with no armed retry must be headlined as stopped.\n"+
+			"--- got ---\n%s", out)
+	}
+	// The loop history is still worth carrying, subordinate to the headline.
+	if !strings.Contains(out, "after a crash loop") {
+		t.Errorf("the crash-loop history was dropped entirely; it is subordinate "+
+			"detail, not noise.\n--- got ---\n%s", out)
+	}
+}
+
+// #5838's "crash-loop reason", satisfied BY DERIVATION rather than by a stored
+// string: CrashLooping() is `LastExitWasCrash && helperRestartDelay(Restarts)
+// >= helperRestartBackoffMax`, so the reason is determined by the restart count
+// plus the schedule reaching its ceiling — both already on the struct. A
+// derived reason cannot drift from the predicate it explains.
+func TestCrashLoopReasonIsDerivedFromTheRestartCount7250(t *testing.T) {
+	now := time.Now()
+	dp := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{
+			fakeDP: fakeDP{loaded: true},
+			err:    errors.New("helper not running"),
+		},
+		known: true,
+		rec: userspace.HelperCrashRecord{
+			LastExitWasCrash: true,
+			RestartPending:   true,
+			Restarts:         9,
+			ExitCode:         101,
+			NextRestart:      now.Add(time.Minute),
+		},
+	}
+	fs := crashBuild(t, dp)
+	if !fs.HelperCrashLooping {
+		t.Fatalf("precondition: Restarts=9 must reach the backoff cap")
+	}
+	out := Format(fs)
+	if !strings.Contains(out, "Helper crash-loop reason") {
+		t.Errorf("no crash-loop reason rendered.\n--- got ---\n%s", out)
+	}
+	// The COUNT must appear: that is the input the derivation is built from,
+	// and a hardcoded sentence would pass a mere "reason row exists" check.
+	if !strings.Contains(out, "9 restarts") {
+		t.Errorf("the reason must name the restart count it was derived from, so an "+
+			"operator can see WHY the verdict fired rather than being asserted at.\n"+
+			"--- got ---\n%s", out)
+	}
+
+	// And it must NOT appear when the helper is not looping — otherwise the
+	// row is decoration rather than a verdict.
+	quiet := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{
+			fakeDP: fakeDP{loaded: true},
+			err:    errors.New("helper not running"),
+		},
+		known: true,
+		rec: userspace.HelperCrashRecord{
+			LastExitWasCrash: true, RestartPending: true, Restarts: 1, ExitCode: 101,
+		},
+	}
+	qfs := crashBuild(t, quiet)
+	if qfs.HelperCrashLooping {
+		t.Fatalf("precondition: Restarts=1 must NOT reach the backoff cap")
+	}
+	if strings.Contains(Format(qfs), "crash-loop reason") {
+		t.Error("a crash-loop reason was rendered for a helper that is not looping")
+	}
+}
+
+// THE MIDDLE ROW. A healthy box and an `exit status 101` crash are the two
+// ends, and a two-row table passes against a total flip of the discriminator.
+// The fixture that actually separates "keyed on the crash flag" from "keyed on
+// the exit code being non-zero" is a GENUINE crash whose exit code is 0.
+func TestAGenuineCrashWithExitCodeZeroStillRenders7250(t *testing.T) {
+	dp := &fakeCrashDP{
+		fakeUserspaceDP: fakeUserspaceDP{
+			fakeDP: fakeDP{loaded: true},
+			err:    errors.New("helper not running"),
+		},
+		known: true,
+		rec: userspace.HelperCrashRecord{
+			LastExitWasCrash: true,
+			RestartPending:   true,
+			ExitCode:         0, // the helper exited 0 when it should not have
+			Detail:           "exit status 0",
+			PID:              4242,
+			Restarts:         1,
+		},
+	}
+	out := Format(crashBuild(t, dp))
+	if !strings.Contains(out, "Helper exit code") {
+		t.Errorf("a real crash with exit code 0 rendered NO exit code row. The row must "+
+			"be gated on the crash being real, not on the code being non-zero — an "+
+			"unexpected clean exit is still an unexpected exit.\n--- got ---\n%s", out)
+	}
+	if !strings.Contains(out, "restart pending") {
+		t.Errorf("a real crash with exit code 0 was not reported as a crash at all.\n"+
+			"--- got ---\n%s", out)
+	}
 }
 
 // Signal is the discriminator: exactly one of ExitCode >= 0 and Signal != "" is

--- a/pkg/grpcapi/runtime.go
+++ b/pkg/grpcapi/runtime.go
@@ -60,6 +60,14 @@ type userspaceStatusProvider interface {
 	Status() (dpuserspace.ProcessStatus, error)
 }
 
+// userspaceCrashProvider is the #7250 helper-crash accessor. Separate from
+// userspaceStatusProvider for the reason given on its pkg/cli twin: the crash
+// record is Manager state that survives the helper, ProcessStatus is the
+// helper's own and is cleared when it dies.
+type userspaceCrashProvider interface {
+	HelperCrashState() (dpuserspace.HelperCrashRecord, bool)
+}
+
 // userspaceControlProvider: superset of statusProvider used by the
 // diag/control path (queue/binding admin, forwarding-armed, inject).
 type userspaceControlProvider interface {

--- a/pkg/grpcapi/server_show_forwarding.go
+++ b/pkg/grpcapi/server_show_forwarding.go
@@ -63,6 +63,18 @@ func (a forwardingStatusServerUserspaceDataPlane) Status() (dpuserspace.ProcessS
 	return a.server.userspaceDataplaneStatus()
 }
 
+// HelperCrashState feeds fwdstatus's #7250 crash block. Resolves the backend
+// directly rather than via userspaceDataplaneStatus(), because a crash clears
+// the cached ProcessStatus and the crash record is Manager-owned — routing it
+// through the status path would blank the block in the one case it is for.
+func (a forwardingStatusServerUserspaceDataPlane) HelperCrashState() (dpuserspace.HelperCrashRecord, bool) {
+	provider, ok := a.server.dpProbe().(userspaceCrashProvider)
+	if !ok {
+		return dpuserspace.HelperCrashRecord{}, false
+	}
+	return provider.HelperCrashState()
+}
+
 func (s *Server) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
 	if s == nil {
 		return nil

--- a/pkg/grpcapi/server_show_forwarding_adapter_test.go
+++ b/pkg/grpcapi/server_show_forwarding_adapter_test.go
@@ -109,3 +109,66 @@ func TestForwardingStatusDataplaneUsesUserspaceStatusAdapter(t *testing.T) {
 		t.Fatalf("Status() = %#v, want injected userspace status", got)
 	}
 }
+
+// --- #7250: the crash accessor must be WIRED on the gRPC side too ---------
+//
+// The remote `cli` binary lands here, not on pkg/cli. Two frontends render the
+// same fact from one implementation (the pkg/bootstrapshow rule), so both
+// adapters need the method and both need a cell — binding one would leave the
+// other free to regress silently.
+
+type forwardingStatusServerCrashTestDP struct {
+	*forwardingStatusServerUserspaceTestDP
+
+	rec        dpuserspace.HelperCrashRecord
+	known      bool
+	crashCalls int
+}
+
+func (f *forwardingStatusServerCrashTestDP) HelperCrashState() (dpuserspace.HelperCrashRecord, bool) {
+	f.crashCalls++
+	return f.rec, f.known
+}
+
+func TestForwardingStatusServerAdapterExposesTheCrashAccessor7250(t *testing.T) {
+	base := &forwardingStatusServerTestDP{loaded: true}
+	dp := &forwardingStatusServerCrashTestDP{
+		forwardingStatusServerUserspaceTestDP: &forwardingStatusServerUserspaceTestDP{
+			forwardingStatusServerTestDP: base,
+		},
+		known: true,
+		rec: dpuserspace.HelperCrashRecord{
+			LastExitWasCrash: true,
+			RestartPending:   true,
+			Signal:           "killed",
+			ExitCode:         -1,
+			Restarts:         7,
+		},
+	}
+
+	s := &Server{dp: dp}
+	acc := s.forwardingStatusDataplane()
+	if acc == nil {
+		t.Fatal("forwardingStatusDataplane returned nil for a userspace backend")
+	}
+
+	probe, ok := acc.(interface {
+		HelperCrashState() (dpuserspace.HelperCrashRecord, bool)
+	})
+	if !ok {
+		t.Fatal("the gRPC forwarding-status adapter does not expose HelperCrashState, so " +
+			"the remote `cli` binary renders no crash block for `show chassis " +
+			"forwarding` (#7250)")
+	}
+
+	got, known := probe.HelperCrashState()
+	if !known {
+		t.Fatal("adapter reported the crash state as unknown for a backend that answers it")
+	}
+	if got.Signal != "killed" || got.Restarts != 7 {
+		t.Errorf("adapter did not pass the record through unchanged: %+v", got)
+	}
+	if dp.crashCalls == 0 {
+		t.Error("adapter never called through to the backend")
+	}
+}


### PR DESCRIPTION
Closes #7250

## Premise re-derived at current master (`37b75f4fd`)

Checked before writing code, per the campaign's standing rule, and stated
explicitly because "unchanged" is also a finding.

**The premise HAS moved, and in my favour** — PR #7958 landed the data half
about an hour before I started, and I verified each of its four items against
the code rather than trusting the PR body:

| #7250 item | State at master |
|---|---|
| 1. accessor returns an unexported type | **Fixed** — `HelperCrashRecord` is exported (`process_supervisor.go:115`) |
| 2. exit code and signal folded into `Detail` | **Fixed** — separate `ExitCode`/`Signal`, `Signal` is the discriminator |
| 3. no named crash-loop state | **Fixed** — `CrashLooping()`, backoff-at-cap; trips at `Restarts >= 7` with the shipped 1s base / 60s cap |
| 4. a deliberate stop leaves a stale record | **Fixed** — `RestartPending` is *derived* in the accessor from the live `procGen` fence |

**What is still true, and is what this PR does:** nothing renders any of it.
`HelperCrashState()` had **zero production callers** — exhaustively, only its
own definition and two in-package tests. `CrashLooping()` had zero callers of
any kind. The type's own doc comment says it was exported so "a status surface"
could name it; that surface was never built.

So the issue's "Suggested shape" is half-done and its remaining half is exactly
#5838's last acceptance bullet.

## Why `show chassis forwarding`

The deciding fact came out of surveying what already renders helper state. On an
unexpected exit the supervisor runs `resetAfterHelperGoneLocked` →
`clearLastStatusLocked`, so `Manager.Status()` starts erroring and **every**
existing surface degrades to a generic "unavailable":

| Surface | What an operator saw during a crash loop |
|---|---|
| `show chassis forwarding` | `State  Unknown` — **and nothing else** |
| `show chassis cluster data-plane statistics` | the whole helper block **silently vanishes** (`if err == nil` guard) |
| `show system buffers`, `show security wireguard` | "…unavailable: helper not running" |
| `/health`, `/api/v1/status`, `/metrics` | **nothing** — no helper field, no `xpf_userspace_helper_up` |

None of them can separate *crashed and retrying* from *never started* from
*intentionally stopped*. `show chassis forwarding` owns the `State` row, so it is
where an operator already goes to ask whether the dataplane is up, and its
`State: Unknown` is precisely the uninformative answer this issue is about.

**No protobuf change.** `ShowText` is text-over-the-wire (`ShowTextResponse` is
one string), so a field on `fwdstatus.ForwardingStatus` reaches the in-process
CLI and the remote `cli` binary from one implementation — which is the rule
`pkg/bootstrapshow`'s package doc states ("two renderings of the same recorded
fact that disagree is ALWAYS a bug").

**Rejected:** an `else` arm on `show chassis cluster data-plane statistics` (that
command is a statistics dump; the vanishing block is a symptom, not where an
operator looks first), and a new `show system helper …` command (four
registration sites plus a machine-checked authz table, to render a fact that
belongs beside `State`).

## Three properties that are load-bearing, not cosmetic

- **`HelperCrashKnown` is not redundant with `LastExitWasCrash`.** A zero
  `HelperCrashRecord` is byte-identical to a healthy one, *and* `ExitCode: 0`
  satisfies the `ExitCode >= 0` discriminator — so a renderer keyed on the
  record alone prints "exit code 0" for a helper that never crashed. This is the
  same hazard `BufferKnown` already exists for in this struct, so it gets the
  same shape rather than a new sentinel. `known=false` means "could not ask" and
  is never a claim of health.
- **The headline is four named states, and `RestartPending` picks it.**
  `CrashLooping()` stays true after an intentional stop — `LastExitWasCrash`
  survives a stop by design (the retry path reads it as debt) and `Restarts`
  survives with it. The predicate is not lying, but an operator reads the first
  line and acts on it, so a stopped helper is headlined **"stopped — after a
  crash loop"** with the loop history subordinate, never "CRASH LOOPING". The
  next-restart deadline is printed only when a retry is armed; after a stop the
  record carries a time in the *past* with no timer behind it.
- **The probe is not gated on `Status()` succeeding.** The crash record is
  Manager state, and a crash is precisely when `Status()` errors — gating it the
  way the sibling Buffer% block is gated would blank the crash surface whenever a
  helper crashed. `isUserspace` is a type assertion rather than a `Status()`
  outcome, which is what keeps the probe reachable across a crash.

**Silent when healthy.** A successful restart assigns a fresh
`HelperCrashRecord{}`, so a recovered helper holds the zero value and there is no
episode to describe. It follows that this surface reports the **current** crash
episode and never a history — documented, because it is a real limitation.

## #5838's bullet: one field satisfied by derivation, one genuinely unbacked

Split, because the two "absences" are not the same kind of thing.

**Crash-loop reason — satisfied, by derivation.** No field holds it, but
`CrashLooping()` is
`LastExitWasCrash && helperRestartDelay(Restarts) >= helperRestartBackoffMax`,
so the reason is fully determined by inputs already on the struct: **the restart
count**, and **the schedule having reached its ceiling**. Rendered as
`restart backoff reached its maximum after N restarts`. A reason computed from
visible inputs cannot drift from the predicate it explains, which a string
captured at decision time can. The cell asserts the *count* appears (so a
hardcoded sentence cannot satisfy it) and that the row is *absent* when the
helper is not looping (so it is a verdict, not decoration).

**Last-restart timestamp — genuinely unbacked, and NOT claimed.**
`restartHelperAfterCrash` zeroes the whole record on a successful restart, so
such a field would be wiped by the very event it records. That makes it a
question about *where crash history lives*, not a field addition — filed as
**#7967** rather than folded silently into a rendering PR.

**#5838's bullet should NOT be marked done on this surface.** Every other field
it names renders a row, so the missing one is invisible from the output — the
shape where existence stands in for coverage. Both READMEs say so explicitly and
point at #7967.

## Mutation matrix

Every cell runs the **full Go suite** (`go test ./... -count=1`), never under a
`-run` filter. `build_errs` is reported alongside named FAILs because **every
mutation below compiles clean** — the crash accessor is probed as an anonymous
interface, so none of these are caught by the compiler and only a test that
binds the specific property catches them.

| # | Mutation | ok pkgs | build errs | named red |
|---|---|---|---|---|
| 1 | delete `HelperCrashState` from the **CLI** adapter | 68 | 0 | `TestForwardingStatusCLIAdapterExposesTheCrashAccessor7250` |
| 2 | delete `HelperCrashState` from the **gRPC** adapter | 68 | 0 | `TestForwardingStatusServerAdapterExposesTheCrashAccessor7250` |
| 3 | `Build` ignores the `known` flag (`known \|\| true`) | 68 | 0 | `TestUnknownCrashStateRendersNothingRatherThanHealth7250` |
| 4 | delete the `HelperCrashKnown` gate in `Format` | 69 | 0 | **ESCAPED → now** `TestFormatDoesNotRenderAnUnvouchedRecordEvenIfPopulated7250` |
| 5 | render the restart deadline unconditionally | 68 | 0 | `TestStoppedHelperIsNotRenderedAsRestartPending7250` |
| 6 | `RestartPending` no longer picks the headline | — | 0 | `TestStoppedHelperIsNotRenderedAsRestartPending7250` |
| 7 | drop the exit-code/signal `else` | 69 | 0 | **ESCAPED → now** `TestSignalAndExitCodeAreRenderedExclusively7250` |
| 8 | delete the derived crash-loop reason row | — | 0 | `TestCrashLoopReasonIsDerivedFromTheRestartCount7250` |
| 9 | exit-code row gated `> 0` instead of `>= 0` | — | 0 | `TestAGenuineCrashWithExitCodeZeroStillRenders7250` |

Cells 6, 8 and 9 were re-run against the revised behaviour after review; 1–5 and
7 are from the original full-suite pass.

### Cell 9 is the middle row

The original matrix tested a healthy box (no crash) and a crash exiting 101 —
the two **ends**, which a total flip of the discriminator passes. The fixture
that separates "gated on the crash flag" from "gated on the exit code being
non-zero" is a **genuine crash whose exit code is 0**, and it was missing.
Verified load-bearing as a paired result: gating the row `> 0` reds that cell and
only that cell.

### Cell 1 is why both frontends have their own cell

Under cell 1, `pkg/fwdstatus` stayed **`ok`** — all seven renderer cells green
while the feature was completely disconnected from the CLI. And it compiled. So
the renderer cells alone would have shipped a dead feature. Cell 2 is localized
the same way in the other direction (`pkg/cli` green, only the gRPC cell reds),
which is why one frontend cell could not stand in for the set: the remote `cli`
binary and the in-process console reach `fwdstatus` by different adapters.

### Two cells ESCAPED, and the fix was not "add an assertion"

Both escaped for one reason: every existing cell reached the guard **through
`Build`**, and `Build` sanitizes the struct on the way in, so the guard each cell
was written for was never exercised.

- **Cell 4** — `Build` never populates `LastExitWasCrash`/`RestartPending` unless
  `known` is true, so `writeHelperCrash`'s *second* gate absorbed the deletion of
  the first. The pre-existing "unknown state" cell was passing on a property of
  `Build`, not of `Format`.
- **Cell 7** — the `else` is only observable when a signal and a non-negative
  exit code are set together, and the producer never does that
  (`exitCodeAndSignal` returns `(-1, sig)` or `(code, "")`). Both fixtures used
  the values production emits, so the discriminator could not be reached.

`Format` is exported and takes a flat `ForwardingStatus`, so it owes a defined
answer for any struct a caller constructs — including states its usual producer
cannot emit. The two new cells build the struct **directly**, which is the only
way to reach a site the production path launders. Each was verified as a paired
result: it passes on the shipped code, and re-running its mutation produces a
**named** red rather than a build break.

## Gates

`go test ./... -count=1` — **rc=0, 69 packages ok, 0 named FAILs**.

Go-only; no dataplane binary movement, so **no cluster smoke is owed** (the
issue says so too). `pkg/fwdstatus` has no `Format` golden — its `testdata/` is
/proc fixtures, and the `status_summary.golden` the label contract references
lives in `pkg/dataplane/userspace/format`, which this PR does not touch. So there
is no golden to regenerate and no laundered golden diff.

## Docs

`pkg/dataplane/README.md`'s supervision section still named the unexported
`helperCrashState` and still listed "a named crash-loop state" as not covered —
both changed by #7958. Corrected here rather than left to rot, alongside the new
surface's contract. `pkg/fwdstatus/README.md` documents the probe, the three
traps above, and the fact that this package's own tests cannot see the frontend
wiring.
