### PR TITLE
cluster-deploy: make the post-deploy reassert wait on what it depends on (#7962)

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -115,6 +115,31 @@ yet. Here is what is true today:
   an unrelated event happened to trigger one — bounded in name only. The RETH
   sibling meets the same obligation with `triggerPreemptNow()`.
 
+  **Deploy-tooling coupling (#7962).** `cluster-deploy`'s post-deploy primary
+  reassert waits on this fallback, because on an idle cluster it is the only
+  path to convergence: XSK liveness cannot self-prove on a node holding a data
+  RG (`shouldAutoProveIdleStandbyXSKLocked` requires `!hasActiveDataRGLocked()`,
+  and node0 holds RG1), and nothing is driving traffic. The reassert's budget
+  was 30s against a 120s fallback, so it failed **by construction** on a
+  restarted idle cluster — and both its passes and its failures were timing
+  artifacts, indistinguishable from an HA regression in whatever branch happened
+  to deploy next (#7688, #7939).
+
+  The reassert now (a) PRIMES liveness with a little LAN→WAN traffic, which is
+  what an operator does by hand and converges the common case in seconds rather
+  than waiting out the fallback, and (b) falls back to a budget derived from
+  `DefaultDegradedPromoteTimeout` only when priming was impossible — so a
+  failing deploy is not routinely slower. `DEPLOY_REASSERT_FALLBACK_BUDGET_S`
+  (`test/incus/deploy-lib.sh`) and this constant are coupled by
+  `TestDeployReassertBudgetExceedsDegradedFallback7962`, which reads the shell
+  default and fails if either side moves such that the budget stops covering the
+  fallback.
+
+  Its failure message now distinguishes the two states it used to crush into
+  one: *traffic was driven and the dataplane still did not prove liveness* (a
+  real signal) versus *traffic could not be driven, so the precondition was
+  absent* (not an HA regression).
+
   Interaction with #7161: on a cold boot the readiness gate now applies, so the
   hold and the gate compose — the node holds secondary for the hold window, then
   promotes when readiness recomputes. The #7161 degraded-promotion fallback

--- a/pkg/cluster/deploy_reassert_budget_7962_test.go
+++ b/pkg/cluster/deploy_reassert_budget_7962_test.go
@@ -1,0 +1,74 @@
+package cluster
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// #7962: the post-deploy reassert's budget must cover the degraded-promotion
+// fallback it depends on.
+//
+// THE DEFECT THIS GUARDS was not "30 is too small a number". It was that the
+// budget was chosen with no reference to the thing it waits for, so the two
+// could drift independently — and they had. The reassert allowed
+// TRIES*DELAY = 30s while `DefaultDegradedPromoteTimeout` is 120s, and on an
+// idle cluster that fallback is the ONLY path to convergence: XSK liveness
+// cannot self-prove on the node the reassert checks, because
+// `shouldAutoProveIdleStandbyXSKLocked` requires `!hasActiveDataRGLocked()` and
+// node0 holds RG1.
+//
+// So the gate could not pass on a restarted idle cluster unless traffic
+// happened to flow inside its window. Both its passes and its failures were
+// timing artifacts, and the failures were indistinguishable from an HA
+// regression in whatever branch deployed next (#7688, #7939).
+//
+// Raising 30 to a bigger number would have fixed the instance and left the
+// class: the next change to either side reopens it silently. This test is the
+// coupling. It reads the shell default out of the deploy library and fails if
+// either side moves such that the budget no longer covers the fallback — so
+// changing one tells you about the other.
+func TestDeployReassertBudgetExceedsDegradedFallback7962(t *testing.T) {
+	const libPath = "../../test/incus/deploy-lib.sh"
+	src, err := os.ReadFile(libPath)
+	if err != nil {
+		t.Fatalf("read %s: %v — this test is the only thing coupling the deploy "+
+			"budget to the fallback timeout; if the file moved, move this with it", libPath, err)
+	}
+
+	re := regexp.MustCompile(`DEPLOY_REASSERT_FALLBACK_BUDGET_S="\$\{DEPLOY_REASSERT_FALLBACK_BUDGET_S:-(\d+)\}"`)
+	m := re.FindSubmatch(src)
+	if m == nil {
+		t.Fatal("could not find DEPLOY_REASSERT_FALLBACK_BUDGET_S's default in " +
+			"deploy-lib.sh. If it was renamed or restructured, this test stopped " +
+			"guarding the coupling it exists for — update the pattern rather than " +
+			"deleting the test (#7962)")
+	}
+	budgetSecs, err := strconv.Atoi(string(m[1]))
+	if err != nil {
+		t.Fatalf("unparseable budget %q: %v", m[1], err)
+	}
+	budget := time.Duration(budgetSecs) * time.Second
+
+	if budget <= DefaultDegradedPromoteTimeout {
+		t.Errorf("the deploy reassert's fallback budget is %s but the degraded-promotion "+
+			"fallback it waits for takes %s. On an idle cluster that fallback is the "+
+			"ONLY path to convergence, so the gate fails BY CONSTRUCTION and its "+
+			"failure is indistinguishable from a real HA regression — which is the "+
+			"defect #7962 was filed for. Raise the budget, or lower the fallback, but "+
+			"they must not be chosen independently.",
+			budget, DefaultDegradedPromoteTimeout)
+	}
+
+	// Anti-vacuity: a budget absurdly larger than the fallback would satisfy the
+	// check above while making every genuinely failing deploy pay for it. The
+	// margin is meant to absorb election and status-read latency, not to be a
+	// second, invisible timeout.
+	if budget > DefaultDegradedPromoteTimeout*3 {
+		t.Errorf("the budget %s is more than 3x the %s fallback. That is no longer a "+
+			"margin, it is an independent timeout — and every failing deploy pays it "+
+			"before reporting (#7962)", budget, DefaultDegradedPromoteTimeout)
+	}
+}

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -598,6 +598,21 @@ const DefaultTakeoverHoldTime = 0
 // the length of an outage. A node that is not ready two minutes after boot is
 // not "still starting"; something is wrong, and forwarding degraded beats
 // forwarding nothing once there is no peer to take over instead.
+// #7962 COUPLING — read this before changing the value. The cluster deploy's
+// post-deploy primary reassert WAITS on this fallback: on an idle cluster it is
+// the only path to convergence, because XSK liveness cannot self-prove on a node
+// holding a data RG (shouldAutoProveIdleStandbyXSKLocked requires
+// !hasActiveDataRGLocked, and node0 holds RG1) and nothing is driving traffic.
+//
+// So `DEPLOY_REASSERT_FALLBACK_BUDGET_S` in test/incus/deploy-lib.sh must exceed
+// this. It did not — 30s against 120s — and the gate therefore failed BY
+// CONSTRUCTION on a restarted idle cluster, with both its passes and its
+// failures being timing artifacts indistinguishable from an HA regression in
+// whatever branch deployed next (#7688, #7939, #7962).
+//
+// TestDeployReassertBudgetExceedsDegradedFallback7962 reads that shell default
+// and asserts the relationship, so raising this value fails a test rather than
+// silently reopening the gap.
 const DefaultDegradedPromoteTimeout = 2 * time.Minute
 const DefaultPreManualFailoverRetryTimeout = 5 * time.Second
 const DefaultPreManualFailoverRetryInterval = 500 * time.Millisecond

--- a/test/incus/deploy-lib-selftest.sh
+++ b/test/incus/deploy-lib-selftest.sh
@@ -818,6 +818,40 @@ test_reassert_dies_when_role_not_achieved() {
 	fi
 }
 
+# #7962: the failure message must say WHICH failure this is. A gate that fails
+# identically whether the helper is broken or whether nothing asked it to
+# forward a packet carries no information, and its failures get read as HA
+# regressions in whatever branch happened to deploy next.
+test_reassert_failure_names_the_missing_precondition_7962() {
+	reset_cli_mock
+	CLI_STATUS_RESPONSES=("$STATUS_INVERTED_RG0")
+	# No LAN host reachable, so liveness CANNOT be primed: the fallback is the
+	# only mechanism and the diagnosis must say the precondition was absent.
+	local out rc=0
+	out=$( CLUSTER_LAN_HOST= IPERF_TARGET4= \
+		deploy_reassert_primary_node0 "fake:vm0" 2>&1 ) || rc=$?
+	if (( rc != 0 )) && printf '%s' "$out" | grep -q "precondition was absent"; then
+		ok "reassert: unprimed failure names the ABSENT PRECONDITION, not an HA regression"
+	else
+		bad "reassert: unprimed failure did not distinguish 'nothing drove traffic' from 'the dataplane is broken' (rc=$rc)"
+	fi
+}
+
+# The other half of the same split: when traffic WAS driven and the state still
+# did not converge, the gate must say so affirmatively — that one IS a signal.
+test_reassert_failure_names_a_real_signal_when_primed_7962() {
+	reset_cli_mock
+	CLI_STATUS_RESPONSES=("$STATUS_INVERTED_RG0")
+	local out rc=0
+	out=$( CLUSTER_LAN_HOST="fake:lan" IPERF_TARGET4="10.0.0.1" \
+		deploy_reassert_primary_node0 "fake:vm0" 2>&1 ) || rc=$?
+	if (( rc != 0 )) && printf '%s' "$out" | grep -q "REAL dataplane/HA signal"; then
+		ok "reassert: primed failure is reported as a REAL signal"
+	else
+		bad "reassert: primed failure did not report itself as a real signal (rc=$rc)"
+	fi
+}
+
 test_reassert_issues_reset_transfer_reset_per_rg() {
 	reset_cli_mock
 	CLI_STATUS_RESPONSES=("$STATUS_BOTH_RG_NODE0_PRIMARY")
@@ -1057,6 +1091,8 @@ test_reassert_dies_when_status_never_readable
 test_reassert_retries_status_read_until_settled
 test_reassert_dies_when_role_not_achieved
 test_reassert_issues_reset_transfer_reset_per_rg
+test_reassert_failure_names_the_missing_precondition_7962
+test_reassert_failure_names_a_real_signal_when_primed_7962
 test_reassert_transfer_rc_is_not_the_verdict
 test_reassert_is_wired_into_both_deploy_paths
 test_reassert_clears_the_peer_manual_pin

--- a/test/incus/deploy-lib.sh
+++ b/test/incus/deploy-lib.sh
@@ -298,6 +298,57 @@ DEPLOY_REASSERT_READ_DELAY="${DEPLOY_REASSERT_READ_DELAY:-2}"
 DEPLOY_REASSERT_VERIFY_TRIES="${DEPLOY_REASSERT_VERIFY_TRIES:-15}"
 DEPLOY_REASSERT_VERIFY_DELAY="${DEPLOY_REASSERT_VERIFY_DELAY:-2}"
 
+# #7962: the verify budget when the degraded-promotion FALLBACK is the only path
+# to convergence.
+#
+# On an idle cluster, XSK liveness cannot self-prove on the node this reassert
+# checks. `shouldAutoProveIdleStandbyXSKLocked` requires `!hasActiveDataRGLocked()`
+# and node0 holds RG1, so the auto-prove arm is unreachable there; with no traffic
+# `currentRX` stays 0 and the RG waits out
+# `cluster.DefaultDegradedPromoteTimeout` (120s). The old budget was
+# TRIES*DELAY = 30s, so the gate could not pass on a restarted idle cluster
+# unless traffic happened to flow inside its window — it failed BY CONSTRUCTION,
+# and both its passes and its failures were timing artifacts (#7688, #7939, #7962).
+#
+# This number MUST exceed that fallback. It is not independently chosen and must
+# not be tuned on its own: TestDeployReassertBudgetExceedsDegradedFallback7962
+# (pkg/cluster) reads this default out of this file and fails if either side
+# moves such that the budget no longer covers the fallback. Change one, that test
+# tells you about the other.
+DEPLOY_REASSERT_FALLBACK_BUDGET_S="${DEPLOY_REASSERT_FALLBACK_BUDGET_S:-150}"
+
+# Whether to PRIME dataplane liveness with a little traffic before verifying.
+#
+# This is what an operator does by hand, and it is the difference between asking
+# the system for proof it cannot produce and supplying the precondition. A
+# handful of packets LAN->WAN makes the node log `XSK liveness proven` in
+# seconds, so the common idle case converges immediately instead of waiting out
+# the 120s fallback. Set to 0 to skip (the self-test does).
+DEPLOY_REASSERT_PRIME_LIVENESS="${DEPLOY_REASSERT_PRIME_LIVENESS:-1}"
+DEPLOY_REASSERT_PRIME_COUNT="${DEPLOY_REASSERT_PRIME_COUNT:-20}"
+
+# deploy_reassert_prime_liveness drives a few packets through the data path so
+# the helper can prove XSK liveness. Returns 0 if traffic was actually sent, 1 if
+# it could not be (no LAN host, no target, unreachable).
+#
+# The RETURN VALUE is load-bearing and is not about success of the ping: it
+# records whether the precondition was SUPPLIED, which is what lets the failure
+# message below tell "the helper did not prove liveness despite forwarded
+# traffic" apart from "nothing ever asked it to forward a packet". Those are the
+# two states this gate used to crush into one, and the reason its failures cost
+# lanes an afternoon.
+deploy_reassert_prime_liveness() {
+	local lan="${CLUSTER_LAN_HOST:-}" target="${IPERF_TARGET4:-${IPERF_TARGET:-}}"
+	[[ "$DEPLOY_REASSERT_PRIME_LIVENESS" == "1" ]] || return 1
+	[[ -n "$lan" && -n "$target" ]] || return 1
+	incus exec "$lan" -- ping -c "$DEPLOY_REASSERT_PRIME_COUNT" -i 0.05 -W 1 "$target" \
+		>/dev/null 2>&1 || true
+	# Ping REPLIES are not required: a one-way packet still drives RX on the
+	# firewall, which is all liveness needs. What matters is that we were able
+	# to issue traffic at all.
+	return 0
+}
+
 # deploy_reassert_primary_node0 leaves node0 the primary for EVERY redundancy
 # group after a deploy, so downstream smoke (apply-cos-config, test-failover)
 # starts from the documented node0-primary steady state regardless of preempt
@@ -366,15 +417,46 @@ deploy_reassert_primary_node0() {
 	# observed role, not the exit code of any one CLI call. A transfer that
 	# returns non-zero but lands is fine; one that returns zero and does not
 	# land is not — and only this read can tell them apart.
-	for (( try = 0; try < DEPLOY_REASSERT_VERIFY_TRIES; try++ )); do
+	# #7962: supply the precondition before demanding the proof. On an idle
+	# cluster liveness cannot self-prove on this node, so without traffic the
+	# only path to convergence is the 120s degraded fallback.
+	local primed=0 tries="$DEPLOY_REASSERT_VERIFY_TRIES" regime="primed"
+	if deploy_reassert_prime_liveness; then
+		primed=1
+	else
+		# Priming was not possible, so the fallback IS the mechanism and the
+		# budget must cover it. Derived, not independently chosen — see
+		# DEPLOY_REASSERT_FALLBACK_BUDGET_S.
+		regime="fallback"
+		# Guard the divisor. The self-test runs with DELAY=0 so it never sleeps;
+		# dividing by it aborts the function under `set -e` and turns every
+		# should-succeed case into a failure — which is exactly what it did on
+		# the first run of this change.
+		if (( DEPLOY_REASSERT_VERIFY_DELAY > 0 )); then
+			tries=$(( DEPLOY_REASSERT_FALLBACK_BUDGET_S / DEPLOY_REASSERT_VERIFY_DELAY ))
+			(( tries > DEPLOY_REASSERT_VERIFY_TRIES )) || tries="$DEPLOY_REASSERT_VERIFY_TRIES"
+		fi
+	fi
+
+	for (( try = 0; try < tries; try++ )); do
 		status=$(incus exec "$rinst" -- cli -c "show chassis cluster status" 2>/dev/null || true)
 		if printf '%s\n' "$status" | deploy_reassert_node0_primary_ok; then
-			info "Re-asserted node0 primary for all redundancy groups (post-deploy, verified)."
+			info "Re-asserted node0 primary for all redundancy groups (post-deploy, verified; ${regime} regime)."
 			return 0
 		fi
 		sleep "$DEPLOY_REASSERT_VERIFY_DELAY"
 	done
-	die "post-deploy primary reassert FAILED: node0 is not primary for every redundancy group after ${DEPLOY_REASSERT_VERIFY_TRIES} verification attempts. The cluster is left in whatever state the transfer produced; do NOT run an HA smoke against it and read the failure as an HA regression. Last status from $rinst:
+
+	# #7962: say WHICH failure this is. A gate that fails identically whether
+	# the helper is broken or whether nothing asked it to forward a packet
+	# carries no information, and its failures get read as HA regressions.
+	local diagnosis
+	if (( primed == 1 )); then
+		diagnosis="Traffic WAS driven through the data path before this wait (${DEPLOY_REASSERT_PRIME_COUNT} packets to ${IPERF_TARGET4:-${IPERF_TARGET:-the smoke target}}), so the dataplane had the opportunity to prove XSK liveness and did not take it. Treat this as a REAL dataplane/HA signal."
+	else
+		diagnosis="Traffic could NOT be driven (no reachable LAN host/target), so liveness had no opportunity to be proven and this wait depended entirely on the ${DEPLOY_REASSERT_FALLBACK_BUDGET_S}s degraded-promotion fallback. If the status below says 'userspace XSK liveness not proven', the precondition was absent rather than the dataplane broken — that is NOT an HA regression (#7962)."
+	fi
+	die "post-deploy primary reassert FAILED: node0 is not primary for every redundancy group after ${tries} verification attempts (${regime} regime). ${diagnosis} The cluster is left in whatever state the transfer produced. Last status from $rinst:
 ${status}"
 }
 


### PR DESCRIPTION
Closes #7962

The reassert's verify budget was `TRIES*DELAY` = **30s** while the
degraded-promotion fallback it waits for takes
`DefaultDegradedPromoteTimeout` = **120s**. On an idle cluster that fallback is
the *only* path to convergence — XSK liveness cannot self-prove on the node the
reassert checks (`shouldAutoProveIdleStandbyXSKLocked` requires
`!hasActiveDataRGLocked()` and node0 holds RG1), so with no traffic `currentRX`
stays 0.

The gate could not pass on a restarted idle cluster unless traffic happened to
flow inside its window. **Both its passes and its failures were timing
artifacts**, and the failures were indistinguishable from an HA regression in
whatever branch deployed next — the #7688 / #7939 recurrence.

## The fix is not a bigger number

The defect was not that 30 is too small. It is that the budget was chosen with
**no reference to the thing it waits for**, so the two could drift
independently. Raising it alone fixes the instance and leaves the class.

**1. Prime the precondition.** The reassert drives a little LAN→WAN traffic
before verifying. On an idle cluster liveness genuinely cannot be proven without
it, so demanding proof without supplying traffic asks the system for something it
cannot produce. This is what an operator does by hand, and it converges the
common case in seconds.

**2. Derive the budget, and only when it is the mechanism.** If priming succeeds
the loop keeps the existing short budget — liveness is proven, promotion is
quick — so **a failing deploy is not routinely 2.5 minutes slower**. Only when
priming was impossible does the fallback become the mechanism, and only then does
the budget extend to `DEPLOY_REASSERT_FALLBACK_BUDGET_S`.

**3. Say which failure this is.** The message now separates the two states it
used to crush into one:

| state | reported as |
|---|---|
| traffic WAS driven, dataplane still did not prove liveness | "Treat this as a REAL dataplane/HA signal" |
| traffic could NOT be driven | "the precondition was absent rather than the dataplane broken — that is NOT an HA regression" |

A gate that fails identically in both cases carries no information, which is why
its failures cost lanes an afternoon.

## The coupling is asserted, not documented and hoped for

`TestDeployReassertBudgetExceedsDegradedFallback7962` (`pkg/cluster`) reads the
shell default out of `deploy-lib.sh` and asserts it exceeds the Go constant.

| mutation | result |
|---|---|
| budget 150 → 30 (the #7962 defect restored) | **RED** — "fails BY CONSTRUCTION … #7962 was filed for" |
| budget 150 → 900 | **RED** — "no longer a margin, it is an independent timeout" |
| rename the shell constant | **RED** — "this test stopped guarding the coupling it exists for" |

The third matters: without it the guard could silently stop guarding. The second
is the anti-vacuity arm — a budget merely *larger* than the fallback satisfies
the inequality while making every failing deploy pay for it.

The reciprocal note lives at `DefaultDegradedPromoteTimeout` itself, so someone
changing the timer sees the deploy dependency rather than discovering it.

## A bug this change made, and what caught it

Computing tries from the budget divides by `DEPLOY_REASSERT_VERIFY_DELAY`, which
the self-test sets to **0** so it never sleeps. The first version aborted under
`set -e` and turned every should-succeed self-test case into a failure (46 → 44).
The divisor is now guarded, and the hermetic self-test is what caught it —
before any cluster.

## Validation

- `make test-deploy-lib` — **48 passed, 0 failed** (2 new cells, one per
  diagnosis branch; both go red when the message stops distinguishing them,
  verified by mutation).
- `make selftest` — all green.
- `go test ./...` — rc=0, 69 packages, **0 FAIL**.

No cluster run: this changes the deploy tooling's own gate, and the honest test
of it is the next deploy anyone runs. The hermetic self-test covers the regime
selection and both diagnosis branches without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y