### PR TITLE
On-wire host-inbound smoke: VLAN + HA-failover legs; dispositions for the rest of #6936

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,20 @@ make test-fbf-steering-lib # Self-test the #6936 FBF two-upstream steering
                      #   carries the probe-blind middle row. Hermetic + the
                      #   Go predicate that every config-committing smoke uses
                      #   the #6440 marker gate.
+make test-host-inbound-lib # Self-test the #6936 ON-WIRE host-inbound
+                     #   verdicts. A probe CANNOT observe a deny — it observes
+                     #   SILENCE, and "the firewall dropped it" and "my prober
+                     #   never reached the firewall" are the same reading. So
+                     #   every DENY cell is scored against a positive control
+                     #   at the SAME ADDRESS in the SAME run, and the selftest
+                     #   carries the middle row (same expectation, same
+                     #   observation, only the control differs). Hermetic.
+make test-host-inbound / test-host-inbound-failover # The smoke itself
+                     #   (loss cluster). Covers host-inbound on a TAGGED VLAN
+                     #   sub-unit and admission UNCHANGED across an RG
+                     #   failover. Commits NOTHING — it reads the committed
+                     #   config, derives its probe targets from it, and
+                     #   refuses to run if the zone posture went stale.
 make test-cluster-env-lib # Self-test the cluster-env resolver (#5024): $FW0/
                      #   $FW1/$CLUSTER_LAN_HOST derive from each env's VM0/VM1/
                      #   LAN_HOST and get INCUS_REMOTE-qualified (no cluster)

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ clean:
 # The standalone instance name defaults to xpf-fw; override it for an
 # ad-hoc/renamed VM with `XPF_INSTANCE=<name> make test-deploy` (#2162). The
 # env var flows through to setup.sh (INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}).
-.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-iperf-throughput-lib test-cos-apply-lib test-fbf-steering-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-iperf-throughput-lib test-cos-apply-lib test-fbf-steering-lib test-host-inbound-lib test-host-inbound test-host-inbound-failover test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
@@ -470,6 +470,35 @@ test-cos-apply-lib:
 test-fbf-steering-lib:
 	bash ./test/incus/fbf-steering-selftest.sh
 	go test -count=1 -run 6440 ./cmd/cli/
+
+# Self-test the #6936 on-wire host-inbound verdicts. The defect class it
+# guards is the one a probe CANNOT see: a probe never observes a deny, it
+# observes SILENCE, and "the firewall dropped it" and "my prober never reached
+# the firewall" are the same reading. So every DENY cell is scored against a
+# positive control at the SAME address in the SAME run, and the selftest table
+# carries the middle row (same expectation, same observation, only the control
+# differs) that is the only way to tell those two apart. Hermetic — no
+# cluster, no incus, no network. Run this after touching
+# test-host-inbound.sh or host-inbound-lib.sh.
+#
+# cluster-cell-selftest.sh is included because the smoke's #1875 lock wiring is
+# asserted there (its destructive-script detector picks up test-host-inbound.sh
+# automatically since #6936), so this target stands alone rather than relying
+# on whoever changes the smoke also remembering to run test-cluster-lock-lib.
+test-host-inbound-lib:
+	bash ./test/incus/host-inbound-selftest.sh
+	python3 -c "import py_compile; py_compile.compile('test/incus/host-inbound-probe.py', doraise=True)"
+	bash ./test/incus/cluster-cell-selftest.sh
+
+# The on-wire host-inbound smoke itself (#6936 — needs the loss userspace
+# cluster). Reads the already-committed config, derives its probe targets from
+# it, and commits NOTHING. `--with-failover` adds the HA leg, which moves RG1
+# and RG2 to the peer and back under the #1875 lock.
+test-host-inbound:
+	./test/incus/test-host-inbound.sh
+
+test-host-inbound-failover:
+	./test/incus/test-host-inbound.sh --with-failover
 
 # Self-test the shared cluster-env resolver (#5024): the HA/failover
 # smoke scripts read $FW0/$FW1/$CLUSTER_LAN_HOST, which cluster-env.sh

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -2090,6 +2090,90 @@ the `to-zone junos-host` mandatory-teardown gate that runs on EVERY
 LocalDelivery session hit (`poll_descriptor`), so declining to cache never skips
 policy.
 
+## On-wire coverage: what a compile-side test structurally cannot show (#6936)
+
+Everything above is enforced by `pkg/config` / `pkg/daemon` / `userspace-dp`
+tests that inspect what the compiler **produced**. None of them can show what
+the box **admitted**. `test/incus/test-host-inbound.sh` closes the two on-wire
+legs #6936 named — host-inbound resolved on a **tagged VLAN sub-unit**, and
+admission **unchanged across an HA failover** — against the loss userspace
+cluster.
+
+It commits nothing. It reads the already-committed config in `display set`
+form, derives its probe targets from it, and refuses to run if the zone posture
+its expectations depend on has changed. A shared cluster's config is not the
+smoke's to own, and an expectation table that has silently gone stale reports a
+clean pass while asserting the wrong thing.
+
+### The matrix, as measured on `loss:xpf-userspace-fw0`
+
+`lan` admits `ssh` + `ping`; `wan` admits `ping` + `gre` and owns the two
+tagged sub-units `reth0.50` / `reth0.80`. Probed from `cluster-userspace-host`:
+
+| target | interface | zone | tcp/22 | tcp/23 | icmp |
+|---|---|---|---|---|---|
+| `10.0.61.1` | `reth1.0` (untagged) | lan | RST → **admitted** | timeout → denied | reply |
+| `2001:559:8585:ef00::1` | `reth1.0` (untagged) | lan | RST → **admitted** | timeout → denied | reply |
+| `172.16.50.8` | `reth0.50` (**VLAN 50**) | wan | timeout → **denied** | timeout → denied | reply |
+| `2001:559:8585:50::8` | `reth0.50` (**VLAN 50**) | wan | timeout → **denied** | timeout → denied | reply |
+| `172.16.80.8` | `reth0.80` (**VLAN 80**) | wan | timeout → **denied** | timeout → denied | reply |
+| `2001:559:8585:80::8` | `reth0.80` (**VLAN 80**) | wan | timeout → **denied** | timeout → denied | reply |
+
+The lan row and the wan rows differ on tcp/22 while agreeing on icmp, and both
+lan rows admit tcp/22 while denying tcp/23 at the *same address*. That pair is
+what makes the VLAN cells load-bearing: no routing or reachability story
+explains a reading where one port at an address answers and another does not.
+
+### Why the RST matters
+
+`xpfd` binds its own listeners (gRPC 50051, HTTP 8080) on `127.0.0.1` only, so
+a probe of a non-listening port on a firewall-local address comes back as an
+**RST** if host-inbound admitted it and as **nothing at all** if host-inbound
+dropped it. Collapsing those two — which is what a bare `nc -z` exit status
+does — would make every negative cell in the smoke unfalsifiable. The prober
+(`host-inbound-probe.py`) therefore reports `OPEN` / `REFUSED` / `TIMEOUT` /
+`ERROR` as a raw observation, and `host-inbound-lib.sh` maps them onto
+`ADMITTED` / `SILENT` / `UNREACHED` / `BLIND`.
+
+Note the vocabulary has no state called `DENIED`. **A probe cannot observe a
+deny.** It observes silence, and "the firewall dropped it" and "my prober never
+reached the firewall" are the same reading. Silence is promoted to a deny only
+by a positive control at the **same address, same family, same run, same
+prober** — the ICMP cell at that address. A same-family-but-different-address
+control would not do: a route that stopped reaching one VLAN address would make
+every deny cell at it pass for the wrong reason. `make test-host-inbound-lib`
+drives that middle row (identical expectation, identical observation, only the
+control differs) hermetically.
+
+### The failover leg asserts a diff, not a pass
+
+`--with-failover` moves RG1 (WAN/`reth0`) and RG2 (LAN/`reth1`) to node1,
+re-runs the matrix, fails back, and re-runs it again. The assertion is that the
+matrix is **identical**, not that it still passes: a run in which every
+admission silently died still satisfies every DENY cell, so re-scoring alone
+cannot see the regression this leg exists for. `hi_matrix_stable_verdict` also
+fails an empty run rather than reading it as "unchanged".
+
+Failing back is explicit. `request chassis cluster failover reset` only clears
+the manual latch; with preempt disabled the current master keeps the group, so
+a reset alone leaves the shared cluster inverted for the next lane.
+
+### What is still not covered on the wire, and why
+
+The duplicate-host-local-address leg #6936 also listed has **no reachable
+venue**, and the reason is the product's own gate rather than the lab's: the
+ambiguous topology is hard-rejected at commit and commit-check by
+`validateDuplicateHostLocalAddressStrict` (§ "Duplicate host-local-address
+ambiguity (#3718, Option B)"). A smoke cannot apply the config it would need to
+observe. The state is reachable only through the tolerant `load` / peer-sync
+path — a deliberate #1960 no-brick concession — and that path's runtime surface
+is already covered where it is observable, by
+`pkg/daemon/host_inbound_ambiguous_3718_test.go` and
+`pkg/api/metrics_host_inbound_ambiguous_3718_test.go`. Reaching it on the wire
+would mean writing the rejected config straight into the config DB and
+restarting, which measures a state the product refuses to enter rather than one
+an operator can reach.
+
 ## Adding a new host-inbound service
 
 Adding or changing a token is a coordinated edit across all three surfaces so the

--- a/docs/log/6936.md
+++ b/docs/log/6936.md
@@ -198,3 +198,252 @@ Not validatable end-to-end right now: #7796 stops the FBF fixture
 committing at all, so no run can reach Phase 2. Hermetic rows are the
 best available evidence, which is equally true of every other cell in
 this file today.
+
+---
+
+# 6936 round 2 — premise re-check, then the on-wire host-inbound smoke
+
+Round 1 (PR #7798) fixed the FBF venue and explicitly deferred both lab
+smokes. This round starts from the premise, not the fix: each of the seven
+rows #6936 names was re-checked at `origin/master` (759f776a2) before any
+code was written.
+
+## Premise findings, row by row
+
+| # | row | status at master | disposition |
+|---|---|---|---|
+| 1 | PBR: dual-provider failure modes | live, **venue does not exist** | close |
+| 2 | PBR: dual-public-IP SNAT | live, **venue does not exist** | close |
+| 3 | PBR: throughput under dual-path load | live, **venue does not exist** | close |
+| 4 | PBR: path-divergence under uplink failure | live, **venue is broken** (#7796) | blocked, not built |
+| 5 | host-inbound VLAN smoke | live, venue exists | **BUILT** |
+| 6 | host-inbound duplicate-address smoke | **unreachable by construction** | close |
+| 7 | host-inbound HA-failover smoke | live, venue exists | **BUILT** |
+
+### Rows 1-3: there is no second uplink, and there is not going to be
+
+The two "providers" in the FBF fixture are `reth0.50` and `reth0.80` — two
+**VLAN tags on one physical WAN interface**, one mlx5 VF pair, one upstream
+switch. Measured on `loss:xpf-userspace-fw0`: both live on `ge-0-0-2`.
+Dual-provider failure modes, dual-public-IP SNAT and dual-path throughput all
+require two independently failable paths. Nothing in this lab supplies one, and
+the CLAUDE.md note about `172.16.100.x` reaching "a different `loss:` uplink
+path" is a *warning against* using it as a data path, not a second provider.
+
+These are not deferred pending effort. They are closed: the honest cost is a
+second physical uplink into the lab, and that is a hardware decision, not a
+work item.
+
+### Row 4: the venue is broken, and by a defect this issue's own round 1 found
+
+`test-fbf-steering.sh` cannot reach Phase 2 today. **#7796** (open): the FBF
+DSCP steering rule fails to install for *every* DSCP name, because
+`rules.go:732` emits the shifted DSCP as `FRA_TOS`, which the kernel validates
+against `IPTOS_TOS_MASK` (0x1E) and rejects for anything >= 8. Re-verified at
+master: `rules.go:732-733` still emits `rule.Tos`, and `rules.go:1128` still
+records "the netlink layer has no `FRA_DSCP`". The whole commit fails, so the
+fixture never lands.
+
+Path-divergence is the one PBR row that is *automatable in principle* — round 1
+already separated it from the other three, and the script's header calls it
+"the smoke-runner's manual step". It is also, on inspection, **separable from
+the broken half**: it exercises the RPM probe plus the ip-monitoring
+`preferred-route` repoint of `ISP-B.inet.0`, not the DSCP steering filter. A
+reduced fixture without the `then routing-instance` filter would commit.
+
+Not built here anyway, and the reason is scope discipline rather than
+difficulty: writing a second, divergent FBF fixture that deliberately omits the
+feature the venue exists to test would leave two fixtures to keep in step, and
+the first thing a #7796 fix will want is the full one. The work is one script
+change once #7796 lands.
+
+### Row 6: the config the smoke would need is hard-rejected at commit
+
+The duplicate-host-local-address topology is not a lab-venue problem. It is
+**refused by the product**: `validateDuplicateHostLocalAddressStrict`
+(`pkg/config/dup_host_local_address.go:284`, wired at
+`compiler_uniformgates_cluster_zone.go:343`) hard-rejects it on the strict
+commit / commit-check path. A smoke cannot apply the config it needs to
+observe.
+
+The state is reachable only through the tolerant `load` / peer-sync path — the
+deliberate #1960 no-brick concession — and that path's runtime surface is
+already covered where it is observable, by
+`pkg/daemon/host_inbound_ambiguous_3718_test.go` and
+`pkg/api/metrics_host_inbound_ambiguous_3718_test.go` (whose fixture asserts
+the strict path rejects while the tolerant path accepts, so the gate's liveness
+is itself pinned). Reaching it on the wire would mean writing the rejected
+config straight into the config DB and restarting — measuring a state the
+product refuses to enter, not one an operator can reach.
+
+Recorded in `docs/host-inbound-service-matrix.md` so the next reader does not
+re-derive it.
+
+## Rows 5 + 7: what was built
+
+`test/incus/test-host-inbound.sh`, plus `host-inbound-lib.sh` (total verdicts),
+`host-inbound-probe.py` (the prober) and `host-inbound-selftest.sh`
+(`make test-host-inbound-lib`, hermetic, 61 cells).
+
+The smoke **commits nothing**. It reads the already-committed config in
+`display set` form, derives its probe targets from it, and refuses to run if
+the zone posture its expectations depend on has changed. That choice removes
+this smoke from the #6440 class entirely — there is no apply phase to gate, no
+rollback to verify, and no way for it to leave the shared cluster dirty.
+
+### The trap the issue's own comment asked to be closed on the first pass
+
+> a host-inbound smoke that probes and gets nothing back must not score that as
+> "correctly denied". Build the verdict total from the start, and put the
+> probe-blind row in the table on the first pass rather than after someone
+> notices.
+
+The vocabulary has no state called `DENIED`. A probe cannot observe a deny; it
+observes SILENCE, and "the firewall dropped it" and "my prober never reached
+the firewall" are the same reading. Silence becomes a deny only via a positive
+control at the **same address, same family, same run, same prober**.
+
+Same-address matters, and a same-family control would not have done. A route
+that stopped reaching one VLAN address would make every deny cell at that
+address pass for the wrong reason while the family-level control stayed green.
+
+A second discriminator makes the negative cells falsifiable at all: `xpfd`
+binds its own listeners on `127.0.0.1` only, so an admitted probe of a
+non-listening port returns an **RST** — a packet-carrying positive signal — and
+a dropped one returns nothing. A bare `nc -z` exit status collapses those two,
+and every negative cell would be unfalsifiable.
+
+### Measured matrix (loss userspace cluster, node0 primary)
+
+`lan` admits ssh+ping; `wan` admits ping+gre and owns `reth0.50` / `reth0.80`.
+
+| target | interface | zone | tcp/22 | tcp/23 | icmp |
+|---|---|---|---|---|---|
+| `10.0.61.1` | `reth1.0` untagged | lan | RST → admitted | timeout | reply |
+| `2001:559:8585:ef00::1` | `reth1.0` untagged | lan | RST → admitted | timeout | reply |
+| `172.16.50.8` | `reth0.50` **VLAN 50** | wan | timeout → denied | timeout | reply |
+| `2001:559:8585:50::8` | `reth0.50` **VLAN 50** | wan | timeout → denied | timeout | reply |
+| `172.16.80.8` | `reth0.80` **VLAN 80** | wan | timeout → denied | timeout | reply |
+| `2001:559:8585:80::8` | `reth0.80` **VLAN 80** | wan | timeout → denied | timeout | reply |
+
+Both lan rows admit tcp/22 and deny tcp/23 at the *same address*; the wan rows
+deny tcp/22 while answering icmp at the same address. Neither pattern has a
+routing explanation.
+
+### The failover leg asserts a DIFF
+
+`--with-failover` moves RG1 (WAN/`reth0`) and RG2 (LAN/`reth1`) to node1,
+re-runs, fails back, re-runs. The assertion is that the matrix is **identical**,
+not that it still passes — a run in which every admission silently died still
+satisfies every DENY cell, so re-scoring alone cannot see the regression this
+leg exists for. `hi_matrix_stable_verdict` also fails an empty run rather than
+reading it as "unchanged".
+
+Failing back is explicit: `failover reset` only clears the manual latch, and
+with preempt disabled the current master keeps the group. Measured during this
+work — a reset-only restore left node1 primary for both RGs. Without the
+explicit `failover ... node 0`, this smoke would leave the SHARED cluster
+inverted for the next lane.
+
+## Validation
+
+Live, `loss:xpf-userspace-fw0/fw1` under the #1875 lock:
+
+- matrix only: **26 cells, 0 failed**
+- `--with-failover`: **68 cells, 0 failed**, matrix identical across both the
+  failover and the failback; node0 primacy restored and asserted.
+
+Hermetic: `make test-host-inbound-lib` — 61 cells, 0 failed.
+
+### Mutation matrix on the lib (hermetic, one mutation per cell)
+
+| mutation | cells red | localisation |
+|---|---|---|
+| DENY+SILENT ignores the control | 4 | all four `DENY_SILENT_CONTROL_*` |
+| a missing prober line reads SILENT not BLIND | 5 | all five `CLS_*_BLIND` |
+| drop the `system-services all` subsumption | 2 | `ZONE_ALL_*` |
+| matrix stability skips the empty-run guard | 1 | `MATRIX_BOTH_EMPTY` |
+| config readability always true | 2 | `ZONE_CLI_ERROR_BLIND`, `ZONE_NO_ZONES_BLIND` |
+| UNREACHED scored as a deny | 1 | `DENY_UNREACHED_IS_NOT_DENY` |
+
+### Mutation matrix on the SMOKE (live, against the real cluster)
+
+The lib being sound proves nothing about whether the smoke is wired to it.
+
+| mutation | result |
+|---|---|
+| **S1** point one target at an unroutable address (`198.51.100.7`) | **3 FAIL**, exit 1 — the ping control and both DENY cells at that target, each naming the blind prober |
+| **S2a** same bad input, control forced ADMITTED everywhere | **0 FAIL** — a clean 26/26 pass on an address the prober never reached |
+| **S2b** same bad input, control removed from ONLY the two DENY cells | **1 FAIL** — the untouched ping cell still reds; both DENY cells PASS. Localised: it is specifically the DENY cells' control that caught S1 |
+| **S3** flip the ADMIT/DENY expectation table | **2 FAIL** — exactly the two `lan-*-ssh` cells |
+
+S1+S2b are the paired cell: same bad input, guard removed must PASS (the
+silence really was invisible without the control) and guard restored must FAIL.
+A lone S1 would only have shown correlation. S2b is the localised form — S2a
+also forces the ping cell's own observation, so it cannot tell which of the two
+uses of `$control` did the work.
+
+## A defect found while writing this
+
+The instance-liveness precondition was first written as
+`incus info "$inst" | grep -q "RUNNING" || die`. Under `set -o pipefail` that
+is wrong in the direction that matters least but is still wrong: `grep -q`
+exits on the first match and SIGPIPEs `incus`, the pipeline reports the
+writer's failure, and a RUNNING instance reads as down. Caught on the first
+live run. Now consumes the whole stream, the shape `test-active-active.sh`
+already uses.
+
+## Guard: the destructive-smoke list was an enumeration, not a census
+
+`cluster-cell-selftest.sh` asserted the #1875 lock preamble over a **hardcoded
+list** of eight scripts. A new destructive smoke was covered only if whoever
+wrote it also remembered to add its name — the same shape that let
+`test-fbf-steering.sh` go ungated until #7798. The detector that decides "is
+line N a node mutation" already existed for the ordering assertion; it now
+decides membership too, over every `test-*.sh`. The old list survives as a
+FLOOR in the other direction: each named script must still be DETECTED, so a
+regression in the detector reports as a missing script rather than as a
+silently empty scan. `test-host-inbound.sh` is picked up automatically —
+9 scripts matched, all 8 known ones covered.
+
+### ...and the derived form had to be made fail-CLOSED
+
+The first version of the detector was `awk ... || true`, printing a line
+number or nothing. Once it decides MEMBERSHIP rather than just ordering, that
+is a fail-open predicate: "this script performs no node mutation" and "awk did
+not run" are the same empty string, and the second silently drops a
+destructive script out of the scanned set.
+
+Not hypothetical. One run of this file reported `test-private-rg.sh` as "not
+matched" while the machine was saturated by a concurrent `go test ./...`;
+every re-run on a quiet machine passed, and 10 further runs of the original
+shape did not reproduce it. With a fail-open detector that instance is not
+diagnosable after the fact — an awk that could not fork is indistinguishable
+from a clean non-match — so the SHAPE was fixed rather than the instance
+explained. The helper now prints `NONE` for a genuine non-match and returns
+non-zero on any failure; both call sites fail on it.
+
+Paired cell, simulating an unreadable script for `test-host-inbound.sh`
+(deliberately the one NOT in `KNOWN_DESTRUCTIVE`, since the floor list cannot
+catch it):
+
+| shape | result |
+|---|---|
+| fail-closed (shipped) | `FAIL: the destructive-script detector could not read test-host-inbound.sh` |
+| fail-open (`\|\| true`) | **clean pass** — "detector matched 8 destructive scripts (covers all 8 known ones)", having silently stopped guarding the ninth |
+
+The membership check in the floor loop is pure bash rather than
+`printf ... | grep -q`: that pipe SIGPIPEs its writer under `set -o pipefail`,
+which is the exact shape that broke the instance-liveness check in the smoke.
+It was not observed to fire on a nine-element list — the pipe is avoided on
+principle, not on evidence, and the comment says so.
+
+## Files
+- `test/incus/test-host-inbound.sh` (new) — the smoke
+- `test/incus/host-inbound-lib.sh` (new) — total verdict helpers
+- `test/incus/host-inbound-probe.py` (new) — RST-vs-timeout prober
+- `test/incus/host-inbound-selftest.sh` (new) — hermetic table, 61 cells
+- `test/incus/cluster-cell-selftest.sh` — derive the destructive set
+- `Makefile`, `CLAUDE.md` — targets
+- `docs/host-inbound-service-matrix.md` — on-wire coverage section + why the
+  dup-address leg has no reachable venue

--- a/test/incus/cluster-cell-selftest.sh
+++ b/test/incus/cluster-cell-selftest.sh
@@ -44,7 +44,21 @@ waitfor() { # waitfor <seconds> <desc> <cmd...>
 # These are the scripts whose Makefile targets reboot / force-stop /
 # fail over / restart a node on the SHARED loss cluster. Each MUST
 # source cluster-cell.sh and call the entry helper in its preamble.
-DESTRUCTIVE=(
+#
+# #6936: the set is now DERIVED, not enumerated. It used to be the
+# hardcoded list below, which is a floor rather than a census: a NEW
+# destructive smoke is covered only if whoever wrote it also remembered
+# to add its name here, and a guard that has to be told about its own
+# subject is the shape that let test-fbf-steering.sh go ungated (#7798).
+# The detector that decides "is line N a node mutation" already existed
+# further down for the ordering assertion; running it over every
+# test-*.sh makes it decide membership too.
+#
+# KNOWN_DESTRUCTIVE stays as a FLOOR assertion in the other direction:
+# each named script must still be DETECTED as destructive, so a
+# regression in the detector (a changed heredoc shape, a renamed verb)
+# reports as a missing script rather than as a silently empty scan.
+KNOWN_DESTRUCTIVE=(
 	test-failover.sh
 	test-ha-crash.sh
 	test-double-failover.sh
@@ -54,6 +68,62 @@ DESTRUCTIVE=(
 	test-restart-connectivity.sh
 	test-private-rg.sh
 )
+
+# xpf_first_mutation_line <script> — prints the first non-comment line number
+# that reboots / force-stops / fails over / restarts a node, or the literal
+# NONE when the script does none of those. `failover reset` is skipped: it
+# clears a manual latch and moves nothing.
+#
+# FAIL-CLOSED, deliberately. The obvious form is `awk ... || true`, printing
+# the line number or nothing — but then "this script performs no node
+# mutation" and "awk did not run" are the SAME empty string, and the second
+# one silently DROPS a destructive script out of the scanned set. This is now
+# the predicate that decides membership, so a fail-open detector would quietly
+# stop guarding scripts rather than say so.
+#
+# That is not hypothetical: during #6936 one run of this file reported
+# test-private-rg.sh as "not matched" while the machine was saturated by a
+# concurrent `go test ./...`, and every re-run under a quiet machine passed.
+# With the old fail-open form the failure is not diagnosable after the fact —
+# an awk that could not fork is indistinguishable from a clean non-match — so
+# the shape is fixed rather than the (unreproducible) instance explained.
+# An empty return now means the helper itself failed, and callers fail on it.
+xpf_first_mutation_line() {
+	local out
+	out="$(awk '
+		/^[[:space:]]*#/ { next }
+		/failover reset/ { next }
+		/incus (stop|start|restart) |sysrq|systemctl (stop|restart)|request chassis cluster failover redundancy-group/ { print NR; found = 1; exit }
+		END { if (!found) print "NONE" }
+	' "$1")" || return 1
+	[[ -n "$out" ]] || return 1
+	printf '%s\n' "$out"
+}
+
+DESTRUCTIVE=()
+for p in "${SCRIPT_DIR}"/test-*.sh; do
+	[[ -f "$p" ]] || continue
+	_mut="$(xpf_first_mutation_line "$p")" \
+		|| fail "static: the destructive-script detector could not read $(basename "$p") — refusing to treat an unread script as non-destructive"
+	[[ "$_mut" == NONE ]] && continue
+	DESTRUCTIVE+=("$(basename "$p")")
+done
+(( ${#DESTRUCTIVE[@]} > 0 )) \
+	|| fail "static: the destructive-script detector matched 0 of $(ls -1 "${SCRIPT_DIR}"/test-*.sh | wc -l) test-*.sh scripts — a scan that reaches nothing passes clean while guarding nothing"
+for known in "${KNOWN_DESTRUCTIVE[@]}"; do
+	[[ -f "${SCRIPT_DIR}/${known}" ]] || fail "static: missing destructive smoke script $known"
+	# Pure-bash membership. `printf ... | grep -q` would be the idiomatic form,
+	# but `grep -q` exits at the first match and SIGPIPEs the writer, which
+	# under `set -o pipefail` reports the WRITER's failure — the exact shape
+	# that broke the instance-liveness check in test-host-inbound.sh. It was
+	# NOT observed to fire on a list this short; the pipe is avoided on
+	# principle, not on evidence.
+	_found=no
+	for d in "${DESTRUCTIVE[@]}"; do [[ "$d" == "$known" ]] && _found=yes; done
+	[[ "$_found" == yes ]] \
+		|| fail "static: $known is a known destructive smoke but the detector did not match it — the detector regressed, and every UNLISTED destructive script it also stopped matching is now unguarded"
+done
+ok "static: detector matched ${#DESTRUCTIVE[@]} destructive test-*.sh scripts (covers all ${#KNOWN_DESTRUCTIVE[@]} known ones)"
 
 for s in "${DESTRUCTIVE[@]}"; do
 	p="${SCRIPT_DIR}/${s}"
@@ -73,11 +143,9 @@ for s in "${DESTRUCTIVE[@]}"; do
 	# node. The lock call must precede it so we never mutate the shared
 	# cluster before acquiring the lock. Skip comment lines so a "Phase
 	# 1: incus stop --force" doc line is not mistaken for a real op.
-	mut_line=$(awk '
-		/^[[:space:]]*#/ { next }
-		/failover reset/ { next }
-		/incus (stop|start|restart) |sysrq|systemctl (stop|restart)|request chassis cluster failover redundancy-group/ { print NR; exit }
-	' "$p" || true)
+	mut_line=$(xpf_first_mutation_line "$p") \
+		|| fail "static: the destructive-script detector could not read $s"
+	[[ "$mut_line" == NONE ]] && mut_line=""
 	if [[ -n "$mut_line" ]]; then
 		(( call_line < mut_line )) \
 			|| fail "static: $s mutates the cluster (line $mut_line) before taking the lock (line $call_line)"

--- a/test/incus/host-inbound-lib.sh
+++ b/test/incus/host-inbound-lib.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Verdict helpers for the #6936 on-wire host-inbound smoke
+# (test/incus/test-host-inbound.sh).
+#
+# WHY THIS EXISTS
+#
+# #6936 asks for on-wire host-inbound coverage — VLAN, and admission across an
+# HA failover — because the compile-side tests (pkg/config/host_inbound_*) can
+# only show what the compiler PRODUCED, never what the box ADMITTED. The
+# failure mode being covered is SILENT: an admission that quietly stops working
+# after a failover looks, from a prober, exactly like a service that is
+# correctly denied. Both are "nothing came back".
+#
+# That is the same trap #7798 had to close in the FBF smoke, and the #6936
+# comment asks for it to be avoided on the FIRST pass here rather than after
+# someone notices. So the vocabulary below deliberately has no state called
+# "DENIED". A probe cannot observe a deny. It can only observe SILENCE, and
+# silence is promoted to "denied" ONLY by a positive control that proves, in
+# the same run and from the same prober, that a packet CAN reach the firewall's
+# host stack at that address family.
+#
+#   OPEN / REFUSED -> ADMITTED   the SYN reached the host stack (a listener
+#                                accepted, or the stack answered RST). Either
+#                                way host-inbound let it through.
+#   TIMEOUT        -> SILENT     nothing came back. A host-inbound DROP *or* a
+#                                blind probe. NOT a verdict on its own.
+#   ERROR          -> UNREACHED  ICMP unreachable / no route / EHOSTUNREACH:
+#                                the packet never reached a host-inbound
+#                                decision at all, so it can neither confirm an
+#                                admit nor certify a deny.
+#   (no line)      -> BLIND      the prober produced no reading for this cell.
+#
+# The REFUSED state is what makes the negative cells meaningful. xpfd binds its
+# own listeners on 127.0.0.1 only, so an ADMITTED probe to a non-listening port
+# comes back as an RST from the kernel stack -- a POSITIVE, packet-carrying
+# signal that host-inbound admitted it. Without that distinction the only
+# observable difference between "admitted, nothing listening" and "dropped by
+# host-inbound" would be a timeout, and every deny cell would be unfalsifiable.
+#
+# Depends on nothing but bash, so host-inbound-selftest.sh
+# (`make test-host-inbound-lib`) is hermetic — no cluster, no incus, no network.
+
+# hi_classify_probe <probe-output> <target> <port>
+#
+#   Reduce the prober's raw output to one word of the admission vocabulary.
+#   TOTAL: always prints exactly one of ADMITTED / SILENT / UNREACHED / BLIND.
+#
+#   The prober (host-inbound-probe.py) emits one line per cell:
+#       PROBE <target> <port> <OPEN|REFUSED|TIMEOUT|ERROR> <elapsed>
+#   Missing line, unparseable line, or an unknown result word all read as
+#   BLIND — never as SILENT, because "the prober said nothing about this cell"
+#   must not be able to masquerade as "the firewall said nothing to this cell".
+hi_classify_probe() {
+	local out="$1" target="$2" port="$3" line result
+	line="$(awk -v t="$target" -v p="$port" \
+		'$1 == "PROBE" && $2 == t && $3 == p { print $4; exit }' <<<"$out")"
+	result="${line//[[:space:]]/}"
+	case "$result" in
+	OPEN | REFUSED) printf 'ADMITTED\n' ;;
+	TIMEOUT) printf 'SILENT\n' ;;
+	ERROR) printf 'UNREACHED\n' ;;
+	*) printf 'BLIND\n' ;;
+	esac
+}
+
+# hi_classify_ping <ping-output>
+#
+#   Same vocabulary for an ICMP cell. TOTAL.
+#
+#   `ping` reports "N received"; anything that is not a positive receive count
+#   is SILENT, and output that carries no statistics line at all is BLIND (the
+#   prober did not run, or incus itself failed) rather than SILENT. An ICMP
+#   error — "Destination Host Unreachable" / "Network is unreachable" — is
+#   UNREACHED: the packet did not reach a host-inbound decision.
+hi_classify_ping() {
+	local out="$1" recv
+	if [[ -z "${out//[[:space:]]/}" ]]; then
+		printf 'BLIND\n'
+		return 0
+	fi
+	if ! grep -q 'packets transmitted' <<<"$out"; then
+		printf 'BLIND\n'
+		return 0
+	fi
+	recv="$(sed -n 's/.*transmitted, \([0-9][0-9]*\) received.*/\1/p' <<<"$out" | head -1)"
+	if [[ -n "$recv" && "$recv" -gt 0 ]]; then
+		printf 'ADMITTED\n'
+		return 0
+	fi
+	if grep -qE 'Unreachable|unreachable' <<<"$out"; then
+		printf 'UNREACHED\n'
+		return 0
+	fi
+	printf 'SILENT\n'
+}
+
+# hi_cell_verdict <expect ADMIT|DENY> <observation> <control-observation>
+#
+#   Print exactly one line: "PASS <why>" or "FAIL <why>". TOTAL BY
+#   CONSTRUCTION — every input combination prints, so this cell can never be
+#   the silent hole that a bare `[[ -z "$out" ]] && pass` would be.
+#
+#   <control-observation> is the run's POSITIVE CONTROL for this address
+#   family, classified through the same vocabulary: a probe of a service the
+#   zone DOES admit, at an address in the SAME zone, from the SAME prober, in
+#   the SAME run. It exists solely so a DENY cell can tell "the firewall
+#   dropped it" from "my prober is blind". This is the middle row of
+#   host-inbound-selftest.sh, and it is the reason this file exists.
+hi_cell_verdict() {
+	local expect="$1" obs="$2" control="$3"
+	case "$expect" in
+	ADMIT)
+		case "$obs" in
+		ADMITTED) printf 'PASS %s\n' "admitted (the host stack answered)" ;;
+		SILENT) printf 'FAIL %s\n' "expected ADMIT but nothing came back — an admitted host-inbound service is being dropped" ;;
+		UNREACHED) printf 'FAIL %s\n' "expected ADMIT but the probe never reached the firewall (ICMP unreachable / no route) — this cell measured routing, not host-inbound" ;;
+		*) printf 'FAIL %s\n' "expected ADMIT but the prober returned no reading for this cell (observation=${obs:-<empty>})" ;;
+		esac
+		;;
+	DENY)
+		case "$obs" in
+		ADMITTED) printf 'FAIL %s\n' "expected DENY but the host stack answered — host-inbound admitted a service the zone does not list" ;;
+		SILENT)
+			if [[ "$control" == "ADMITTED" ]]; then
+				printf 'PASS %s\n' "silent, and the run's positive control was admitted — so the silence is a host-inbound drop, not a blind prober"
+			else
+				printf 'FAIL %s\n' "silent, but the run's positive control was ${control:-<empty>} rather than ADMITTED — the prober is not proven able to reach the firewall at all, so this silence CANNOT be scored as a deny (it is indistinguishable from a blind probe)"
+			fi
+			;;
+		UNREACHED) printf 'FAIL %s\n' "expected DENY but the probe never reached the firewall (ICMP unreachable / no route) — an unreachable is not a host-inbound deny, and scoring it as one would certify the deny on a packet that never got a verdict" ;;
+		*) printf 'FAIL %s\n' "expected DENY but the prober returned no reading for this cell (observation=${obs:-<empty>}) — an absence cannot be certified by an instrument that produced nothing" ;;
+		esac
+		;;
+	*)
+		printf 'FAIL %s\n' "unknown expectation ${expect:-<empty>} — the cell table is malformed"
+		;;
+	esac
+}
+
+# hi_config_readable <display-set-output>
+#
+#   Exit 0 iff the `show configuration security zones | display set` output is
+#   usable as evidence. An empty or zone-less read must never be allowed to
+#   answer an ABSENT question: "the wan zone does not admit ssh" and "I could
+#   not read the config" are the same string to grep, and only one of them is
+#   a reason to run the matrix.
+hi_config_readable() {
+	local lines="$1"
+	[[ -n "${lines//[[:space:]]/}" ]] || return 1
+	grep -q '^set security zones security-zone ' <<<"$lines"
+}
+
+# hi_zone_service_verdict <display-set-lines> <zone> <service> <want PRESENT|ABSENT>
+#
+#   Print exactly one line: "PASS <why>" or "FAIL <why>". TOTAL.
+#
+#   The smoke's expectation table is only correct for a particular zone
+#   posture. Rather than hard-coding that posture and silently asserting the
+#   wrong matrix if the shared cluster's config changes, the smoke checks the
+#   posture it depends on FIRST and refuses to run otherwise.
+#
+#   Exact whole-line match, so `system-services ssh` is not satisfied by a
+#   hypothetical `system-services ssh-something`, and an ABSENT question is
+#   never answered from an unreadable config.
+hi_zone_service_verdict() {
+	local lines="$1" zone="$2" svc="$3" want="$4" needle found=no
+	if ! hi_config_readable "$lines"; then
+		printf 'FAIL %s\n' "zone posture check (${zone}/${svc}): 'show configuration security zones | display set' returned nothing usable — the precondition is unread, so neither PRESENT nor ABSENT can be concluded"
+		return 0
+	fi
+	needle="set security zones security-zone ${zone} host-inbound-traffic system-services ${svc}"
+	if grep -qxF "$needle" <<<"$lines"; then
+		found=yes
+	fi
+	# `system-services all` subsumes every named service, so an ABSENT
+	# expectation must fail on it too — otherwise a zone opened wide would
+	# still satisfy "ssh is not listed".
+	if grep -qxF "set security zones security-zone ${zone} host-inbound-traffic system-services all" <<<"$lines"; then
+		found=all
+	fi
+	case "$want:$found" in
+	PRESENT:yes) printf 'PASS %s\n' "zone ${zone} admits ${svc}" ;;
+	PRESENT:all) printf 'PASS %s\n' "zone ${zone} admits ${svc} (via system-services all)" ;;
+	PRESENT:no) printf 'FAIL %s\n' "zone ${zone} no longer admits ${svc}; the matrix's ADMIT cells for this zone are stale — update the expectation table, do not weaken the cell" ;;
+	ABSENT:no) printf 'PASS %s\n' "zone ${zone} does not admit ${svc}" ;;
+	ABSENT:yes) printf 'FAIL %s\n' "zone ${zone} now admits ${svc}; the matrix's DENY cells for this zone are stale — update the expectation table, do not weaken the cell" ;;
+	ABSENT:all) printf 'FAIL %s\n' "zone ${zone} carries 'system-services all', which subsumes ${svc}; the matrix's DENY cells for this zone are stale" ;;
+	*) printf 'FAIL %s\n' "zone posture check (${zone}/${svc}): unknown expectation ${want:-<empty>}" ;;
+	esac
+}
+
+# hi_iface_address <display-set-lines> <iface> <unit> <inet|inet6>
+#
+#   Echo the bare address (no prefix length) configured on <iface> unit <unit>
+#   for <family>, or nothing when there is none. Used so the smoke derives its
+#   probe targets from the box's OWN config instead of hard-coding lab
+#   addresses that rot when the cluster is re-addressed.
+#
+#   Prints nothing rather than a partial value on an unreadable config; the
+#   caller treats an empty result as a precondition failure.
+hi_iface_address() {
+	local lines="$1" iface="$2" unit="$3" family="$4" addr
+	hi_config_readable_iface "$lines" || return 0
+	addr="$(awk -v i="$iface" -v u="$unit" -v f="$family" '
+		$1 == "set" && $2 == "interfaces" && $3 == i && $4 == "unit" && $5 == u \
+			&& $6 == "family" && $7 == f && $8 == "address" { print $9; exit }' <<<"$lines")"
+	printf '%s\n' "${addr%%/*}"
+}
+
+# hi_config_readable_iface <display-set-lines>
+#
+#   The interface-stanza twin of hi_config_readable: an empty or
+#   interface-less read must not answer "this interface has no address".
+hi_config_readable_iface() {
+	local lines="$1"
+	[[ -n "${lines//[[:space:]]/}" ]] || return 1
+	grep -q '^set interfaces ' <<<"$lines"
+}
+
+# hi_matrix_stable_verdict <label-a> <observations-a> <label-b> <observations-b>
+#
+#   Print exactly one line: "PASS <why>" or "FAIL <why>". TOTAL.
+#
+#   The HA-failover leg's actual assertion. It is NOT "the matrix passed after
+#   the failover" — that alone is satisfied by a run where every cell went
+#   silent, since a matrix of all-DENY expectations would then read clean. It
+#   is "the matrix is bit-identical to the pre-failover one", so an admission
+#   that silently stopped working across the failover shows up as a DIFF even
+#   where the cell's own expectation would have tolerated it.
+#
+#   Each observations argument is the newline-separated list of
+#   "<cell-name> <observation>" lines from one matrix run.
+hi_matrix_stable_verdict() {
+	local la="$1" a="$2" lb="$3" b="$4" diff
+	if [[ -z "${a//[[:space:]]/}" || -z "${b//[[:space:]]/}" ]]; then
+		printf 'FAIL %s\n' "matrix stability (${la} vs ${lb}): one of the two runs produced no observations at all, so they cannot be compared — an empty run must never read as 'unchanged'"
+		return 0
+	fi
+	if [[ "$(sort <<<"$a")" == "$(sort <<<"$b")" ]]; then
+		printf 'PASS %s\n' "host-inbound matrix identical ${la} and ${lb} ($(grep -c . <<<"$a") cells)"
+		return 0
+	fi
+	diff="$(comm -3 <(sort <<<"$a") <(sort <<<"$b") | tr '\t' ' ' | tr '\n' ';')"
+	printf 'FAIL %s\n' "host-inbound matrix CHANGED between ${la} and ${lb} — differing cells: ${diff}"
+}

--- a/test/incus/host-inbound-probe.py
+++ b/test/incus/host-inbound-probe.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""TCP host-inbound prober for test/incus/test-host-inbound.sh (#6936).
+
+Runs ON the LAN prober container, not on the dev box. Each argument is one
+cell, spelled ``host|port`` (a pipe, because an IPv6 literal is full of
+colons). For every cell it prints exactly one line:
+
+    PROBE <host> <port> <OPEN|REFUSED|TIMEOUT|ERROR> <elapsed-seconds>
+
+The four result words are the RAW observation, not a verdict. Deciding what
+they mean is host-inbound-lib.sh's job (``hi_classify_probe``), and it is kept
+there because that is the half a hermetic selftest can drive.
+
+The distinction that matters is REFUSED vs TIMEOUT. xpfd binds its own
+listeners on 127.0.0.1 only, so a probe of a non-listening port on a
+firewall-local address comes back as an RST *if host-inbound admitted it* and
+as nothing at all if host-inbound dropped it. Collapsing those two -- which is
+what a bare ``nc -z`` exit status does -- would make every negative cell in the
+smoke unfalsifiable.
+
+One line is printed per cell even on an unexpected exception, so a cell can
+never silently vanish from the matrix: a missing line is what the shell side
+scores as BLIND.
+"""
+
+import socket
+import sys
+import time
+
+TIMEOUT = float(__import__("os").environ.get("HI_PROBE_TIMEOUT", "3"))
+
+
+def probe(host: str, port: int) -> str:
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except OSError:
+        return "ERROR"
+    family, socktype, proto, _, sockaddr = infos[0]
+    s = socket.socket(family, socktype, proto)
+    s.settimeout(TIMEOUT)
+    try:
+        s.connect(sockaddr)
+        return "OPEN"
+    except ConnectionRefusedError:
+        return "REFUSED"
+    except socket.timeout:
+        return "TIMEOUT"
+    except OSError:
+        # EHOSTUNREACH / ENETUNREACH / EACCES (an ICMP admin-prohibited
+        # translated by the stack). The packet never reached a host-inbound
+        # decision, so this must NOT read as a deny.
+        return "ERROR"
+    finally:
+        s.close()
+
+
+def main(argv: list) -> int:
+    for spec in argv:
+        host, _, port = spec.rpartition("|")
+        if not host or not port.isdigit():
+            print(f"PROBE {spec} - ERROR 0.00", flush=True)
+            continue
+        started = time.monotonic()
+        try:
+            result = probe(host, int(port))
+        except Exception:  # noqa: BLE001 - a cell must never vanish
+            result = "ERROR"
+        print(
+            f"PROBE {host} {port} {result} {time.monotonic() - started:.2f}",
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/incus/host-inbound-selftest.sh
+++ b/test/incus/host-inbound-selftest.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Hermetic self-test for test/incus/host-inbound-lib.sh (#6936).
+#
+# No cluster, no incus, no network. Runs in `make test-host-inbound-lib`.
+#
+# The rows that matter are DENY_SILENT_CONTROL_*. A probe cannot observe a
+# deny; it observes SILENCE. "the firewall dropped it" and "my prober never
+# reached the firewall" are the same reading, and only the run's positive
+# control separates them. Under any form that scores a bare timeout as PASS,
+# the two collapse — which is precisely the defect #7798 had to remove from the
+# FBF smoke, and which the #6936 comment asks to be avoided here on the first
+# pass rather than after someone notices.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./host-inbound-lib.sh
+. "${SCRIPT_DIR}/host-inbound-lib.sh"
+
+pass=0
+fail=0
+
+# --- classification: raw prober output -> admission vocabulary --------------
+checkc() {
+	local name="$1" want="$2" out="$3" target="$4" port="$5" got
+	got="$(hi_classify_probe "$out" "$target" "$port")"
+	if [[ "$got" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-34s -> %s\n' "$name" "$got"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-34s -> want %s got %s\n' "$name" "$want" "$got"
+	fi
+	[[ "$(grep -c . <<<"$got")" -eq 1 ]] || {
+		fail=$((fail + 1)); printf 'FAIL %-34s -> not exactly one word: %q\n' "$name" "$got"; }
+}
+
+MATRIX_OUT='PROBE 10.0.61.1 22 REFUSED 0.00
+PROBE 10.0.61.1 23 TIMEOUT 3.00
+PROBE 172.16.50.8 22 TIMEOUT 3.00
+PROBE 2001:559:8585:ef00::1 22 OPEN 0.01
+PROBE 198.51.100.7 22 ERROR 0.00'
+
+checkc CLS_REFUSED_IS_ADMITTED  ADMITTED  "$MATRIX_OUT" 10.0.61.1 22
+checkc CLS_OPEN_IS_ADMITTED     ADMITTED  "$MATRIX_OUT" 2001:559:8585:ef00::1 22
+checkc CLS_TIMEOUT_IS_SILENT    SILENT    "$MATRIX_OUT" 10.0.61.1 23
+checkc CLS_V6_TARGET_MATCHES    SILENT    "$MATRIX_OUT" 172.16.50.8 22
+checkc CLS_ERROR_IS_UNREACHED   UNREACHED "$MATRIX_OUT" 198.51.100.7 22
+# A cell the prober never reported must be BLIND, never SILENT: "the prober
+# said nothing about this cell" must not be able to pose as "the firewall said
+# nothing to this cell".
+checkc CLS_MISSING_CELL_IS_BLIND BLIND    "$MATRIX_OUT" 10.0.61.1 80
+checkc CLS_EMPTY_OUTPUT_IS_BLIND BLIND    ""            10.0.61.1 22
+checkc CLS_GARBAGE_IS_BLIND      BLIND    "incus: command not found" 10.0.61.1 22
+checkc CLS_UNKNOWN_WORD_IS_BLIND BLIND    "PROBE 10.0.61.1 22 WAT 0.00" 10.0.61.1 22
+# Port must match as a whole field: a cell for port 2 must not be answered by
+# the port-22 line.
+checkc CLS_PORT_NEAR_MISS        BLIND    "$MATRIX_OUT" 10.0.61.1 2
+
+# --- classification: ping ---------------------------------------------------
+checkp() {
+	local name="$1" want="$2" out="$3" got
+	got="$(hi_classify_ping "$out")"
+	if [[ "$got" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-34s -> %s\n' "$name" "$got"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-34s -> want %s got %s\n' "$name" "$want" "$got"
+	fi
+}
+
+checkp PING_REPLIES_ADMITTED ADMITTED '3 packets transmitted, 3 received, 0% packet loss, time 2044ms'
+checkp PING_PARTIAL_ADMITTED ADMITTED '3 packets transmitted, 1 received, 66% packet loss, time 2044ms'
+checkp PING_NO_REPLY_SILENT  SILENT   '3 packets transmitted, 0 received, 100% packet loss, time 2044ms'
+checkp PING_UNREACH_IS_ERR   UNREACHED 'From 10.0.61.9 icmp_seq=1 Destination Host Unreachable
+3 packets transmitted, 0 received, +3 errors, 100% packet loss, time 2044ms'
+# No statistics line at all means the prober never ran — BLIND, not SILENT.
+checkp PING_EMPTY_IS_BLIND   BLIND    ''
+checkp PING_INCUS_ERR_BLIND  BLIND    'Error: Instance is not running'
+
+# --- THE CORE TABLE: every (expectation x observation x control) combination -
+checkv() {
+	local name="$1" want="$2" expect="$3" obs="$4" control="$5" got verdict
+	got="$(hi_cell_verdict "$expect" "$obs" "$control")"
+	verdict="${got%% *}"
+	if [[ "$verdict" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-34s -> %s\n' "$name" "$verdict"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-34s -> want %s got %s (%s)\n' "$name" "$want" "$verdict" "$got"
+	fi
+	# TOTALITY: exactly one line, and it is one of the two known words.
+	[[ "$(grep -c . <<<"$got")" -eq 1 ]] || {
+		fail=$((fail + 1)); printf 'FAIL %-34s -> verdict was not exactly one line: %q\n' "$name" "$got"; }
+	[[ "$verdict" == PASS || "$verdict" == FAIL ]] || {
+		fail=$((fail + 1)); printf 'FAIL %-34s -> verdict word %q is neither PASS nor FAIL\n' "$name" "$verdict"; }
+}
+
+# ADMIT cells.
+checkv ADMIT_ADMITTED        PASS ADMIT ADMITTED  ADMITTED
+checkv ADMIT_SILENT          FAIL ADMIT SILENT    ADMITTED
+checkv ADMIT_UNREACHED       FAIL ADMIT UNREACHED ADMITTED
+checkv ADMIT_BLIND           FAIL ADMIT BLIND     ADMITTED
+checkv ADMIT_EMPTY_OBS       FAIL ADMIT ""        ADMITTED
+
+# DENY cells. The leak direction.
+checkv DENY_ADMITTED_IS_LEAK FAIL DENY  ADMITTED  ADMITTED
+
+# THE MIDDLE ROW. Same observation, same expectation; only the control
+# differs. Any form that scores a bare timeout as "denied" makes these four
+# indistinguishable, and the smoke then certifies a deny on a prober that was
+# never shown able to reach the box.
+checkv DENY_SILENT_CONTROL_OK      PASS DENY SILENT ADMITTED
+checkv DENY_SILENT_CONTROL_SILENT  FAIL DENY SILENT SILENT
+checkv DENY_SILENT_CONTROL_UNREACH FAIL DENY SILENT UNREACHED
+checkv DENY_SILENT_CONTROL_BLIND   FAIL DENY SILENT BLIND
+checkv DENY_SILENT_CONTROL_EMPTY   FAIL DENY SILENT ""
+
+# An ICMP unreachable is not a deny even with a healthy control: the packet
+# never reached a host-inbound decision.
+checkv DENY_UNREACHED_IS_NOT_DENY  FAIL DENY UNREACHED ADMITTED
+checkv DENY_BLIND                  FAIL DENY BLIND     ADMITTED
+checkv DENY_EMPTY_OBS              FAIL DENY ""        ADMITTED
+
+# A malformed table must fail loudly rather than fall through to a healthy word.
+checkv UNKNOWN_EXPECTATION         FAIL WAT   ADMITTED ADMITTED
+checkv EMPTY_EXPECTATION           FAIL ""    ADMITTED ADMITTED
+
+# --- zone posture precondition ----------------------------------------------
+ZONES='set security zones security-zone mgmt interfaces fxp0
+set security zones security-zone mgmt host-inbound-traffic system-services ssh
+set security zones security-zone wan interfaces reth0.50
+set security zones security-zone wan interfaces reth0.80
+set security zones security-zone wan host-inbound-traffic system-services ping
+set security zones security-zone wan host-inbound-traffic system-services gre
+set security zones security-zone lan interfaces reth1
+set security zones security-zone lan host-inbound-traffic system-services ssh
+set security zones security-zone lan host-inbound-traffic system-services ping'
+
+checkz() {
+	local name="$1" want="$2" lines="$3" zone="$4" svc="$5" expect="$6" got verdict
+	got="$(hi_zone_service_verdict "$lines" "$zone" "$svc" "$expect")"
+	verdict="${got%% *}"
+	if [[ "$verdict" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-34s -> %s\n' "$name" "$verdict"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-34s -> want %s got %s (%s)\n' "$name" "$want" "$verdict" "$got"
+	fi
+	[[ "$(grep -c . <<<"$got")" -eq 1 ]] || {
+		fail=$((fail + 1)); printf 'FAIL %-34s -> not exactly one line: %q\n' "$name" "$got"; }
+}
+
+checkz ZONE_LAN_ADMITS_SSH    PASS "$ZONES" lan ssh PRESENT
+checkz ZONE_WAN_DENIES_SSH    PASS "$ZONES" wan ssh ABSENT
+checkz ZONE_WAN_ADMITS_PING   PASS "$ZONES" wan ping PRESENT
+checkz ZONE_LAN_SSH_NOT_ABSENT FAIL "$ZONES" lan ssh ABSENT
+checkz ZONE_WAN_SSH_NOT_PRESENT FAIL "$ZONES" wan ssh PRESENT
+# THE MIDDLE ROW AGAIN, for the precondition: an unreadable config must not be
+# allowed to answer an ABSENT question. "wan does not admit ssh" and "I could
+# not read the config" are the same string to grep, and only one of them is a
+# reason to run the matrix.
+checkz ZONE_EMPTY_CONFIG_BLIND    FAIL ""  wan ssh ABSENT
+checkz ZONE_WS_CONFIG_BLIND       FAIL "   " wan ssh ABSENT
+checkz ZONE_CLI_ERROR_BLIND       FAIL "error: unknown command" wan ssh ABSENT
+checkz ZONE_NO_ZONES_BLIND        FAIL "set interfaces reth1 unit 0 family inet address 10.0.61.1/24" wan ssh ABSENT
+# `system-services all` subsumes every named service, so an ABSENT expectation
+# must fail on it. Without this, a zone opened wide still satisfies "ssh is not
+# listed" and every DENY cell for that zone silently becomes a false pass.
+ZONES_ALL='set security zones security-zone wan interfaces reth0.50
+set security zones security-zone wan host-inbound-traffic system-services all'
+checkz ZONE_ALL_DEFEATS_ABSENT    FAIL "$ZONES_ALL" wan ssh ABSENT
+checkz ZONE_ALL_SATISFIES_PRESENT PASS "$ZONES_ALL" wan ssh PRESENT
+# Whole-line match: a longer service name sharing the prefix is not the same
+# token (the near-miss direction #7798's NEAR_MISS_GW row caught in the FBF lib).
+ZONES_NEAR='set security zones security-zone wan interfaces reth0.50
+set security zones security-zone wan host-inbound-traffic system-services ssh-alt'
+checkz ZONE_NEAR_MISS_SERVICE     PASS "$ZONES_NEAR" wan ssh ABSENT
+checkz ZONE_UNKNOWN_EXPECT        FAIL "$ZONES" wan ssh MAYBE
+
+# --- probe-target derivation -------------------------------------------------
+IFACES='set interfaces reth1 unit 0 family inet address 10.0.61.1/24
+set interfaces reth1 unit 0 family inet6 address 2001:559:8585:ef00::1/64
+set interfaces reth0 unit 50 family inet address 172.16.50.8/24
+set interfaces reth0 unit 80 family inet address 172.16.80.8/24
+set interfaces reth0 unit 80 family inet6 address 2001:559:8585:80::8/64'
+
+checka() {
+	local name="$1" want="$2" lines="$3" iface="$4" unit="$5" fam="$6" got
+	got="$(hi_iface_address "$lines" "$iface" "$unit" "$fam")"
+	if [[ "$got" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-34s -> %s\n' "$name" "${got:-<empty>}"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-34s -> want %q got %q\n' "$name" "$want" "$got"
+	fi
+}
+
+checka ADDR_LAN_V4      10.0.61.1               "$IFACES" reth1 0  inet
+checka ADDR_LAN_V6      2001:559:8585:ef00::1   "$IFACES" reth1 0  inet6
+checka ADDR_VLAN50_V4   172.16.50.8             "$IFACES" reth0 50 inet
+checka ADDR_VLAN80_V6   2001:559:8585:80::8     "$IFACES" reth0 80 inet6
+# Unit is a whole field: unit 8 must not be answered by the unit-80 line.
+checka ADDR_UNIT_NEAR_MISS ""                   "$IFACES" reth0 8  inet
+checka ADDR_MISSING_FAMILY ""                   "$IFACES" reth0 50 inet6
+# An unreadable config yields nothing — the caller treats empty as a
+# precondition failure, so this must not fabricate an address.
+checka ADDR_EMPTY_CONFIG   ""                   ""        reth1 0  inet
+checka ADDR_NO_IFACES      ""                   "set security zones security-zone lan interfaces reth1" reth1 0 inet
+
+# --- matrix stability across a failover --------------------------------------
+checkm() {
+	local name="$1" want="$2" a="$3" b="$4" got verdict
+	got="$(hi_matrix_stable_verdict before "$a" after "$b")"
+	verdict="${got%% *}"
+	if [[ "$verdict" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-34s -> %s\n' "$name" "$verdict"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-34s -> want %s got %s (%s)\n' "$name" "$want" "$verdict" "$got"
+	fi
+	[[ "$(grep -c . <<<"$got")" -eq 1 ]] || {
+		fail=$((fail + 1)); printf 'FAIL %-34s -> not exactly one line: %q\n' "$name" "$got"; }
+}
+
+BASE='lan-v4-ssh ADMITTED
+lan-v4-telnet SILENT
+wan-vlan50-v4-ssh SILENT'
+checkm MATRIX_IDENTICAL   PASS "$BASE" "$BASE"
+# Order must not matter; content must.
+checkm MATRIX_REORDERED   PASS "$BASE" 'wan-vlan50-v4-ssh SILENT
+lan-v4-ssh ADMITTED
+lan-v4-telnet SILENT'
+# The regression this leg exists for: an admission that silently stopped
+# working across the failover. Both matrices' own cells could still be scored
+# against their expectations; only the DIFF sees it.
+checkm MATRIX_ADMIT_LOST  FAIL "$BASE" 'lan-v4-ssh SILENT
+lan-v4-telnet SILENT
+wan-vlan50-v4-ssh SILENT'
+checkm MATRIX_DENY_LEAKED FAIL "$BASE" 'lan-v4-ssh ADMITTED
+lan-v4-telnet SILENT
+wan-vlan50-v4-ssh ADMITTED'
+checkm MATRIX_CELL_VANISHED FAIL "$BASE" 'lan-v4-ssh ADMITTED
+lan-v4-telnet SILENT'
+# THE MIDDLE ROW, third time: an empty run must never read as "unchanged".
+checkm MATRIX_AFTER_EMPTY   FAIL "$BASE" ''
+checkm MATRIX_BEFORE_EMPTY  FAIL ''      "$BASE"
+checkm MATRIX_BOTH_EMPTY    FAIL ''      ''
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/test/incus/test-host-inbound.sh
+++ b/test/incus/test-host-inbound.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# xpf on-wire host-inbound smoke — #6936 (residual of #4422).
+#
+# Covers the two legs the pkg/config host-inbound suite structurally cannot:
+# host-inbound resolved on a TAGGED VLAN sub-unit, and admission UNCHANGED
+# across an HA failover. Commits nothing. Full rationale — including why a
+# DENY cell is scored against a same-address positive control and why the
+# failover leg diffs the matrix rather than re-scoring it — is in the block
+# below the lock preamble and in docs/host-inbound-service-matrix.md.
+#
+# Usage:
+#   ./test/incus/test-host-inbound.sh                  # matrix only (fast)
+#   ./test/incus/test-host-inbound.sh --with-failover  # + HA-failover leg
+#
+# Env:
+#   HI_PROBE_TIMEOUT=3   seconds a TCP cell waits before scoring TIMEOUT
+#   HI_SETTLE=8          seconds to let VRRP settle after a manual failover
+
+set -euo pipefail
+
+case "${1:-}" in
+-h | --help)
+	sed -n '2,17p' "$0"
+	exit 0
+	;;
+esac
+
+# #1875/#4020: with --with-failover this smoke MOVES REDUNDANCY GROUPS on the
+# SHARED loss cluster. Re-exec under the incus-admin group if needed, then
+# serialize as a #1875 lock cell so a concurrent deploy/smoke cannot collide
+# with our failover (it queues behind a held /tmp/xpf-cluster.lock). Taken
+# unconditionally rather than only for the failover leg: the matrix run pushes
+# a file into the LAN prober and reads cluster state, and a lock cell that is
+# sometimes taken is a lock cell nobody can reason about.
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-host-inbound $*" "$0" "$@"
+
+# WHAT THIS COVERS THAT THE UNIT TESTS CANNOT
+#
+# pkg/config carries a large host-inbound suite (host_inbound_per_iface_3362,
+# host_inbound_view_3654, host_inbound_tokens, ...). Every one of them shows
+# what the COMPILER produced. None can show what the BOX ADMITTED. #6936 names
+# the two on-wire legs that were never covered:
+#
+#   VLAN            — host-inbound resolved on a TAGGED sub-unit (reth0.50 /
+#                     reth0.80), not just on an untagged interface. The
+#                     interesting direction is the DENY: the wan zone admits
+#                     ping and gre but not ssh, so a tcp/22 probe to a VLAN
+#                     sub-unit address must get nothing back while a ping to
+#                     the SAME address gets a reply.
+#   HA failover     — admission is UNCHANGED after the redundancy groups move
+#                     to the peer node. The failure mode is silent: an
+#                     admission that quietly stops working after a failover
+#                     looks, to a prober, exactly like a service that is
+#                     correctly denied.
+#
+# HOW THE SILENT FAILURE MODE IS KEPT VISIBLE
+#
+# A probe cannot observe a deny. It observes SILENCE, and "the firewall dropped
+# it" and "my prober never reached the firewall" are the same reading. So:
+#
+#   * every DENY cell is scored against a POSITIVE CONTROL at the SAME
+#     ADDRESS, SAME FAMILY, SAME RUN, SAME PROBER — an ICMP echo to that exact
+#     address. A DENY cell whose control did not answer is scored FAIL
+#     (blind), never PASS. host-inbound-lib.sh makes that verdict total and
+#     host-inbound-selftest.sh drives the middle row.
+#   * the prober distinguishes an RST from a timeout. xpfd binds its own
+#     listeners on 127.0.0.1 only, so an admitted probe of a non-listening
+#     port comes back as an RST — a packet-carrying POSITIVE signal that
+#     host-inbound let it through. Without that, "admitted, nothing listening"
+#     and "dropped" would be the same timeout.
+#   * the failover leg asserts the matrix is IDENTICAL across the failover,
+#     not merely that it still passes. A run where every admission silently
+#     died would still satisfy every DENY cell; only the diff sees it.
+#
+# It commits NOTHING. It reads the already-committed cluster config, derives
+# its probe targets from it, and refuses to run if the zone posture it depends
+# on has changed — so it can neither dirty the shared cluster nor silently
+# assert a stale matrix.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+# shellcheck source=test/incus/host-inbound-lib.sh
+source "${SCRIPT_DIR}/host-inbound-lib.sh"
+
+WITH_FAILOVER=0
+for arg in "$@"; do
+	case "$arg" in
+	--with-failover) WITH_FAILOVER=1 ;;
+	-h | --help) ;; # handled before the lock preamble
+	*)
+		echo "unknown argument: $arg" >&2
+		exit 2
+		;;
+	esac
+done
+
+HI_PROBE_TIMEOUT="${HI_PROBE_TIMEOUT:-3}"
+HI_SETTLE="${HI_SETTLE:-8}"
+PROBE_SRC="${SCRIPT_DIR}/host-inbound-probe.py"
+REMOTE_PROBE="/tmp/xpf-host-inbound-probe.py"
+CLI=/usr/local/sbin/cli
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+info() { echo "==> $*"; }
+pass() { echo "  PASS  $*"; PASS=$((PASS + 1)); }
+fail() {
+	echo "  FAIL  $*"
+	FAIL=$((FAIL + 1))
+	ERRORS+=("$*")
+}
+die() {
+	echo "FATAL: $*" >&2
+	exit 2
+}
+
+# score <verdict-line> — map a "PASS <why>" / "FAIL <why>" line from the lib
+# onto this script's counters. The lib's verdicts are TOTAL, so the catch-all
+# is unreachable in principle; it is here because a verdict word this script
+# does not recognise must be an error, not a silent skip.
+score() {
+	local label="$1" verdict="$2"
+	case "$verdict" in
+	PASS\ *) pass "${label}: ${verdict#PASS }" ;;
+	FAIL\ *) fail "${label}: ${verdict#FAIL }" ;;
+	*) fail "${label}: verdict helper returned an unrecognised line: ${verdict:-<empty>}" ;;
+	esac
+}
+
+# ── Phase 0: preconditions ───────────────────────────────────────────
+
+[[ -f "$PROBE_SRC" ]] || die "prober missing: $PROBE_SRC"
+
+# `grep -q` would exit on the first match and SIGPIPE `incus info`; under
+# `set -o pipefail` the pipeline then reports the WRITER's failure and a
+# RUNNING instance reads as down. Consume the whole stream (the same shape
+# test-active-active.sh uses) so the check measures the status, not the pipe.
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
+	[[ "$(incus info "$inst" 2>/dev/null | grep -o "RUNNING" | head -1)" == "RUNNING" ]] \
+		|| die "$inst is not RUNNING — bring the cluster up first (make cluster-deploy)"
+done
+info "cluster instances up: $FW0, $FW1, $CLUSTER_LAN_HOST"
+
+# Read the ACTIVE config in flat-set form. `display set` gives whole-line
+# tokens, so the posture questions below are exact-line matches rather than
+# brace parsing.
+ZONE_SETS="$(incus exec "$FW0" -- "$CLI" -c "show configuration security zones | display set" 2>/dev/null || true)"
+IFACE_SETS="$(incus exec "$FW0" -- "$CLI" -c "show configuration interfaces | display set" 2>/dev/null || true)"
+
+hi_config_readable "$ZONE_SETS" \
+	|| die "could not read 'show configuration security zones | display set' from $FW0 — the matrix's expectations are unverified, so refusing to run (an unreadable config answers every ABSENT question the way a healthy one does)"
+hi_config_readable_iface "$IFACE_SETS" \
+	|| die "could not read 'show configuration interfaces | display set' from $FW0 — probe targets are derived from it"
+info "read $(grep -c . <<<"$ZONE_SETS") zone and $(grep -c . <<<"$IFACE_SETS") interface set-lines from $FW0"
+
+# The matrix below is only correct for this posture. Check it rather than
+# assume it: on a shared cluster the config is not this script's to own, and
+# an expectation table that has silently gone stale reports a clean pass while
+# asserting the wrong thing.
+info "Phase 0: zone posture the matrix depends on"
+score "posture lan/ssh" "$(hi_zone_service_verdict "$ZONE_SETS" lan ssh PRESENT)"
+score "posture lan/ping" "$(hi_zone_service_verdict "$ZONE_SETS" lan ping PRESENT)"
+score "posture wan/ping" "$(hi_zone_service_verdict "$ZONE_SETS" wan ping PRESENT)"
+score "posture wan/ssh" "$(hi_zone_service_verdict "$ZONE_SETS" wan ssh ABSENT)"
+score "posture lan/telnet" "$(hi_zone_service_verdict "$ZONE_SETS" lan telnet ABSENT)"
+score "posture wan/telnet" "$(hi_zone_service_verdict "$ZONE_SETS" wan telnet ABSENT)"
+for tagged in reth0.50 reth0.80; do
+	if grep -qxF "set security zones security-zone wan interfaces ${tagged}" <<<"$ZONE_SETS"; then
+		pass "posture wan/${tagged}: the wan zone owns the tagged sub-unit (this is the VLAN leg's subject)"
+	else
+		fail "posture wan/${tagged}: the wan zone no longer owns this VLAN sub-unit — the VLAN cells below would measure some other zone's posture"
+	fi
+done
+[[ "$FAIL" -eq 0 ]] || die "zone posture precondition failed — update the expectation table rather than weakening a cell"
+
+# ── Phase 1: derive probe targets from the box's own config ──────────
+
+declare -A TARGET_ADDR TARGET_FAMILY TARGET_ZONE
+add_target() {
+	local name="$1" iface="$2" unit="$3" family="$4" zone="$5" addr
+	addr="$(hi_iface_address "$IFACE_SETS" "$iface" "$unit" "$family")"
+	[[ -n "$addr" ]] \
+		|| die "no ${family} address configured on ${iface} unit ${unit} — cannot derive the ${name} probe target (refusing to fall back to a hard-coded lab address, which would silently probe something else)"
+	TARGET_ADDR[$name]="$addr"
+	TARGET_FAMILY[$name]="$family"
+	TARGET_ZONE[$name]="$zone"
+}
+
+# reth1 is UNTAGGED and in the lan zone (admits ssh + ping): the positive
+# controls and the per-service discrimination cells.
+add_target lan-v4 reth1 0 inet lan
+add_target lan-v6 reth1 0 inet6 lan
+# reth0.50 / reth0.80 are TAGGED sub-units in the wan zone (admits ping, not
+# ssh): the VLAN leg, both tags, both families.
+add_target wan-vlan50-v4 reth0 50 inet wan
+add_target wan-vlan50-v6 reth0 50 inet6 wan
+add_target wan-vlan80-v4 reth0 80 inet wan
+add_target wan-vlan80-v6 reth0 80 inet6 wan
+
+TARGET_ORDER=(lan-v4 lan-v6 wan-vlan50-v4 wan-vlan50-v6 wan-vlan80-v4 wan-vlan80-v6)
+for t in "${TARGET_ORDER[@]}"; do
+	info "target ${t} = ${TARGET_ADDR[$t]} (zone ${TARGET_ZONE[$t]}, ${TARGET_FAMILY[$t]})"
+done
+
+# Remove first: an existing 0755 file from a previous run makes the push fail
+# with "permission denied" (the same shape test-fbf-steering.sh guards with an
+# `rm -f` before its own push).
+incus exec "$CLUSTER_LAN_HOST" -- rm -f "$REMOTE_PROBE" >/dev/null 2>&1 || true
+incus file push --mode 0755 "$PROBE_SRC" "${CLUSTER_LAN_HOST}${REMOTE_PROBE}" >/dev/null \
+	|| die "could not push the prober to $CLUSTER_LAN_HOST"
+
+# ── Phase 2: the matrix ──────────────────────────────────────────────
+
+# run_matrix <label>
+#   Probe every cell once and echo "<cell-name> <observation>" lines on stdout.
+#   Diagnostics go to stderr so the caller can capture the observations
+#   cleanly for hi_matrix_stable_verdict.
+run_matrix() {
+	local label="$1" t addr specs=() probe_out ping_out obs
+	for t in "${TARGET_ORDER[@]}"; do
+		addr="${TARGET_ADDR[$t]}"
+		specs+=("${addr}|22" "${addr}|23")
+	done
+	echo "==> [${label}] TCP cells: ${#specs[@]}" >&2
+	probe_out="$(incus exec "$CLUSTER_LAN_HOST" --env "HI_PROBE_TIMEOUT=${HI_PROBE_TIMEOUT}" \
+		-- python3 "$REMOTE_PROBE" "${specs[@]}" 2>&1 || true)"
+	echo "$probe_out" | sed 's/^/    /' >&2
+
+	for t in "${TARGET_ORDER[@]}"; do
+		addr="${TARGET_ADDR[$t]}"
+		# ICMP: the per-target positive control. -n so a broken resolver
+		# cannot stall the cell; 3 packets so a single loss is not the
+		# whole reading.
+		if [[ "${TARGET_FAMILY[$t]}" == inet6 ]]; then
+			ping_out="$(incus exec "$CLUSTER_LAN_HOST" -- ping -6 -n -c 3 -W 2 "$addr" 2>&1 || true)"
+		else
+			ping_out="$(incus exec "$CLUSTER_LAN_HOST" -- ping -4 -n -c 3 -W 2 "$addr" 2>&1 || true)"
+		fi
+		obs="$(hi_classify_ping "$ping_out")"
+		printf '%s %s\n' "${t}-ping" "$obs"
+		printf '%s %s\n' "${t}-ssh" "$(hi_classify_probe "$probe_out" "$addr" 22)"
+		printf '%s %s\n' "${t}-telnet" "$(hi_classify_probe "$probe_out" "$addr" 23)"
+	done
+}
+
+# score_matrix <label> <observations>
+#   Apply the expectation table. Each DENY cell is controlled by the ping cell
+#   at the SAME address — not by a global "the cluster is up" check, because a
+#   route that stopped reaching THIS address would make every DENY cell at it
+#   pass for the wrong reason.
+score_matrix() {
+	local label="$1" obs_lines="$2" t control ssh_expect
+	for t in "${TARGET_ORDER[@]}"; do
+		control="$(awk -v c="${t}-ping" '$1 == c { print $2; exit }' <<<"$obs_lines")"
+		control="${control:-BLIND}"
+		# ping is admitted in BOTH zones, so every ping cell is an ADMIT
+		# cell; it is simultaneously the control for the two TCP cells at
+		# this address.
+		score "[${label}] ${t}-ping (control)" \
+			"$(hi_cell_verdict ADMIT "$control" "$control")"
+		if [[ "${TARGET_ZONE[$t]}" == lan ]]; then ssh_expect=ADMIT; else ssh_expect=DENY; fi
+		score "[${label}] ${t}-ssh (zone ${TARGET_ZONE[$t]} -> ${ssh_expect})" \
+			"$(hi_cell_verdict "$ssh_expect" "$(awk -v c="${t}-ssh" '$1 == c { print $2; exit }' <<<"$obs_lines")" "$control")"
+		# telnet is admitted by NO zone here. On the lan address this is
+		# the strongest cell in the file: same address, same prober, one
+		# port admitted and another not — a reading no routing or
+		# reachability story can explain away.
+		score "[${label}] ${t}-telnet (no zone admits telnet -> DENY)" \
+			"$(hi_cell_verdict DENY "$(awk -v c="${t}-telnet" '$1 == c { print $2; exit }' <<<"$obs_lines")" "$control")"
+	done
+}
+
+rg_primary() {
+	local rg="$1"
+	incus exec "$FW0" -- "$CLI" -c "show chassis cluster status" 2>/dev/null |
+		awk -v rg="$rg" '
+			$0 ~ ("Redundancy group: " rg " ,") { inrg = 1; next }
+			inrg && /Redundancy group:/ { inrg = 0 }
+			inrg && $3 == "primary" { print $1; exit }'
+}
+
+info "Phase 1: host-inbound matrix (baseline)"
+BASELINE="$(run_matrix baseline)"
+score_matrix baseline "$BASELINE"
+
+# ── Phase 3: the HA-failover leg ─────────────────────────────────────
+
+if [[ "$WITH_FAILOVER" -eq 1 ]]; then
+	FAILED_OVER=0
+	restore_primacy() {
+		[[ "$FAILED_OVER" -eq 1 ]] || return 0
+		echo "==> Restoring node0 primacy for RG1/RG2" >&2
+		local rg
+		for rg in 1 2; do
+			incus exec "$FW0" -- "$CLI" -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+			incus exec "$FW1" -- "$CLI" -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+			# `failover reset` only clears the MANUAL latch; with preempt
+			# disabled the current master keeps the group, so an explicit
+			# failover back to node 0 is required or the shared cluster is
+			# left inverted for the next lane.
+			incus exec "$FW0" -- "$CLI" -c "request chassis cluster failover redundancy-group $rg node 0" >/dev/null 2>&1 || true
+		done
+		sleep "$HI_SETTLE"
+		for rg in 1 2; do
+			incus exec "$FW0" -- "$CLI" -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+			incus exec "$FW1" -- "$CLI" -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+		done
+	}
+	trap restore_primacy EXIT
+
+	info "Phase 2: manual failover of RG1 (WAN/reth0) and RG2 (LAN/reth1) to node1"
+	FAILED_OVER=1
+	for rg in 1 2; do
+		incus exec "$FW1" -- "$CLI" -c "request chassis cluster failover redundancy-group $rg node 1" 2>&1 | sed 's/^/    /'
+	done
+	sleep "$HI_SETTLE"
+	for rg in 1 2; do
+		if [[ "$(rg_primary "$rg")" == "node1" ]]; then
+			pass "RG${rg} primary is node1 after the manual failover"
+		else
+			fail "RG${rg} primary is '$(rg_primary "$rg")' after the manual failover, expected node1 — the leg below would measure the pre-failover node and prove nothing"
+		fi
+	done
+
+	info "Phase 3: host-inbound matrix (after failover to node1)"
+	AFTER="$(run_matrix after-failover)"
+	score_matrix after-failover "$AFTER"
+	# The real assertion. Scoring each cell against its expectation is not
+	# enough: a run in which every admission silently died still satisfies
+	# every DENY cell. Only the diff against the pre-failover matrix sees an
+	# admission that stopped working.
+	score "matrix stability across failover" \
+		"$(hi_matrix_stable_verdict baseline "$BASELINE" after-failover "$AFTER")"
+
+	info "Phase 4: failing back to node0 and re-checking"
+	restore_primacy
+	FAILED_OVER=0
+	trap - EXIT
+	for rg in 1 2; do
+		if [[ "$(rg_primary "$rg")" == "node0" ]]; then
+			pass "RG${rg} primary is node0 after failback"
+		else
+			fail "RG${rg} primary is '$(rg_primary "$rg")' after failback, expected node0 — the SHARED cluster is left inverted for the next lane; fix it before leaving"
+		fi
+	done
+	FAILBACK="$(run_matrix after-failback)"
+	score_matrix after-failback "$FAILBACK"
+	score "matrix stability across failback" \
+		"$(hi_matrix_stable_verdict baseline "$BASELINE" after-failback "$FAILBACK")"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo
+echo "════════════════════════════════════════"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "════════════════════════════════════════"
+if [[ "$FAIL" -gt 0 ]]; then
+	echo
+	echo "Failures:"
+	for e in "${ERRORS[@]}"; do echo "  - $e"; done
+	exit 1
+fi
+echo "PASS: on-wire host-inbound matrix complete"


### PR DESCRIPTION
Closes #6936

## Premise first: the issue's seven rows, re-checked at master (759f776a2)

#6936 is a residual list filed against a closed tracker, so every row was
verified at master rather than taken from the issue text.

| # | row | status at master | disposition |
|---|---|---|---|
| 1 | PBR: dual-provider failure modes | live, **venue does not exist** | close |
| 2 | PBR: dual-public-IP SNAT | live, **venue does not exist** | close |
| 3 | PBR: throughput under dual-path load | live, **venue does not exist** | close |
| 4 | PBR: path-divergence under uplink failure | live, **venue is broken** (#7796) | blocked, not built |
| 5 | host-inbound VLAN smoke | live, venue exists | **BUILT** |
| 6 | host-inbound duplicate-address smoke | **unreachable by construction** | close |
| 7 | host-inbound HA-failover smoke | live, venue exists | **BUILT** |

### Rows 1-3 — there is no second uplink, and there is not going to be

The two "providers" in the FBF fixture are `reth0.50` and `reth0.80`: two VLAN
tags on **one** physical WAN interface, one mlx5 VF pair, one upstream switch.
Measured on `loss:xpf-userspace-fw0`, both live on `ge-0-0-2`. Dual-provider
failure modes, dual-public-IP SNAT and dual-path throughput each require two
independently failable paths, and nothing in this lab supplies one. (The
CLAUDE.md note about `172.16.100.x` reaching "a different `loss:` uplink path"
is a warning against using it as a data path, not a second provider.)

These are not deferred pending effort. The honest cost is a second physical
uplink into the lab — a hardware decision, not a work item.

### Row 4 — the venue is broken, by a defect this issue's own round 1 found

`test-fbf-steering.sh` cannot reach Phase 2 today. **#7796** (open): the FBF
DSCP steering rule fails to install for *every* DSCP name — `rules.go:732`
emits the shifted DSCP as `FRA_TOS`, which the kernel validates against
`IPTOS_TOS_MASK` (0x1E) and rejects for anything >= 8, so the whole commit
fails and the fixture never lands. Re-verified at master: `rules.go:732-733`
still emits `rule.Tos`, and `rules.go:1128` still records "the netlink layer
has no `FRA_DSCP`".

Path-divergence is the one PBR row that is automatable in principle, and it is
**separable** from the broken half — it exercises the RPM probe plus the
ip-monitoring `preferred-route` repoint of `ISP-B.inet.0`, not the DSCP
steering filter, so a reduced fixture would commit. Not built here on scope
grounds rather than difficulty: a second FBF fixture that deliberately omits
the feature the venue exists to test leaves two fixtures to keep in step, and
the first thing a #7796 fix will want is the full one. It is one script change
once #7796 lands.

### Row 6 — the config the smoke needs is hard-rejected at commit

This is not a lab-venue problem; it is the product refusing the state.
`validateDuplicateHostLocalAddressStrict` (`pkg/config/dup_host_local_address.go:284`,
wired at `compiler_uniformgates_cluster_zone.go:343`) hard-rejects the
ambiguous topology on the strict commit / commit-check path. A smoke cannot
apply the config it would need to observe.

The state is reachable only through the tolerant `load` / peer-sync path — the
deliberate #1960 no-brick concession — and that path's runtime surface is
already covered where it is observable, by
`pkg/daemon/host_inbound_ambiguous_3718_test.go` and
`pkg/api/metrics_host_inbound_ambiguous_3718_test.go` (whose fixture asserts
the strict path rejects while the tolerant path accepts, so the gate's liveness
is itself pinned). Reaching it on the wire would mean writing the rejected
config straight into the config DB and restarting — measuring a state the
product refuses to enter. Recorded in `docs/host-inbound-service-matrix.md` so
the next reader does not re-derive it.

## Rows 5 + 7 — what is built

`test/incus/test-host-inbound.sh`, with `host-inbound-lib.sh` (total verdicts),
`host-inbound-probe.py` (the prober) and `host-inbound-selftest.sh`
(`make test-host-inbound-lib`, hermetic, 61 cells).

It **commits nothing**: it reads the already-committed config in `display set`
form, derives its probe targets from it, and refuses to run when the zone
posture its expectations depend on has changed. That removes it from the #6440
class entirely — no apply phase to gate, no rollback to verify, no way to leave
the shared cluster dirty.

### The trap the issue's own comment asked to be closed on the first pass

> a host-inbound smoke that probes and gets nothing back must not score that as
> "correctly denied" ... put the probe-blind row in the table on the first pass

The vocabulary has **no state called `DENIED`**. A probe cannot observe a deny;
it observes SILENCE, and "the firewall dropped it" and "my prober never reached
the firewall" are the same reading. Silence becomes a deny only via a positive
control at the **same address, same family, same run, same prober**.
Same-address matters — a route that stopped reaching one VLAN address would
make every deny cell at it pass for the wrong reason while a family-level
control stayed green.

A second discriminator makes the negative cells falsifiable at all: `xpfd`
binds its own listeners on `127.0.0.1` only, so an admitted probe of a
non-listening port returns an **RST** (a packet-carrying positive signal) where
a dropped one returns nothing. A bare `nc -z` exit status collapses those two.

### Measured matrix (loss userspace cluster)

`lan` admits ssh+ping; `wan` admits ping+gre and owns `reth0.50` / `reth0.80`.

| target | interface | zone | tcp/22 | tcp/23 | icmp |
|---|---|---|---|---|---|
| `10.0.61.1` | `reth1.0` untagged | lan | RST → admitted | timeout | reply |
| `2001:559:8585:ef00::1` | `reth1.0` untagged | lan | RST → admitted | timeout | reply |
| `172.16.50.8` | `reth0.50` **VLAN 50** | wan | timeout → denied | timeout | reply |
| `2001:559:8585:50::8` | `reth0.50` **VLAN 50** | wan | timeout → denied | timeout | reply |
| `172.16.80.8` | `reth0.80` **VLAN 80** | wan | timeout → denied | timeout | reply |
| `2001:559:8585:80::8` | `reth0.80` **VLAN 80** | wan | timeout → denied | timeout | reply |

Both lan rows admit tcp/22 and deny tcp/23 at the *same address*; the wan rows
deny tcp/22 while answering icmp at the same address. Neither pattern has a
routing explanation.

### The failover leg asserts a DIFF

`--with-failover` moves RG1 (WAN/`reth0`) and RG2 (LAN/`reth1`) to node1,
re-runs, fails back, re-runs. The assertion is that the matrix is **identical**
— a run in which every admission silently died still satisfies every DENY cell,
so re-scoring alone cannot see the regression this leg exists for.
`hi_matrix_stable_verdict` also fails an empty run rather than reading it as
"unchanged". Failback is explicit: measured during this work, a `failover
reset`-only restore left node1 primary for both RGs (preempt is disabled), so
without it the shared cluster would be left inverted for the next lane.

## A guard that was an enumeration, not a census

`cluster-cell-selftest.sh` asserted the #1875 lock preamble over a **hardcoded
list** of eight scripts — a new destructive smoke was covered only if its
author also remembered to add its name, the same shape that let
`test-fbf-steering.sh` go ungated until #7798. The detector that already
decided "is line N a node mutation" now decides membership too, over every
`test-*.sh`.

It is **fail-closed**: the obvious `awk ... || true` form cannot tell "this
script mutates nothing" from "awk did not run", and the second silently drops a
destructive script out of the scanned set. Paired cell, simulating an
unreadable `test-host-inbound.sh` (deliberately the one *not* in the floor
list, since the floor cannot catch it):

| shape | result |
|---|---|
| fail-closed (shipped) | `FAIL: the destructive-script detector could not read test-host-inbound.sh` |
| fail-open | **clean pass** — "matched 8 destructive scripts (covers all 8 known ones)", having silently stopped guarding the ninth |

## A defect found while writing the smoke

The instance-liveness precondition was first `incus info | grep -q RUNNING`.
Under `set -o pipefail`, `grep -q` exits at the first match and SIGPIPEs
`incus`, the pipeline reports the writer's failure, and a RUNNING instance
reads as down. Caught on the first live run; now consumes the whole stream.

## Validation

Live on `loss:xpf-userspace-fw0/fw1` under the #1875 lock:

- matrix only: **26 cells, 0 failed**
- `--with-failover`: **68 cells, 0 failed**, matrix identical across both the
  failover and the failback
- cluster left healthy afterwards: node0 primary for RG0/1/2, node1 secondary,
  no manual latch

Hermetic / suite:

- `make test-host-inbound-lib` — 61/61
- `make test-cluster-lock-lib` — 14/14
- `make test-fbf-steering-lib` — 15/15 (untouched, regression check)
- `go test -count=1 ./...` — green, 0 `--- FAIL`, 0 "no space left"

No Rust or Go source changed, so `make test-rust` was not run.

### Mutation matrix on the lib (hermetic, one mutation per cell)

| mutation | cells red | localisation |
|---|---|---|
| DENY+SILENT ignores the control | 4 | all four `DENY_SILENT_CONTROL_*` |
| a missing prober line reads SILENT not BLIND | 5 | all five `CLS_*_BLIND` |
| drop the `system-services all` subsumption | 2 | `ZONE_ALL_*` |
| matrix stability skips the empty-run guard | 1 | `MATRIX_BOTH_EMPTY` |
| config readability always true | 2 | `ZONE_CLI_ERROR_BLIND`, `ZONE_NO_ZONES_BLIND` |
| UNREACHED scored as a deny | 1 | `DENY_UNREACHED_IS_NOT_DENY` |

### Mutation matrix on the SMOKE (live) — the lib being sound proves nothing about the wiring

| mutation | result |
|---|---|
| **S1** point one target at an unroutable address | **3 FAIL**, exit 1 — the ping control and both DENY cells, each naming the blind prober |
| **S2b** same bad input, control removed from ONLY the DENY cells | **1 FAIL** — the untouched ping cell still reds; both DENY cells **PASS** |
| **S3** flip the ADMIT/DENY expectation table | **2 FAIL** — exactly the two `lan-*-ssh` cells |

S1 + S2b are the paired cell: guard removed must pass (the silence really was
invisible without the control), guard restored must fail. A lone S1 would only
have shown correlation.

## Docs

`docs/host-inbound-service-matrix.md` gains an on-wire coverage section (the
measured matrix, why the RST matters, why the failover leg diffs, and why the
dup-address leg has no reachable venue). `CLAUDE.md` and the Makefile document
the new targets. `docs/log/6936.md` carries the full round-2 record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fSMeD3QCCvtZ1zRaxikJZ
