### PR TITLE
userspace-dp: spend the ICMP rate-limit token only on replies we send (#7174 M04)

### DIFF
--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -263,11 +263,6 @@ pub(super) fn build_local_time_exceeded_request(
         .get(&ingress_ident.ifindex)
         .copied()
         .unwrap_or(0);
-    if !allow_generated_error_zoned(forwarding, GeneratedErrorReason::TimeExceeded, from_zone_id) {
-        counters.touched = true;
-        return None;
-    }
-
     let now_ns = monotonic_nanos();
     // #2238: classify the GENERATED ICMP/ICMPv6 error by its OWN egress
     // 5-tuple, NOT the triggering inbound packet's tuple/ingress. Pre-#2238
@@ -301,6 +296,32 @@ pub(super) fn build_local_time_exceeded_request(
         }
         return None;
     }
+
+    // #7174 M04: consume the rate-limit token LAST, once this reply is known to
+    // be one we will actually send.
+    //
+    // This gate used to run before `classify_generated_reply` above, so a reply
+    // an output filter was going to DISCARD still spent a token. The budget
+    // exists to bound what this box EMITS, and a reply that never leaves emits
+    // nothing — so charging for it lets a filtered stream starve the errors that
+    // would have gone out, and does it invisibly: the drop is attributed to the
+    // filter counter while the missing errors are attributed to the limiter.
+    //
+    // Same principle as the #3656 H11 "build-before-consume" ordering recorded
+    // above, applied to the branch it did not cover — that change stopped an
+    // UNBUILDABLE attempt spending a token, this stops an unsendable one. The
+    // trigger-packet disposition is unchanged either way: a rate-limited attempt
+    // still returns None.
+    //
+    // Ordering between the two drops is deliberate. A reply that is BOTH
+    // filtered and over budget is attributed to the FILTER, because that
+    // decision is deterministic and the limiter should only meter traffic that
+    // would otherwise have gone out.
+    if !allow_generated_error_zoned(forwarding, GeneratedErrorReason::TimeExceeded, from_zone_id) {
+        counters.touched = true;
+        return None;
+    }
+
     Some(PendingForwardRequest {
         target_ifindex,
         target_binding_index: None,

--- a/userspace-dp/src/afxdp/icmp_ratelimit.rs
+++ b/userspace-dp/src/afxdp/icmp_ratelimit.rs
@@ -137,6 +137,15 @@ pub(in crate::afxdp) struct TokenBucket {
 }
 
 impl TokenBucket {
+    /// #7174 M04 test observable. `theoretical_arrival_ns` IS the limiter state:
+    /// consuming a token advances it, declining to consume leaves it alone. So
+    /// "did this path spend a token?" is exactly "did this value move?", which
+    /// is a precise question a burst-exhaustion probe can only approximate.
+    #[cfg(test)]
+    pub(in crate::afxdp) fn arrival_ns(&self) -> u64 {
+        self.theoretical_arrival_ns.load(Ordering::Relaxed)
+    }
+
     pub(in crate::afxdp) const fn new() -> Self {
         TokenBucket {
             theoretical_arrival_ns: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/tests_icmp_te.rs
+++ b/userspace-dp/src/afxdp/tests_icmp_te.rs
@@ -205,8 +205,11 @@ fn build_local_time_exceeded_request_returns_prebuilt_forward_for_ttl_expiry() {
 /// never consulted).
 #[test]
 fn build_local_time_exceeded_request_classifies_generated_icmp_on_egress() {
-    // #5567: the reply must be built + pass the token before the output-filter
-    // classify runs, so this drop-attribution test needs a non-empty bucket.
+    // #5567 needed a non-empty bucket here because the token was consumed
+    // BEFORE the output-filter classify. #7174 M04 reversed that — the token is
+    // consumed last, only for a reply that will actually be sent — so this test
+    // no longer depends on bucket state. The lock stays because the fallback
+    // bucket is a shared static and these tests must not race.
     let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
     let client_ip = Ipv4Addr::new(10, 0, 61, 102);
     let dst_ip = Ipv4Addr::new(1, 1, 1, 1);
@@ -266,6 +269,21 @@ fn build_local_time_exceeded_request_classifies_generated_icmp_on_egress() {
         },
     );
 
+    // #7174 M04: give this zone its OWN bucket so the token observation below is
+    // isolated from the shared static fallback (and from every other test).
+    // Key the bucket on the zone the code will ACTUALLY resolve. `from_zone_id`
+    // comes from `forwarding.ifindex_to_zone_id[ingress_ident.ifindex]`, so
+    // binding it here is what makes the bucket reachable — inserting under a
+    // zone the lookup never produces leaves the code on the shared static
+    // fallback and both assertions below pass vacuously. The control cell caught
+    // exactly that on its first run.
+    forwarding.ifindex_to_zone_id.insert(5, TEST_LAN_ZONE_ID);
+    let te_bucket = std::sync::Arc::new(crate::afxdp::icmp_ratelimit::TokenBucket::new());
+    forwarding
+        .time_exceeded_buckets
+        .insert(TEST_LAN_ZONE_ID, te_bucket.clone());
+    let arrival_before = te_bucket.arrival_ns();
+
     let mut counters = BatchCounters::default();
     let request = build_local_time_exceeded_request(
         &frame,
@@ -283,6 +301,17 @@ fn build_local_time_exceeded_request_classifies_generated_icmp_on_egress() {
     assert!(
         request.is_none(),
         "egress output-filter `then discard` (protocol icmp) must reject the generated ICMP reply"
+    );
+    // #7174 M04: and it must not have COST anything. The budget bounds what this
+    // box emits; a reply the filter discards emits nothing, so charging for it
+    // lets a filtered stream starve the errors that would have gone out — and
+    // does it invisibly, because the drop is attributed to the filter counter
+    // while the missing errors are attributed to the limiter.
+    assert_eq!(
+        te_bucket.arrival_ns(),
+        arrival_before,
+        "a filter-DROPPED ICMP Time Exceeded must not spend a rate-limit token \
+         (#7174 M04); the bucket state moved, so it did"
     );
     assert_eq!(
         counters.time_exceeded_output_filter_drops, 1,
@@ -354,6 +383,23 @@ fn build_local_time_exceeded_request_ignores_trigger_matching_output_filter() {
         },
     );
 
+    // #7174 M04 CONTROL. The sibling drop-path cell asserts a filtered reply
+    // spends NO token; that assertion is only meaningful if a reply which IS
+    // sent DOES spend one. Without this, "the bucket did not move" would be
+    // satisfied by a bucket nothing ever consults.
+    // Key the bucket on the zone the code will ACTUALLY resolve. `from_zone_id`
+    // comes from `forwarding.ifindex_to_zone_id[ingress_ident.ifindex]`, so
+    // binding it here is what makes the bucket reachable — inserting under a
+    // zone the lookup never produces leaves the code on the shared static
+    // fallback and both assertions below pass vacuously. The control cell caught
+    // exactly that on its first run.
+    forwarding.ifindex_to_zone_id.insert(5, TEST_LAN_ZONE_ID);
+    let te_bucket = std::sync::Arc::new(crate::afxdp::icmp_ratelimit::TokenBucket::new());
+    forwarding
+        .time_exceeded_buckets
+        .insert(TEST_LAN_ZONE_ID, te_bucket.clone());
+    let arrival_before = te_bucket.arrival_ns();
+
     let mut counters = BatchCounters::default();
     let request = build_local_time_exceeded_request(
         &frame,
@@ -368,6 +414,12 @@ fn build_local_time_exceeded_request_ignores_trigger_matching_output_filter() {
         &mut counters,
     );
 
+    assert_ne!(
+        te_bucket.arrival_ns(),
+        arrival_before,
+        "a reply that IS sent must spend a rate-limit token — otherwise the \
+         drop-path cell's 'no token spent' assertion proves nothing (#7174 M04)"
+    );
     assert!(
         request.is_some(),
         "an output filter matching the UDP trigger must NOT drop the generated ICMP reply"
@@ -403,8 +455,11 @@ fn build_local_time_exceeded_request_ignores_trigger_matching_output_filter() {
 /// never pass vacuously.
 #[test]
 fn build_local_time_exceeded_request_resolves_logical_ingress_for_classify_6102() {
-    // #5567: the reply must be built + pass the token before the output-filter
-    // classify runs, so this drop-attribution test needs a non-empty bucket.
+    // #5567 needed a non-empty bucket here because the token was consumed
+    // BEFORE the output-filter classify. #7174 M04 reversed that — the token is
+    // consumed last, only for a reply that will actually be sent — so this test
+    // no longer depends on bucket state. The lock stays because the fallback
+    // bucket is a shared static and these tests must not race.
     let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
     let client_ip = Ipv4Addr::new(10, 0, 61, 102);
     let dst_ip = Ipv4Addr::new(1, 1, 1, 1);


### PR DESCRIPTION
#7174 M04. Verified by **predicate** at `origin/master` (`1784ef260`), in a
worktree — not at the cited line numbers, and not in the main checkout.

## The defect

`build_local_time_exceeded_request` consumed a TimeExceeded rate-limit token
before `classify_generated_reply` ran the output-filter check, so a reply an
output filter was going to **discard** still spent budget.

The budget bounds what this box **emits**. A reply that never leaves emits
nothing, so charging for it lets a filtered stream starve the errors that would
have gone out — and does it **invisibly**, because the drop is attributed to the
filter counter while the missing errors are attributed to the limiter. An
operator seeing both has no reason to connect them.

## Not a new principle

The comment a few lines above already records the #3656 H11
*"build-before-consume"* ordering: an **unbuildable** attempt must not spend a
token. M04 is the same principle on the branch it did not cover — an
**unsendable** one. The trigger-packet disposition is unchanged either way.

Ordering between the two drops is deliberate: a reply that is BOTH filtered and
over budget is attributed to the **filter**, because that decision is
deterministic and the limiter should only meter traffic that would otherwise have
gone out.

## The control is the interesting part

The assertions go on the two cells that already drive each branch rather than in
a new fixture — the egress-filter drop test requires the bucket **not** to move,
and its send-path sibling requires that it **does**.

That control is load-bearing, and it earned its place immediately: **"the bucket
did not move" is equally satisfied by a bucket nothing ever consults**, which is
exactly what my first version did. `from_zone_id` resolves through
`forwarding.ifindex_to_zone_id`, so a bucket keyed on a zone that map never
produces leaves the code on the shared static fallback and *both* assertions pass
vacuously. The control failed on its first run with `left: 0, right: 0` and
that is what surfaced it. Both cells now bind the zone map so the bucket is
genuinely reachable.

`TokenBucket::arrival_ns` is a `#[cfg(test)]` accessor.
`theoretical_arrival_ns` *is* the limiter state — consuming advances it,
declining leaves it — so "did this path spend a token?" is exactly "did this
value move?", which a burst-exhaustion probe can only approximate.

## Stale claims corrected in the same change

Two #5567 comments asserted the OLD ordering as a requirement — *"the reply must
be built + pass the token before the output-filter classify runs, so this
drop-attribution test needs a non-empty bucket"*. That is now false. The
shared-static lock they take is kept, because that is about test isolation rather
than ordering.

## Mutation

Restoring the shipped ordering reds the drop cell with its own message and leaves
the send-path control green — **25 passed, 1 failed**, localised to the cell that
owns the property.

## Validation

`make test-rust` — **4972 passed, 0 failed, 0 compile errors**. `go test ./...` —
0 FAIL.

> A process note worth recording: my first full-suite run reported this failing,
> and the cause was that `git checkout -- <path>` after the mutation restored
> from the **index**, discarding the uncommitted fix while keeping the new tests.
> The gate was correct; the tree was not the one I thought I was testing. The fix
> is staged before gating now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y