### PR TITLE
login class: the fine-grained allow/deny regex matcher core (#7172 cut 2)

### DIFF
--- a/pkg/config/login_regex.go
+++ b/pkg/config/login_regex.go
@@ -1,0 +1,304 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Fine-grained `system login class` allow/deny regex evaluation (#7172).
+//
+// This is the ONE matcher every enforcement point shares, the fine-grained
+// sibling of login_perms.go's coarse `ResolveClassPermissions`. Coarse
+// permissions authorize the command FAMILY first; this narrows within it. A
+// caller that reaches this without having passed the coarse gate has skipped a
+// check, not replaced one.
+//
+// It is deliberately PURE — patterns and a command string in, a decision out,
+// no dispatch surface, no config store, no principal. The dispatch wiring is
+// mechanical; this is the part where a mistake is a privilege escalation, so it
+// is reviewable on its own.
+//
+// ── SEMANTICS, AND WHERE THEY COME FROM ──────────────────────────────────
+//
+// Junos has TWO statement families with DIFFERENT precedence (#7971):
+//
+//	allow-commands / deny-commands (+ -configuration)  → allow wins
+//	allow-commands-regexps / deny-commands-regexps     → DENY wins, and the
+//	                                                     regex matches the
+//	                                                     command's full path
+//
+// xpf implements only the first. The precedence is therefore held as PER-FAMILY
+// DATA on LoginRegexFamily rather than as a constant, because the natural way to
+// add the second family is to reuse "the precedence logic" — and that reuse
+// would look responsible while inverting the rule on the leaf that matters.
+//
+// Matching is UNANCHORED (partial). Juniper: "You must use anchors when
+// specifying complex regular expressions with the allow-commands statement",
+// with `(^monitor)|(^ping)|(^show)|(^exit)` as the worked example — explicit
+// anchors would be redundant if the match were implicitly anchored. Anchors are
+// the operator's tool for narrowing, not something we apply for them.
+//
+// The asymmetry that follows is the sharp edge of this feature and is worked
+// through in docs/system-login.md: partial matching makes a DENY broader (safe)
+// and an ALLOW broader (fail-open), so combined with allow-over-deny a wide
+// allow can silently re-permit a narrow deny.
+type LoginRegexLeaf int
+
+const (
+	// LoginRegexNeither is "no leaf decided this" — the zero value, so a
+	// half-built decision reads as undecided rather than as an allow.
+	LoginRegexNeither LoginRegexLeaf = iota
+	LoginRegexAllow
+	LoginRegexDeny
+)
+
+func (l LoginRegexLeaf) String() string {
+	switch l {
+	case LoginRegexAllow:
+		return "allow"
+	case LoginRegexDeny:
+		return "deny"
+	default:
+		return "neither"
+	}
+}
+
+// LoginRegexFamily carries one Junos statement family's precedence rules.
+//
+// A struct rather than constants because #7971 records that the `-regexps`
+// family inverts the first tier and matches a different string. Whoever adds it
+// should be forced to supply a family, not tempted to reuse a hardcoded rule.
+type LoginRegexFamily struct {
+	// Name is the family's operator-facing spelling, for audit strings.
+	Name string
+	// IdenticalPatternWinner decides the case Juniper states outright: "if you
+	// configure the same command for both the allow-commands and deny-commands
+	// statements, then the allow operation takes precedence over the deny
+	// operation." For the plain family that is LoginRegexAllow. For the
+	// `-regexps` family it is LoginRegexDeny.
+	IdenticalPatternWinner LoginRegexLeaf
+}
+
+// LoginRegexPlainFamily is `allow-commands` / `deny-commands` and the
+// `-configuration` pair — the only family xpf implements.
+var LoginRegexPlainFamily = LoginRegexFamily{
+	Name:                   "allow-commands/deny-commands",
+	IdenticalPatternWinner: LoginRegexAllow,
+}
+
+// CompiledLoginRegexes is one class's allow/deny pair, compiled once at
+// admission so evaluation cannot fail, panic, or fall open at runtime.
+//
+// PRESENCE IS NOT VALUE. allowSet/denySet record whether the LEAF WAS WRITTEN,
+// independently of what it holds, because `deny-commands ""` and an absent
+// `deny-commands` mean OPPOSITE things: an empty POSIX regex matches every
+// command, so an empty deny denies EVERYTHING, while an absent deny denies
+// nothing. Collapsing them is the fail-open direction. This mirrors
+// LoginClass.DenyLeavesPresent, which exists for the same reason and must
+// survive the #6838 gate's retirement.
+type CompiledLoginRegexes struct {
+	family LoginRegexFamily
+
+	allow    *regexp.Regexp
+	allowSrc string
+	allowSet bool
+
+	deny    *regexp.Regexp
+	denySrc string
+	denySet bool
+}
+
+// CompileLoginRegexes compiles one class's pair. Returns an error the strict
+// commit path surfaces to the operator; a class that does not compile must
+// never reach evaluation.
+//
+// DIALECT: regexp.CompilePOSIX, Go's egrep/POSIX-ERE mode — the dialect Junos
+// uses. Same choice, and for the same reason, as ValidASPathRegex in
+// aspath_regex.go, whose comment works through why Go and glibc differing here
+// differ in the safe direction.
+//
+// BUT NOT ITS EMPTY CHECK, AND THIS IS DELIBERATE. ValidASPathRegex opens with
+// `if strings.TrimSpace(regex) == "" { return error }`. Copying that here would
+// invert the fail-closed direction on the leaf that matters: an operator who
+// writes `deny-commands ""` has written the most restrictive thing the grammar
+// allows — deny everything — and rejecting it, or worse treating it as "no
+// restriction", turns a total lockout into a total permit. The two functions
+// look like they should agree and must not. See docs/system-login.md.
+func CompileLoginRegexes(
+	family LoginRegexFamily,
+	allow string, allowPresent bool,
+	deny string, denyPresent bool,
+) (CompiledLoginRegexes, error) {
+	out := CompiledLoginRegexes{family: family}
+	if allowPresent {
+		re, err := regexp.CompilePOSIX(allow)
+		if err != nil {
+			return CompiledLoginRegexes{}, fmt.Errorf(
+				"allow regex is not a valid POSIX extended regular expression: %w", err)
+		}
+		out.allow, out.allowSrc, out.allowSet = re, allow, true
+	}
+	if denyPresent {
+		re, err := regexp.CompilePOSIX(deny)
+		if err != nil {
+			return CompiledLoginRegexes{}, fmt.Errorf(
+				"deny regex is not a valid POSIX extended regular expression: %w", err)
+		}
+		out.deny, out.denySrc, out.denySet = re, deny, true
+	}
+	return out, nil
+}
+
+// LoginRegexDecision is the verdict.
+//
+// Reason NEVER carries the command or its arguments. #7172 requires audit
+// output that names the class, the canonical command and the deny reason
+// "without leaking argument values", and this layer cannot tell an argument
+// from a verb — only the caller knows which command string is safe to log. So
+// the core describes the RULE that decided, and the caller composes it with
+// whatever command text it has already deemed loggable.
+type LoginRegexDecision struct {
+	Allowed bool
+	// DecidedBy is which leaf carried the decision, or LoginRegexNeither when
+	// no regex applied at all.
+	DecidedBy LoginRegexLeaf
+	// Reason is an operator-facing explanation of the RULE. Safe to log.
+	Reason string
+}
+
+// longestMatchLen returns the length of the longest substring `re` matches
+// anywhere in `s`, or -1 when it does not match.
+//
+// LONGEST MATCH ANYWHERE, not the leftmost one. CompilePOSIX gives Go
+// leftmost-longest semantics, but leftmost-longest is not globally longest:
+// `a|bbbb` against "a bbbb" matches "a" leftmost while "bbbb" is the longer
+// match. Junos's rule is about how much of the command a pattern accounts for,
+// so the longest match anywhere is the faithful reading.
+//
+// Zero is a legitimate return: an empty pattern matches an empty substring
+// everywhere. That is why the caller tests >= 0 rather than > 0 — an empty deny
+// MUST count as matching, since it is the "deny everything" spelling.
+func longestMatchLen(re *regexp.Regexp, s string) int {
+	locs := re.FindAllStringIndex(s, -1)
+	if locs == nil {
+		return -1
+	}
+	best := -1
+	for _, loc := range locs {
+		if n := loc[1] - loc[0]; n > best {
+			best = n
+		}
+	}
+	return best
+}
+
+// Evaluate decides whether `command` is permitted.
+//
+// ── PRECEDENCE, THREE TIERS ──────────────────────────────────────────────
+//
+// Tier 1 — IDENTICAL PATTERN in both leaves → family.IdenticalPatternWinner
+// (allow, for the plain family). Juniper states this outright: "if you
+// configure the same command for both the allow-commands and deny-commands
+// statements, then the allow operation takes precedence over the deny
+// operation." Not our call to change.
+//
+// Tier 2 — DIFFERENT patterns, DIFFERENT matched lengths → the LONGEST MATCHED
+// SUBSTRING wins, whichever leaf it came from. Juniper: "If the allow-commands
+// and deny-commands statements have two different variants of a command, the
+// longest match is always executed", with the worked example of a class that
+// may run `commit synchronize` but not `commit`.
+//
+// NOTE WHAT TIER 2 MEANS: a longer DENY beats a shorter ALLOW. "allow always
+// wins" is FALSE, and implementing it would be a fail-open — `allow-commands
+// "commit"` beside `deny-commands "commit synchronize"` must DENY `commit
+// synchronize`.
+//
+// Tier 3 — DIFFERENT patterns, EQUAL matched lengths → DENY. Upstream is
+// silent here (it addresses identical patterns in tier 1 and differing lengths
+// in tier 2, not a length tie between different patterns), so this is OUR
+// interpretation of an underspecified rule, chosen fail-closed. It is recorded
+// as ours in docs/system-login.md rather than presented as Junos behaviour,
+// because the next person with a real Junos box needs to know which sentence to
+// go and check.
+//
+// ── A REVIEWER'S WARNING ─────────────────────────────────────────────────
+//
+// Tier 1 giving ALLOW the win is deliberate and is NOT a fail-open bug. It
+// inverts the usual "deny wins" instinct, so a reviewer who assumes deny-wins
+// will read this as broken and try to "fix" it. It is Junos parity and it is
+// stated in docs/system-login.md:416-418 and on Juniper's own documentation.
+// Changing it silently would break the deny-with-exceptions idiom this feature
+// exists to support.
+func (c CompiledLoginRegexes) Evaluate(command string) LoginRegexDecision {
+	// No regexes configured: this class opted out of fine-grained control and
+	// the coarse permission bits are the whole story.
+	if !c.allowSet && !c.denySet {
+		return LoginRegexDecision{Allowed: true, DecidedBy: LoginRegexNeither,
+			Reason: "no allow/deny regexes configured for this class"}
+	}
+
+	allowLen, denyLen := -1, -1
+	if c.allowSet {
+		allowLen = longestMatchLen(c.allow, command)
+	}
+	if c.denySet {
+		denyLen = longestMatchLen(c.deny, command)
+	}
+
+	// Both matched — the precedence tiers decide.
+	if allowLen >= 0 && denyLen >= 0 {
+		switch {
+		case c.allowSrc == c.denySrc:
+			// Tier 1.
+			winner := c.family.IdenticalPatternWinner
+			return LoginRegexDecision{
+				Allowed:   winner == LoginRegexAllow,
+				DecidedBy: winner,
+				Reason: fmt.Sprintf(
+					"allow and deny carry the identical pattern; %s wins for the %s family",
+					winner, c.family.Name),
+			}
+		case allowLen > denyLen:
+			// Tier 2, allow is the longer match.
+			return LoginRegexDecision{Allowed: true, DecidedBy: LoginRegexAllow,
+				Reason: fmt.Sprintf(
+					"allow matched a longer extent than deny (%d > %d characters)",
+					allowLen, denyLen)}
+		case denyLen > allowLen:
+			// Tier 2, deny is the longer match. THIS is the case that makes
+			// "allow always wins" wrong.
+			return LoginRegexDecision{Allowed: false, DecidedBy: LoginRegexDeny,
+				Reason: fmt.Sprintf(
+					"deny matched a longer extent than allow (%d > %d characters)",
+					denyLen, allowLen)}
+		default:
+			// Tier 3 — ours.
+			return LoginRegexDecision{Allowed: false, DecidedBy: LoginRegexDeny,
+				Reason: fmt.Sprintf(
+					"allow and deny matched equal extents (%d characters) with different "+
+						"patterns; denied (xpf interpretation of an underspecified rule)",
+					denyLen)}
+		}
+	}
+
+	// Deny alone matched.
+	if denyLen >= 0 {
+		return LoginRegexDecision{Allowed: false, DecidedBy: LoginRegexDeny,
+			Reason: "matched the class's deny regex"}
+	}
+
+	// An allow regex, once configured, is an ALLOWLIST: anything it does not
+	// match is denied, even with no deny regex present at all.
+	if c.allowSet {
+		if allowLen >= 0 {
+			return LoginRegexDecision{Allowed: true, DecidedBy: LoginRegexAllow,
+				Reason: "matched the class's allow regex"}
+		}
+		return LoginRegexDecision{Allowed: false, DecidedBy: LoginRegexAllow,
+			Reason: "an allow regex is configured and this command does not match it"}
+	}
+
+	// Only a deny was configured and it did not match.
+	return LoginRegexDecision{Allowed: true, DecidedBy: LoginRegexNeither,
+		Reason: "did not match the class's deny regex"}
+}

--- a/pkg/config/login_regex.go
+++ b/pkg/config/login_regex.go
@@ -139,6 +139,22 @@ func CompileLoginRegexes(
 		out.allow, out.allowSrc, out.allowSet = re, allow, true
 	}
 	if denyPresent {
+		// NO EMPTY-PATTERN GUARD HERE, AND ITS ABSENCE IS THE POINT.
+		//
+		// The sibling this borrows its dialect from — ValidASPathRegex in
+		// pkg/config/aspath_regex.go — opens with
+		// `if strings.TrimSpace(regex) == "" { return error }`. Diffing the two
+		// functions, the natural conclusion is that this one is missing a guard.
+		// It is not.
+		//
+		// An empty POSIX regex matches EVERY string. For an AS-path filter that
+		// is a useless pattern worth rejecting. For a DENY leaf it is the most
+		// restrictive thing the grammar can express — deny everything — and it
+		// is a spelling operators actually use. Rejecting it, or treating it as
+		// "no restriction", converts a total lockout into a total permit.
+		//
+		// So the two functions must disagree, and this one must not grow that
+		// guard. See TestEmptyDenyPatternDeniesEverything7172.
 		re, err := regexp.CompilePOSIX(deny)
 		if err != nil {
 			return CompiledLoginRegexes{}, fmt.Errorf(
@@ -249,7 +265,21 @@ func (c CompiledLoginRegexes) Evaluate(command string) LoginRegexDecision {
 	if allowLen >= 0 && denyLen >= 0 {
 		switch {
 		case c.allowSrc == c.denySrc:
-			// Tier 1.
+			// TIER 1 — UPSTREAM-DOCUMENTED. DO NOT "HARDEN" THIS TO DENY.
+			//
+			// Juniper: "if you configure the same command for both the
+			// allow-commands and deny-commands statements, then the allow
+			// operation takes precedence over the deny operation."
+			//
+			// Allow winning here reads like a fail-open and is not one. It is
+			// the deny-with-exceptions idiom the feature exists to support, and
+			// flipping it would be a parity break in the single case the vendor
+			// documents BY NAME — found by the first operator who copies the
+			// example out of Juniper's docs and watches it behave differently
+			// here. "We made it safer" is a poor answer to that.
+			//
+			// Contrast tier 3 below, which IS ours to choose because upstream
+			// says nothing about it.
 			winner := c.family.IdenticalPatternWinner
 			return LoginRegexDecision{
 				Allowed:   winner == LoginRegexAllow,
@@ -272,7 +302,19 @@ func (c CompiledLoginRegexes) Evaluate(command string) LoginRegexDecision {
 					"deny matched a longer extent than allow (%d > %d characters)",
 					denyLen, allowLen)}
 		default:
-			// Tier 3 — ours.
+			// TIER 3 — OURS, AND DELIBERATELY FAIL-CLOSED.
+			//
+			// Upstream is genuinely silent here: Juniper addresses identical
+			// patterns (tier 1) and differing matched lengths (tier 2), but not
+			// a length TIE between two DIFFERENT patterns. So there is no parity
+			// answer to be faithful to, and the choice is ours to make.
+			//
+			// Denying is the fail-closed direction, which is the right default
+			// for an authorization decision nobody has specified. It is surfaced
+			// as xpf's interpretation in the Reason string and recorded as ours
+			// in docs/system-login.md, so a reader with a real Junos box knows
+			// this is the sentence to go and verify rather than assuming we
+			// copied it from somewhere.
 			return LoginRegexDecision{Allowed: false, DecidedBy: LoginRegexDeny,
 				Reason: fmt.Sprintf(
 					"allow and deny matched equal extents (%d characters) with different "+

--- a/pkg/config/login_regex_7172_test.go
+++ b/pkg/config/login_regex_7172_test.go
@@ -1,0 +1,263 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7172 cut 2 — the fine-grained allow/deny matcher core.
+//
+// These cells are pure: patterns and a command in, a decision out. No dispatch
+// surface. This is the piece where a mistake is a privilege escalation rather
+// than a bug, so it is tested on its own before any wiring exists.
+
+func mustCompileLoginRegexes(t *testing.T, allow string, allowSet bool, deny string, denySet bool) CompiledLoginRegexes {
+	t.Helper()
+	c, err := CompileLoginRegexes(LoginRegexPlainFamily, allow, allowSet, deny, denySet)
+	if err != nil {
+		t.Fatalf("CompileLoginRegexes(%q,%v,%q,%v): %v", allow, allowSet, deny, denySet, err)
+	}
+	return c
+}
+
+// ── Tier 2, and the fixture that proves "allow always wins" is not what
+// shipped. This is the case a flat allow-precedence implementation gets wrong,
+// and it is a FAIL-OPEN when it does.
+func TestLongerDenyBeatsShorterAllow7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, "commit", true, "commit synchronize", true)
+	got := c.Evaluate("commit synchronize")
+	if got.Allowed {
+		t.Fatalf("`commit synchronize` was ALLOWED with allow=%q deny=%q. Junos's longest-match "+
+			"tier means a longer DENY beats a shorter ALLOW; permitting it here is the "+
+			"fail-open that a flat \"allow always wins\" implementation produces. got %+v",
+			"commit", "commit synchronize", got)
+	}
+	if got.DecidedBy != LoginRegexDeny {
+		t.Errorf("expected the deny leaf to carry the decision, got %v", got.DecidedBy)
+	}
+	// And the mirror: the shorter command, which only the allow matches.
+	if d := c.Evaluate("commit"); !d.Allowed {
+		t.Errorf("`commit` must be allowed — only the allow regex matches it: %+v", d)
+	}
+}
+
+// Juniper's own worked example, in the direction they state it: a class that
+// may run `commit synchronize` but not `commit`.
+func TestJunipersWorkedExampleAllowsTheLongerVariant7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, "commit synchronize", true, "commit", true)
+	if d := c.Evaluate("commit synchronize"); !d.Allowed {
+		t.Errorf("`commit synchronize` must be ALLOWED — the allow regex matches a longer "+
+			"extent than the deny: %+v", d)
+	}
+	if d := c.Evaluate("commit"); d.Allowed {
+		t.Errorf("`commit` must be DENIED — only the deny regex matches it: %+v", d)
+	}
+}
+
+// ── THE MIDDLE ROW for the length metric.
+//
+// `commit` / `commit synchronize` passes under BOTH readings of "longest" and
+// therefore proves nothing about which one shipped. These patterns separate
+// them: matched-substring length gives allow (".*" matches all 18 characters,
+// "commit" matches 6), while longest-PATTERN length would give deny ("commit"
+// is 6 characters of pattern, ".*" is 2).
+func TestLongestMeansMatchedSubstringNotPatternLength7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, ".*", true, "commit", true)
+	got := c.Evaluate("commit synchronize")
+	if !got.Allowed {
+		t.Fatalf("expected ALLOW: `.*` matches the whole 18-character command while `commit` "+
+			"matches 6, so matched-substring length picks allow. A deny here means the "+
+			"implementation is comparing PATTERN lengths (2 vs 6), which is the other "+
+			"reading of \"longest match\". got %+v", got)
+	}
+	if !strings.Contains(got.Reason, "longer extent") {
+		t.Errorf("reason should name the extent comparison, got %q", got.Reason)
+	}
+}
+
+// ── Tier 1: identical patterns. Juniper states allow wins; a flat "tie -> deny"
+// rule would invert a documented case, so this pins it explicitly.
+func TestIdenticalPatternsAllowWins7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, "request system reboot", true, "request system reboot", true)
+	got := c.Evaluate("request system reboot")
+	if !got.Allowed {
+		t.Fatalf("identical allow and deny patterns must resolve to ALLOW for the plain "+
+			"family — Juniper: \"if you configure the same command for both ... the allow "+
+			"operation takes precedence\". This is Junos parity, NOT a fail-open; see the "+
+			"reviewer warning on Evaluate. got %+v", got)
+	}
+	if got.DecidedBy != LoginRegexAllow {
+		t.Errorf("expected the allow leaf to carry it, got %v", got.DecidedBy)
+	}
+}
+
+// ── Tier 3, ours: equal extents, DIFFERENT patterns -> deny (fail-closed).
+// Distinct from tier 1, which is the identical-pattern case.
+func TestEqualExtentDifferentPatternsDenies7172(t *testing.T) {
+	// Both match exactly "commit" (6 chars) but are not the same pattern.
+	c := mustCompileLoginRegexes(t, "commit", true, "commi.", true)
+	got := c.Evaluate("commit")
+	if got.Allowed {
+		t.Fatalf("equal-extent matches from DIFFERENT patterns must deny — upstream is silent "+
+			"on this tie and xpf resolves it fail-closed. got %+v", got)
+	}
+	if !strings.Contains(got.Reason, "underspecified") {
+		t.Errorf("the reason must mark this as xpf's interpretation rather than Junos "+
+			"behaviour, so a later reader knows which sentence to go and verify: %q", got.Reason)
+	}
+}
+
+// ── The empty-pattern trap. An empty POSIX regex matches everything, so an
+// empty deny denies EVERYTHING. The natural defensive line —
+// `if pattern == "" { return noRestriction }` — is the exact opposite, and is
+// the line a reviewer would add as tidying.
+func TestEmptyDenyPatternDeniesEverything7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, "", false, "", true) // deny PRESENT, empty value
+	for _, cmd := range []string{"show interfaces", "request system reboot", ""} {
+		if d := c.Evaluate(cmd); d.Allowed {
+			t.Errorf("`deny-commands \"\"` must deny %q. An empty POSIX regex matches every "+
+				"command, so an empty deny is the most restrictive thing the grammar allows "+
+				"— treating it as \"no restriction\" turns a total lockout into a total "+
+				"permit. got %+v", cmd, d)
+		}
+	}
+}
+
+// Presence is not value: an ABSENT deny must deny nothing, which is the
+// opposite of an empty one. If these two collapse, one of them is a fail-open.
+func TestAbsentDenyIsNotAnEmptyDeny7172(t *testing.T) {
+	absent := mustCompileLoginRegexes(t, "", false, "", false)
+	if d := absent.Evaluate("request system reboot"); !d.Allowed {
+		t.Errorf("no regexes configured must allow: %+v", d)
+	}
+	empty := mustCompileLoginRegexes(t, "", false, "", true)
+	if d := empty.Evaluate("request system reboot"); d.Allowed {
+		t.Errorf("an empty deny must deny — it is not the same as an absent one: %+v", d)
+	}
+}
+
+// ── THE MIDDLE ROW for anchoring.
+//
+// `allow-commands "show interfaces"` against the input `show interfaces` passes
+// under BOTH readings and proves nothing. `show interfaces terse` is the
+// discriminator: it matches under partial (unanchored) matching and does not
+// under anchored matching.
+//
+// Junos: "You must use anchors when specifying complex regular expressions with
+// the allow-commands statement", with `(^monitor)|(^ping)|(^show)|(^exit)` as
+// the example — explicit anchors would be redundant under implicit anchoring.
+func TestMatchingIsUnanchoredPartial7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, "show interfaces", true, "", false)
+	if d := c.Evaluate("show interfaces terse"); !d.Allowed {
+		t.Fatalf("`show interfaces terse` must match the allow pattern `show interfaces` — "+
+			"matching is UNANCHORED, so the pattern matches a substring. A deny here means "+
+			"the implementation anchored the match, which would also make an operator's "+
+			"explicit `^` redundant. got %+v", d)
+	}
+	// And the operator's own anchor must still narrow, or anchors are useless.
+	anchored := mustCompileLoginRegexes(t, "^show interfaces$", true, "", false)
+	if d := anchored.Evaluate("show interfaces terse"); d.Allowed {
+		t.Errorf("`^show interfaces$` must NOT match `show interfaces terse` — anchors are "+
+			"the operator's tool for narrowing: %+v", d)
+	}
+	if d := anchored.Evaluate("show interfaces"); !d.Allowed {
+		t.Errorf("`^show interfaces$` must match `show interfaces`: %+v", d)
+	}
+}
+
+// An allow regex, once configured, is an ALLOWLIST — non-matching commands are
+// denied even with no deny regex present.
+func TestAllowRegexEstablishesAnAllowlist7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t, "^show", true, "", false)
+	if d := c.Evaluate("show interfaces"); !d.Allowed {
+		t.Errorf("a matching command must be allowed: %+v", d)
+	}
+	got := c.Evaluate("request system reboot")
+	if got.Allowed {
+		t.Fatalf("a command NOT matching the allow regex must be denied even with no deny "+
+			"regex configured — a configured allow is an allowlist, not a hint: %+v", got)
+	}
+	if got.DecidedBy != LoginRegexAllow {
+		t.Errorf("the allow leaf is what denied this; audit must say so, got %v", got.DecidedBy)
+	}
+}
+
+// Invalid syntax must fail at COMPILE (admission), so evaluation can never
+// panic or fall open at runtime.
+func TestInvalidRegexFailsAtCompileNotRuntime7172(t *testing.T) {
+	for _, tc := range []struct {
+		name, allow, deny string
+		allowSet, denySet bool
+	}{
+		{name: "bad allow", allow: "([unclosed", allowSet: true},
+		{name: "bad deny", deny: "*leading-star", denySet: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileLoginRegexes(LoginRegexPlainFamily,
+				tc.allow, tc.allowSet, tc.deny, tc.denySet)
+			if err == nil {
+				t.Fatal("an unparseable pattern must fail at compile time; deferring it to " +
+					"evaluation is how a regex authz gate falls open at runtime")
+			}
+			if !strings.Contains(err.Error(), "POSIX") {
+				t.Errorf("the error should name the dialect so an operator knows which "+
+					"syntax is expected: %v", err)
+			}
+		})
+	}
+}
+
+// PER-FAMILY DATA, not a constant (#7971). The `-regexps` family inverts tier 1;
+// a core that hardcodes "allow wins" would be reused by whoever adds it, and the
+// reuse would look responsible while inverting the rule on the leaf that matters.
+func TestPrecedenceIsPerFamilyData7172(t *testing.T) {
+	// Same inputs, opposite family rule, opposite verdict.
+	denyWins := LoginRegexFamily{Name: "test-regexps-like", IdenticalPatternWinner: LoginRegexDeny}
+	c, err := CompileLoginRegexes(denyWins, "commit", true, "commit", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := c.Evaluate("commit"); d.Allowed {
+		t.Fatalf("a family declaring deny as the identical-pattern winner must DENY, "+
+			"proving the tier-1 rule is read from family data rather than hardcoded: %+v", d)
+	}
+	// The shipped family is the other way round — the pair is what proves the
+	// field is consulted rather than incidentally agreeing with a constant.
+	plain := mustCompileLoginRegexes(t, "commit", true, "commit", true)
+	if d := plain.Evaluate("commit"); !d.Allowed {
+		t.Fatalf("the plain family must ALLOW on identical patterns: %+v", d)
+	}
+}
+
+// ── LONGEST MATCH ANYWHERE, not the leftmost one.
+//
+// This cell exists because a mutation ESCAPED without it: narrowing
+// longestMatchLen to the first match only (`FindAllStringIndex(s, 1)`) left
+// every other cell green. Every fixture above uses a pattern whose leftmost
+// match IS its longest, so none of them could tell the two apart — the
+// distinction was asserted in a doc comment and bound by nothing.
+//
+// An alternation is where they diverge, and it diverges in the FAIL-OPEN
+// direction: measuring a deny by its leftmost (shorter) match understates its
+// extent, so a competing allow wins a comparison it should have lost.
+//
+//	command: "show configuration security"
+//	deny:    "show|configuration security"  leftmost "show" (4), longest (21)
+//	allow:   "show configuration"           (18)
+//
+// longest -> deny 21 > allow 18 -> DENY. leftmost -> deny 4 < allow 18 -> ALLOW.
+func TestLongestMatchIsAnywhereNotLeftmost7172(t *testing.T) {
+	c := mustCompileLoginRegexes(t,
+		"show configuration", true,
+		"show|configuration security", true)
+	got := c.Evaluate("show configuration security")
+	if got.Allowed {
+		t.Fatalf("expected DENY: the deny pattern's LONGEST match is `configuration security` "+
+			"(21 chars), which beats the allow's 18. Permitting this means match extent is "+
+			"being measured from the LEFTMOST match (`show`, 4 chars), which understates a "+
+			"deny built from an alternation — the fail-open direction. got %+v", got)
+	}
+	if got.DecidedBy != LoginRegexDeny {
+		t.Errorf("the deny leaf must carry it, got %v", got.DecidedBy)
+	}
+}


### PR DESCRIPTION
Cut 2 of #7172, landing first and alone per the agreed split. **Pure matcher: patterns and a command string in, a decision out.** No dispatch surface, no config store, no principal — nothing reads this yet.

It is separated deliberately: this is the one cut where a mistake is a **privilege escalation** rather than a bug, and it is reviewable without the wiring.

## Premise check at `origin/master` (1784ef260)

The issue describes state at `bcfe392cc`, **2065 commits** back, so this needed verifying rather than assuming. Exactly **one** commit touched `pkg/config/compiler_login_deny.go` in that span (`6a1e16d22`, a docs retarget), and all four named loci are present and substantively unchanged: `loginClassLeafRestrictive`, `validateLoginClassDenyStrict`, `foldLoginClassDenyToRepairableFloor`, and `login_class_deny_5831_test.go`. **#6838's gate is intact and this PR does not touch it** — it is retired in cut 6, once enforcement is complete and proven.

## Precedence is three tiers, and "allow always wins" is false

| tier | condition | winner | source |
|---|---|---|---|
| 1 | identical pattern in both leaves | **allow** (plain family) | Juniper, stated |
| 2 | different patterns, different matched lengths | **longest matched substring**, either leaf | Juniper, stated |
| 3 | different patterns, **equal** matched lengths | **deny** | **xpf's interpretation** — upstream silent |

Tier 2 is the one that matters and the one an obvious implementation gets wrong: it means a **longer deny beats a shorter allow**. `allow-commands "commit"` beside `deny-commands "commit synchronize"` must **deny** `commit synchronize`. A flat allow-precedence implementation permits it, and that is a fail-open.

Tier 3 is ours and is labelled as ours in the decision reason, not presented as Junos behaviour, so a later reader with a real Junos box knows exactly which sentence to go and check.

> **Reviewer warning, also on `Evaluate` itself:** tier 1 giving **allow** the win is deliberate and is *not* a fail-open. It inverts the usual deny-wins instinct. It is Junos parity (`docs/system-login.md:416-418` and Juniper's own docs), and changing it breaks the deny-with-exceptions idiom this feature exists to support.

## Matching is unanchored

Juniper requires explicit anchors for complex `allow-commands` expressions and ships `(^monitor)|(^ping)|(^show)|(^exit)` as the example — anchors that would be redundant under implicit anchoring. Anchors are the operator's tool for narrowing, not something applied for them.

The asymmetry, which belongs in the operator docs in cut 3+: partial matching makes a **deny** broader (safe) and an **allow** broader (**fail-open**), so combined with allow-over-deny a wide allow can silently re-permit a narrow deny.

## Presence is not value

`deny-commands ""` and an absent `deny-commands` mean **opposite** things: an empty POSIX regex matches every command, so an empty deny denies **everything** while an absent one denies nothing. Carried as `(value, present)` rather than a string, mirroring `LoginClass.DenyLeavesPresent`, which exists for the same reason and must survive cut 6.

**The dialect precedent has a guard that must not be copied.** `regexp.CompilePOSIX` matches `aspath_regex.go:94`'s `ValidASPathRegex` — the right choice, and its comment works through why Go and glibc differ in the safe direction. But that function opens by *rejecting* an empty regex, and copying it here would invert the fail-closed direction on the leaf that matters. A near-identical sibling doing the opposite correct thing is worse than no precedent, so the divergence is commented at the site.

## Precedence is per-family data (#7971)

Junos's `-regexps` family **inverts tier 1** and matches the command's full path. xpf implements only the plain family, but the natural way to add the other is to reuse "the precedence logic" — and that reuse would look responsible while inverting the rule on the leaf that matters. So the rule is a field on `LoginRegexFamily`, and a cell drives identical inputs through both winners to prove the field is actually read rather than incidentally agreeing with a constant.

## Mutation matrix

All cells build-clean — none of these is caught by the compiler.

| # | Mutation | named reds |
|---|---|---|
| 1 | flat "allow always wins" (drop tier 2) | `TestLongerDenyBeatsShorterAllow7172`, `TestEqualExtentDifferentPatternsDenies7172` |
| 2 | tie resolves to allow (drop tier 3) | `TestEqualExtentDifferentPatternsDenies7172` |
| 3 | empty pattern treated as no restriction | `TestEmptyDenyPatternDeniesEverything7172`, `TestAbsentDenyIsNotAnEmptyDeny7172` |
| 4 | implicit anchoring (`^(...)$`) | `TestMatchingIsUnanchoredPartial7172`, `TestAllowRegexEstablishesAnAllowlist7172` |
| 5 | hardcode tier 1 to allow, ignoring family data | `TestPrecedenceIsPerFamilyData7172` |
| 6 | allow regex stops being an allowlist | `TestMatchingIsUnanchoredPartial7172`, `TestAllowRegexEstablishesAnAllowlist7172` |
| 7 | leftmost match instead of longest | **ESCAPED → now** `TestLongestMatchIsAnywhereNotLeftmost7172` |

### Cell 7 escaped, and the gap was in the fail-open direction

Narrowing `longestMatchLen` to the first match only left **every** cell green. Every fixture used a pattern whose leftmost match *was* its longest, so none could tell the two apart — the distinction was asserted in a doc comment (which even cites `a|bbbb` as the diverging case) and bound by nothing.

An alternation separates them, and it separates them in the direction that matters: measuring a deny by its **leftmost** match understates its extent, so a competing allow wins a comparison it should have lost.

```
command: "show configuration security"
deny:    "show|configuration security"   leftmost "show" (4)  longest (21)
allow:   "show configuration"            (18)
```

longest → deny 21 > allow 18 → **DENY**.  leftmost → deny 4 < allow 18 → **ALLOW**.

### Two fixtures are deliberately "middle rows"

- **Length metric**: `commit` / `commit synchronize` passes under *both* readings of "longest" and proves nothing. `allow ".*"` + `deny "commit"` on `commit synchronize` separates them — matched-substring gives allow (18 vs 6), pattern-length would give deny (2 vs 6).
- **Anchoring**: `show interfaces` against `show interfaces` passes under both readings. `show interfaces terse` is the discriminator.

## Gate

`go test ./... -count=1` — **rc=0, 69 packages, 0 named FAILs**. Go-only, no dataplane movement, no cluster smoke owed.

## Not in this cut

Canonicalization (cut 1), operational enforcement (3), the config-mutation gate (4), the gRPC method→command table (5), retiring #6838 (6). Docs land with the cuts that make behaviour operator-visible; this one changes nothing an operator can see.

Refs #7172, #7971, #5831, #6838.
