### PR TITLE
HA peer fencing: add a fence acknowledgement and a confirmed fencing policy

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -107071,17 +107071,3 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/daemon/external_hostname_watch_6863.go, pkg/daemon/mgmt_listener_reassert.go, pkg/daemon/management.go, pkg/daemon/daemon.go
 
 <!-- LOG-CLOSED-SENTINEL-6874: nothing may be appended below this line. Write to docs/log/<issue>.md instead. -->
-
-- **Timestamp**: 2026-08-29
-  **Action**: #7147 — add peer-fence acknowledgement (`syncMsgFenceAck = 35`),
-  the `peer-fencing disable-rg-confirmed` policy that gates takeover on a
-  peer-confirmed fence with a bounded fail-open wait, and a capability flags
-  byte on `syncMsgPeerCapabilities`. Additive wire: no `SessionSyncWireVersion`
-  / `CurrentHAProtocolVersion` bump.
-  **File(s)**: pkg/cluster/sync_fence_ack_7147.go, pkg/cluster/fence_confirm_7147.go,
-  pkg/cluster/sync.go, pkg/cluster/sync_conn.go, pkg/cluster/sync_conn_read.go,
-  pkg/cluster/sync_conn_write.go, pkg/cluster/heartbeat_manager.go,
-  pkg/cluster/manager.go, pkg/cluster/hooks.go, pkg/cluster/status.go,
-  pkg/daemon/daemon_ha_sync.go, pkg/daemon/daemon_ha_comms_wiring.go,
-  pkg/config/schema_chassis.go, pkg/config/types_chassis.go,
-  docs/ha-failover-status.md, pkg/cluster/README.md, pkg/daemon/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -107071,3 +107071,17 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/daemon/external_hostname_watch_6863.go, pkg/daemon/mgmt_listener_reassert.go, pkg/daemon/management.go, pkg/daemon/daemon.go
 
 <!-- LOG-CLOSED-SENTINEL-6874: nothing may be appended below this line. Write to docs/log/<issue>.md instead. -->
+
+- **Timestamp**: 2026-08-29
+  **Action**: #7147 — add peer-fence acknowledgement (`syncMsgFenceAck = 35`),
+  the `peer-fencing disable-rg-confirmed` policy that gates takeover on a
+  peer-confirmed fence with a bounded fail-open wait, and a capability flags
+  byte on `syncMsgPeerCapabilities`. Additive wire: no `SessionSyncWireVersion`
+  / `CurrentHAProtocolVersion` bump.
+  **File(s)**: pkg/cluster/sync_fence_ack_7147.go, pkg/cluster/fence_confirm_7147.go,
+  pkg/cluster/sync.go, pkg/cluster/sync_conn.go, pkg/cluster/sync_conn_read.go,
+  pkg/cluster/sync_conn_write.go, pkg/cluster/heartbeat_manager.go,
+  pkg/cluster/manager.go, pkg/cluster/hooks.go, pkg/cluster/status.go,
+  pkg/daemon/daemon_ha_sync.go, pkg/daemon/daemon_ha_comms_wiring.go,
+  pkg/config/schema_chassis.go, pkg/config/types_chassis.go,
+  docs/ha-failover-status.md, pkg/cluster/README.md, pkg/daemon/README.md

--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -447,17 +447,70 @@ Peer fencing:
 `disabled` when the leaf is absent — which can differ from the action the listed
 attempts were recorded under, because the event history outlives a config
 change. Each attempt line is one `handlePeerTimeout` fence decision and its
-outcome: `sent to peer`, `Fence failed: <err>` (the sync channel was down — the
-node still takes over on the heartbeat timeout), or `Fence skipped: sync not
-available` (no session-sync peer-fence function was armed).
+outcome.
 
-The fence is **best-effort and unacknowledged**: `SessionSync.SendFence`
-(`pkg/cluster/sync_failover.go`) writes `syncMsgFence` and returns; there is no
-fence-ack message on the wire. A `sent to peer` line therefore means the write
-reached the socket, not that the peer disabled its redundancy groups. Local
-takeover is consequently NOT gated on the fence — `handlePeerTimeout` runs
-`electSingleNode()` before it attempts the fence, so a dead peer (fence
+### `disable-rg` — best-effort, unacknowledged
+
+`SessionSync.SendFence` (`pkg/cluster/sync_failover.go`) writes `syncMsgFence`
+and returns; nothing is sent back. A `sent to peer` line therefore means the
+write reached the socket, not that the peer disabled its redundancy groups.
+Local takeover is consequently NOT gated on the fence — `handlePeerTimeout`
+runs `electSingleNode()` BEFORE it attempts the fence, so a dead peer (fence
 unreachable) can never block the survivor from forwarding.
+
+Attempt lines: `Fence disable-rg sent to peer`, `Fence failed: <err>` (the sync
+channel was down — the node still takes over on the heartbeat timeout), or
+`Fence skipped: sync not available` (no session-sync peer-fence function was
+armed).
+
+### `disable-rg-confirmed` — acknowledged, bounded, fail-open (#7147)
+
+`set chassis cluster peer-fencing disable-rg-confirmed` sends a SEQUENCED fence
+BEFORE the election and waits, bounded, for the peer to report what it
+disabled. `SendFenceAwait` (`pkg/cluster/sync_fence_ack_7147.go`) writes
+`syncMsgFence` carrying an 8-byte sequence number; the peer runs its fence and
+replies `syncMsgFenceAck` (type 35) carrying that sequence, a status, and the
+number of redundancy groups it drove to `rg_active=false` out of the number in
+its live config.
+
+**"Fenced" means peer-confirmed, not merely acknowledged.** The ack is written
+only after the receiver's `fenceAllRedundancyGroups` has run, and only a
+full-success result is reported as confirmed. A peer in config-only mode (no
+published dataplane) replies `unavailable` rather than a vacuous success over
+an empty RG set.
+
+**The gate never withholds ownership.** Every negative outcome proceeds with the
+takeover:
+
+| Situation | Cost | Attempt line |
+|---|---|---|
+| Peer not connected | none — returns immediately | `Fence unconfirmed, took over anyway: peer not connected` |
+| Peer predates #7147 | none — capability not advertised | `Fence unconfirmed, took over anyway: peer does not support fence acknowledgement` |
+| Sync channel dropped mid-wait | none — waiter released at once | `Fence unconfirmed, took over anyway: session sync disconnected...` |
+| Socket alive, peer silent | up to `FenceConfirmTimeout` (250 ms) | `Fence unconfirmed, took over anyway: timed out after 250ms...` |
+| Peer partly fenced | none | `Fence NOT confirmed (peer disabled only 1/3 redundancy groups), took over anyway` |
+| Peer confirmed | one fabric round trip | `Fence confirmed by peer (peer disabled 4/4 redundancy groups)` |
+
+The only row that spends the timeout is a peer whose TCP socket has not yet
+noticed it is gone. The ordinary dead-peer takeover costs nothing extra,
+because `SendFenceAwait` returns immediately when there is no active
+connection — there is nothing to wait for.
+
+A `Confirmations: received N, timed out N, sent to peer N` line accompanies
+`Action` whenever the policy is armed or any ack traffic has occurred. Read
+`timed out` as "takeovers that proceeded without the guarantee you selected";
+it is the only place that number appears, since `Fences sent` counts a
+confirmed and an unconfirmed takeover identically.
+
+**Mixed-version clusters are safe and need no coordinated upgrade.** Both wire
+changes are additive: `syncMsgFenceAck` is a new type that an old peer skips
+via the receive switch's missing `default` arm, and the fence sequence is
+trailing data on an existing type whose old receiver reads no payload. A
+fence-ack capability bit rides the trailing byte of `syncMsgPeerCapabilities`
+(#6650). Neither `SessionSyncWireVersion` nor `CurrentHAProtocolVersion` is
+bumped — bumping would push `GateMixedBaseSwap`'s single-point compatibility
+window off the peer's version and refuse the rolling upgrade this has to
+survive. A mixed pair degrades exactly to `disable-rg` behaviour on both sides.
 
 Do not read this block as the **Install fence:** block that appears above it in
 the same output — that one reports the bulk-sync install barrier sequence

--- a/docs/log/7147.md
+++ b/docs/log/7147.md
@@ -1,0 +1,92 @@
+# #7147 — HA peer fencing: fence acknowledgement on the wire
+
+## Premise check (before any code)
+
+Verified at `759f776a2`, not taken from the issue text:
+
+- `SessionSync.SendFence` (`pkg/cluster/sync_failover.go:381`) still writes
+  `syncMsgFence` with a nil payload and returns; the receive arm
+  (`sync_conn_read.go:615`) replies with nothing.
+- `handlePeerTimeout` still runs `electSingleNode()` BEFORE the fence.
+- `LastFenceSeq` / `LastFenceAckAt` are still the bulk-sync install barrier,
+  written under `syncMsgBarrierAck` — unrelated, as the issue warns.
+- `docs/ha-failover-status.md` asserted the gap in prose as well.
+
+Premise UNCHANGED. The deliverable is real work.
+
+## Corrections to the analysis already on the issue
+
+1. It proposed `syncMsgFenceAck = 30`. **30 is `syncMsgConfigKeyExchange`**
+   (#6629). Ids 1–34 are taken; first free is **35**.
+2. It proposed appending a capability bit to `syncMsgPeerCapabilities` as-is,
+   but `sendCapabilities` returned early when `localSnapshotProtocol == 0`, so
+   the capability would have depended on `userspace.ProtocolVersion` staying
+   nonzero. Made the frame unconditional instead; receiver behaviour is
+   unchanged because it already collapses "frame absent" and "version 0".
+
+## Additive-wire argument (verified independently)
+
+- `handleMessage`'s `switch msgType` has ZERO `default:` arms; framing is
+  length-prefixed.
+- The fence sequence is trailing data on an existing type whose old receiver
+  reads no payload.
+- `MinCompatHAProtocolVersion = CurrentHAProtocolVersion` (`heartbeat.go:51`),
+  and `GateMixedBaseSwap` refuses outside `[MinCompat, Current]`
+  (`imageversions.go:156`) AND requires session-sync EXACT equality (`:169`).
+  Bumping either version is what would break the rolling upgrade.
+
+## Design decisions (the issue's three open questions)
+
+- **Q1**: "fenced" = peer-CONFIRMED. Ack written only after
+  `fenceAllRedundancyGroups` returns; carries `rgs_fenced / rgs_total`.
+  Config-only mode answers `unavailable`, not a vacuous 0-of-0 success.
+- **Q2**: bounded 250ms, fail-open. `SendFenceAwait` returns IMMEDIATELY with
+  no active connection, so the ordinary dead-peer takeover pays nothing; the
+  wait is only reachable when the sync socket is live.
+- **Q3**: node-global, matching the existing fence.
+
+## Hazard accepted deliberately
+
+`awaitPeerFenceLocked` releases `m.mu` between marking the peer lost and
+electing. It does NOT abort if a heartbeat lands in that window: the fence has
+already been delivered, so aborting would leave the peer dark AND this node
+passive — a total outage. Documented at the call site.
+
+## Actions
+
+- **Action**: add `syncMsgFenceAck = 35`, the optional fence sequence, the
+  capability flags byte, `peer-fencing disable-rg-confirmed`, and the
+  `Confirmations:` status render.
+  **File(s)**: `pkg/cluster/sync_fence_ack_7147.go`,
+  `pkg/cluster/fence_confirm_7147.go`, `pkg/cluster/sync.go`,
+  `pkg/cluster/sync_conn.go`, `pkg/cluster/sync_conn_read.go`,
+  `pkg/cluster/sync_conn_write.go`, `pkg/cluster/heartbeat_manager.go`,
+  `pkg/cluster/manager.go`, `pkg/cluster/hooks.go`, `pkg/cluster/status.go`,
+  `pkg/daemon/daemon_ha_sync.go`, `pkg/daemon/daemon_ha_comms_wiring.go`,
+  `pkg/config/schema_chassis.go`, `pkg/config/types_chassis.go`
+- **Action**: supersede `TestSendCapabilitiesStaysSilentWhenUnset6650` rather
+  than delete it; add `syncMsgFenceAck` to the live-type uniqueness registry
+  and raise its floor to 35.
+  **File(s)**: `pkg/cluster/sync_capabilities_6650_test.go`
+- **Action**: tests.
+  **File(s)**: `pkg/cluster/fence_ack_7147_test.go`,
+  `pkg/cluster/fence_confirm_7147_test.go`,
+  `pkg/daemon/fence_confirm_wiring_7147_test.go`
+- **Action**: docs.
+  **File(s)**: `docs/ha-failover-status.md`, `pkg/cluster/README.md`,
+  `pkg/daemon/README.md`
+
+## Validation
+
+- `go test -count=1 ./...` green.
+- 10-cell mutation matrix, full-package runs, control clean at 1058/2209 tests
+  collected; every cell red with a NAMED failure.
+- `make test-failover` on `loss:xpf-userspace-fw0/fw1` under the #1875 lock.
+- No Rust source changed, so `make test-rust` is not implicated.
+
+## Note for the next lane
+
+The first ordering test could not have failed: `UpdateConfig` already elects
+the node primary, so both the new and the pre-#7147 ordering would have sampled
+`StatePrimary` inside the callback. The fixture forces `StateSecondary` and
+guards that precondition explicitly.

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -203,9 +203,12 @@ comms restart key.
   `FenceStatus()`: the CURRENTLY configured action (`disabled` when the
   `peer-fencing` leaf is absent, which can differ from the action past
   events were recorded under) plus every `EventFence` attempt and its
-  result. Do not confuse it with the "Install fence:" block above it —
-  that one is the bulk-sync install barrier (`LastFenceSeq`), not the
-  peer split-brain fence.
+  result. Under `disable-rg-confirmed` (#7147) it also renders a
+  `Confirmations:` line off `SyncStats` — `timed out` there counts
+  takeovers that proceeded WITHOUT the confirmation the operator asked
+  for, which no other counter distinguishes. Do not confuse it with the
+  "Install fence:" block above it — that one is the bulk-sync install
+  barrier (`LastFenceSeq`), not the peer split-brain fence.
 - `triggerGARP` (no-op/log hook today — native VRRP owns GARP),
   plus the gratuitous-ARP / unsolicited-NA burst senders — `garp.go`.
   `SendGratuitousARPBurst` / `SendGratuitousIPv6Burst` send the first
@@ -2641,6 +2644,33 @@ standby can re-initiate the primary's tunnels on takeover:
   self-clearing.
 
 ## DHCP-server lease sync (#2239)
+
+### Peer-fence acknowledgement (#7147)
+
+`peer-fencing disable-rg-confirmed` gates takeover on a peer-confirmed fence.
+The mechanism lives in `sync_fence_ack_7147.go` (wire + waiter) and
+`fence_confirm_7147.go` (policy); `docs/ha-failover-status.md` carries the
+operator-facing table.
+
+- **Wire** — one additive message type `syncMsgFenceAck = 35` carries
+  `{seq u64, status u8, rgs_fenced u16, rgs_total u16}` LE. `syncMsgFence`
+  gains an optional 8-byte sequence; seq 0 is RESERVED and means "no ack
+  requested", which is what a pre-#7147 sender's empty payload decodes to. A
+  capability bit rides the trailing byte of `syncMsgPeerCapabilities` (#6650),
+  which is why `sendCapabilities` is now unconditional — see its comment.
+  No `SessionSyncWireVersion` / `CurrentHAProtocolVersion` bump, for the same
+  reason as #2239 and #6650 below: `MinCompatHAProtocolVersion ==
+  CurrentHAProtocolVersion`, so the accepted window is a single point and a
+  bump would make `GateMixedBaseSwap` refuse the rolling upgrade.
+- **The ack means peer-CONFIRMED, not received.** It is written only after the
+  receiver's `fenceAllRedundancyGroups` returns, and reports what that
+  achieved. The decoder REFUSES a short frame rather than zero-filling it:
+  status 0 is `FenceAckOK`, so a lenient decode would turn fabric corruption
+  into a fabricated confirmation.
+- **It always fails open.** No connection, no capability, write error, timeout,
+  or a negative ack all proceed with the takeover, each recorded to
+  `EventFence` with its reason. `SendFenceAwait` returns immediately when there
+  is no active connection, so the ordinary dead-peer takeover pays nothing.
 
 DHCP-server (Kea) leases ride the SAME session-sync channel and follow the
 IPsec-SA-sync precedent (`QueueIPsecSA` / `peerIPsecSAs` /

--- a/pkg/cluster/fence_ack_7147_test.go
+++ b/pkg/cluster/fence_ack_7147_test.go
@@ -1,0 +1,537 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #7147 — peer-fence acknowledgement.
+//
+// The property under test throughout is a CONJUNCTION, and both halves matter
+// in opposite directions:
+//
+//   - the gate must actually gate: a reachable peer's confirmation is obtained
+//     BEFORE this node claims the redundancy groups; and
+//   - the gate must never withhold ownership: every failure path proceeds with
+//     the takeover, and says so where an operator can see it.
+//
+// A test suite that only checked the first would certify a design that turns
+// every peer failure into an outage, so the fail-open paths get equal weight.
+
+// ---------------------------------------------------------------------------
+// Wire encoding
+// ---------------------------------------------------------------------------
+
+func TestFenceAckPayloadRoundTrips7147(t *testing.T) {
+	t.Parallel()
+	res := FenceResult{RGsFenced: 3, RGsTotal: 4, DataplaneAvailable: true}
+	got, ok := decodeFenceAckPayload(encodeFenceAckPayload(42, res))
+	if !ok {
+		t.Fatal("a well-formed fence ack payload failed to decode")
+	}
+	if got.Seq != 42 {
+		t.Errorf("Seq = %d, want 42", got.Seq)
+	}
+	if got.RGsFenced != 3 || got.RGsTotal != 4 {
+		t.Errorf("counts = %d/%d, want 3/4", got.RGsFenced, got.RGsTotal)
+	}
+	if got.Status != FenceAckPartial {
+		t.Errorf("Status = %d, want FenceAckPartial (%d) — 3 of 4 fenced is not a confirmation",
+			got.Status, FenceAckPartial)
+	}
+	if got.Confirmed() {
+		t.Error("a 3-of-4 fence reported Confirmed(); the surviving node would " +
+			"believe the peer went fully dark when one RG may still be forwarding")
+	}
+}
+
+// A truncated ack must be DROPPED, not partially decoded.
+//
+// This is the cell that matters most in the file: the status code lives at
+// offset 8 and FenceAckOK is 0, so a short frame zero-filled by a lenient
+// decoder reads as a SUCCESSFUL CONFIRMATION. The failure mode of getting this
+// wrong is not "a malformed frame is mishandled", it is "corruption on the
+// fabric authorises a takeover that was never confirmed" — indistinguishable
+// from healthy at every layer above.
+func TestFenceAckShortFrameIsRejectedNotZeroFilled7147(t *testing.T) {
+	t.Parallel()
+	full := encodeFenceAckPayload(7, FenceResult{RGsFenced: 2, RGsTotal: 2, DataplaneAvailable: true})
+	if len(full) != fenceAckPayloadLen {
+		t.Fatalf("encoded length = %d, want %d", len(full), fenceAckPayloadLen)
+	}
+	for n := 0; n < fenceAckPayloadLen; n++ {
+		if _, ok := decodeFenceAckPayload(full[:n]); ok {
+			t.Errorf("a %d-byte fence ack decoded; short frames must be refused", n)
+		}
+	}
+	// Demonstrate the hazard the length gate exists to prevent, so a future
+	// reader can see why "just decode what is there" is not an option.
+	zeroFilled := make([]byte, fenceAckPayloadLen)
+	binary.LittleEndian.PutUint64(zeroFilled[0:8], 7)
+	decoded, ok := decodeFenceAckPayload(zeroFilled)
+	if !ok || !decoded.Confirmed() {
+		t.Fatalf("expected a zero-filled body to read as a CONFIRMED ack (ok=%v confirmed=%v); "+
+			"if this ever stops being true the rationale above needs revisiting",
+			ok, decoded.Confirmed())
+	}
+}
+
+// Extra trailing bytes from a future peer must not break the decode — the
+// #2170 trailing-field discipline this wire relies on.
+func TestFenceAckToleratesTrailingBytes7147(t *testing.T) {
+	t.Parallel()
+	payload := append(encodeFenceAckPayload(9, FenceResult{RGsFenced: 1, RGsTotal: 1, DataplaneAvailable: true}),
+		0xDE, 0xAD, 0xBE, 0xEF)
+	got, ok := decodeFenceAckPayload(payload)
+	if !ok {
+		t.Fatal("a longer ack from a newer peer was refused; trailing fields must be skipped")
+	}
+	if got.Seq != 9 || !got.Confirmed() {
+		t.Errorf("trailing bytes corrupted the decode: %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// What "fenced" means
+// ---------------------------------------------------------------------------
+
+// The MIDDLE rows are the point of this table. An implementation that returned
+// FenceAckOK unconditionally passes an all-success table, and an implementation
+// that never returns OK passes an all-failure one.
+func TestFenceResultStatusMapping7147(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		res  FenceResult
+		want uint8
+	}{
+		{"every rg fenced", FenceResult{RGsFenced: 4, RGsTotal: 4, DataplaneAvailable: true}, FenceAckOK},
+		{"one rg failed", FenceResult{RGsFenced: 3, RGsTotal: 4, DataplaneAvailable: true}, FenceAckPartial},
+		{"no rg fenced", FenceResult{RGsFenced: 0, RGsTotal: 4, DataplaneAvailable: true}, FenceAckPartial},
+		// A node with a dataplane and no RGs owns nothing and so cannot
+		// split-brain: that is a real confirmation, not a vacuous one.
+		{"no rgs configured", FenceResult{RGsFenced: 0, RGsTotal: 0, DataplaneAvailable: true}, FenceAckOK},
+		// ...which is exactly why config-only mode must NOT fold into the row
+		// above. "Nothing to disable" and "unable to disable anything" look
+		// identical in the counts and mean opposite things.
+		{"config-only mode", FenceResult{RGsFenced: 0, RGsTotal: 0, DataplaneAvailable: false}, FenceAckUnavailable},
+		{"config-only with rgs", FenceResult{RGsFenced: 0, RGsTotal: 3, DataplaneAvailable: false}, FenceAckUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.res.Status(); got != tt.want {
+				t.Errorf("Status() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnlyOKStatusConfirms7147(t *testing.T) {
+	t.Parallel()
+	for _, st := range []uint8{FenceAckPartial, FenceAckUnavailable, 99} {
+		if (FenceAck{Status: st}).Confirmed() {
+			t.Errorf("status %d reported Confirmed(); only FenceAckOK may authorise a "+
+				"takeover to be reported as fenced", st)
+		}
+	}
+	if !(FenceAck{Status: FenceAckOK}).Confirmed() {
+		t.Error("FenceAckOK did not report Confirmed()")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sequence matching
+// ---------------------------------------------------------------------------
+
+// A late ack from an EARLIER fence must not satisfy a later one.
+//
+// Without the seq match the gate is worse than absent: it reports a
+// confirmation the peer never gave for the fence in question, and it does so
+// instantly, so the operator sees "Fence confirmed by peer" on a takeover that
+// was never acknowledged.
+func TestFenceAckSeqMustMatchTheWaiter7147(t *testing.T) {
+	t.Parallel()
+	s := &SessionSync{}
+	waiter := make(chan FenceAck, 1)
+	s.fenceAckMu.Lock()
+	s.fenceAckWaiters = map[uint64]chan FenceAck{5: waiter}
+	s.fenceAckMu.Unlock()
+
+	// A stale ack for a previous fence.
+	s.completeFenceAckWait(FenceAck{Seq: 4, Status: FenceAckOK})
+	select {
+	case ack := <-waiter:
+		t.Fatalf("a stale ack (seq 4) satisfied the seq-5 waiter: %+v", ack)
+	default:
+	}
+
+	// An ack from a FUTURE fence must not satisfy it either.
+	s.completeFenceAckWait(FenceAck{Seq: 6, Status: FenceAckOK})
+	select {
+	case ack := <-waiter:
+		t.Fatalf("a seq-6 ack satisfied the seq-5 waiter: %+v", ack)
+	default:
+	}
+
+	s.completeFenceAckWait(FenceAck{Seq: 5, Status: FenceAckOK, RGsFenced: 2, RGsTotal: 2})
+	select {
+	case ack := <-waiter:
+		if ack.Seq != 5 || !ack.Confirmed() {
+			t.Fatalf("matching ack delivered wrong: %+v", ack)
+		}
+	default:
+		t.Fatal("the matching seq-5 ack did not reach its waiter")
+	}
+
+	// The waiter is consumed: a duplicate must find nothing and must not panic
+	// or block the receive loop.
+	s.completeFenceAckWait(FenceAck{Seq: 5, Status: FenceAckOK})
+}
+
+// Sequences must start at 1, because 0 is the reserved "no ack requested"
+// value a pre-#7147 fence's empty payload decodes to. A generator starting at
+// 0 would make the first fence of every boot indistinguishable from an
+// unsequenced one, and the peer would silently not reply to it.
+func TestFenceSeqNeverAllocatesZero7147(t *testing.T) {
+	t.Parallel()
+	s := &SessionSync{}
+	if first := s.fenceSeq.Add(1); first != 1 {
+		t.Fatalf("first allocated fence seq = %d, want 1 (0 is reserved on the wire)", first)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fail-open: the paths that must NOT spend the timeout
+// ---------------------------------------------------------------------------
+
+// The dead-peer takeover — the case the whole feature must not slow down —
+// and the rolling-upgrade case, both of which must return immediately.
+func TestSendFenceAwaitFailsOpenImmediately7147(t *testing.T) {
+	t.Parallel()
+
+	t.Run("peer not connected", func(t *testing.T) {
+		t.Parallel()
+		s := &SessionSync{}
+		start := time.Now()
+		_, err := s.SendFenceAwait(10 * time.Second)
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("SendFenceAwait succeeded with no connection")
+		}
+		if !strings.Contains(err.Error(), "not connected") {
+			t.Errorf("err = %q, want it to name the missing connection", err)
+		}
+		// The assertion that matters: it did not wait. With no socket there is
+		// nothing to wait for, and this is the ordinary dead-peer takeover.
+		if elapsed > time.Second {
+			t.Errorf("took %s with no peer connected; a dead peer must never spend "+
+				"the fence timeout — that would convert peer loss into an outage", elapsed)
+		}
+	})
+
+	t.Run("peer predates 7147", func(t *testing.T) {
+		t.Parallel()
+		client, server := net.Pipe()
+		defer client.Close()
+		defer server.Close()
+		s := &SessionSync{}
+		s.conn0 = client
+		// No capability flags stored: this is what a pre-#7147 peer looks
+		// like, and it will never answer.
+		start := time.Now()
+		_, err := s.SendFenceAwait(10 * time.Second)
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("SendFenceAwait succeeded against a peer that cannot acknowledge")
+		}
+		if !strings.Contains(err.Error(), "does not support") {
+			t.Errorf("err = %q, want it to name the missing capability", err)
+		}
+		if elapsed > time.Second {
+			t.Errorf("took %s against an incapable peer; during a rolling upgrade every "+
+				"peer loss would pay the full timeout for an answer that can never come",
+				elapsed)
+		}
+	})
+}
+
+// A disconnect during the wait must release the waiter immediately rather than
+// holding the takeover until the timeout for an answer that can no longer
+// arrive.
+func TestDisconnectReleasesFenceAckWaiters7147(t *testing.T) {
+	t.Parallel()
+	s := &SessionSync{}
+	waiter := make(chan FenceAck, 1)
+	s.fenceAckMu.Lock()
+	s.fenceAckWaiters = map[uint64]chan FenceAck{1: waiter}
+	s.fenceAckMu.Unlock()
+
+	s.abortFenceAckWaiters()
+
+	select {
+	case _, ok := <-waiter:
+		if ok {
+			t.Fatal("abort delivered a VALUE; it must close the channel so the sender " +
+				"can tell 'peer went away' from 'peer answered' — a delivered zero value " +
+				"has Status 0 == FenceAckOK and would read as a confirmation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("abortFenceAckWaiters did not release the pending waiter")
+	}
+
+	// Idempotent: a second full disconnect must not double-close.
+	s.abortFenceAckWaiters()
+}
+
+// ---------------------------------------------------------------------------
+// Receive path
+// ---------------------------------------------------------------------------
+
+// An UNSEQUENCED fence (what every pre-#7147 sender writes) must still fence
+// locally and must send no ack. This is the receiver half of the additive
+// claim: an old peer's fence keeps working unchanged.
+func TestUnsequencedFenceStillFencesAndSendsNoAck7147(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	fenced := make(chan struct{}, 1)
+	s := &SessionSync{}
+	s.OnFenceReceived = func() FenceResult {
+		fenced <- struct{}{}
+		return FenceResult{RGsFenced: 1, RGsTotal: 1, DataplaneAvailable: true}
+	}
+
+	// nil payload — exactly what SendFence writes.
+	go s.handleMessage(client, syncMsgFence, nil)
+
+	select {
+	case <-fenced:
+	case <-time.After(2 * time.Second):
+		t.Fatal("an unsequenced fence did not run the local fence handler")
+	}
+	if got := s.stats.FencesReceived.Load(); got != 1 {
+		t.Errorf("FencesReceived = %d, want 1", got)
+	}
+	assertNoFrame(t, server)
+	if got := s.stats.FenceAcksSent.Load(); got != 0 {
+		t.Errorf("FenceAcksSent = %d, want 0 — an unsequenced fence must not be acked", got)
+	}
+}
+
+// A SEQUENCED fence must run the local fence and reply with what it achieved,
+// and the reply must be written only AFTER the fence has been applied. An ack
+// that raced ahead of the fence would confirm nothing.
+func TestSequencedFenceIsAckedAfterFencing7147(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	applied := make(chan struct{})
+	s := &SessionSync{}
+	s.OnFenceReceived = func() FenceResult {
+		close(applied)
+		return FenceResult{RGsFenced: 2, RGsTotal: 3, DataplaneAvailable: true}
+	}
+
+	var payload [8]byte
+	binary.LittleEndian.PutUint64(payload[:], 77)
+	go s.handleMessage(client, syncMsgFence, payload[:])
+
+	msgType, body := readFrame(t, server)
+	select {
+	case <-applied:
+	default:
+		t.Fatal("the ack frame was written BEFORE OnFenceReceived ran; an ack that " +
+			"precedes the fence confirms nothing and the gate becomes a lie")
+	}
+	if msgType != syncMsgFenceAck {
+		t.Fatalf("reply type = %d, want syncMsgFenceAck (%d)", msgType, syncMsgFenceAck)
+	}
+	ack, ok := decodeFenceAckPayload(body)
+	if !ok {
+		t.Fatalf("the production ack frame failed its own decoder: % x", body)
+	}
+	if ack.Seq != 77 {
+		t.Errorf("ack seq = %d, want the fence's 77 — an ack that does not echo the "+
+			"sequence cannot be matched to its fence", ack.Seq)
+	}
+	if ack.Status != FenceAckPartial || ack.RGsFenced != 2 || ack.RGsTotal != 3 {
+		t.Errorf("ack = %+v, want the handler's real 2-of-3 partial result; the ack must "+
+			"report what the fence ACHIEVED, not merely that it was received", ack)
+	}
+}
+
+// A fence with no handler wired must still answer, and must answer NEGATIVELY.
+// Silence would make the sender wait out its timeout; a positive ack would
+// claim a fence that never ran.
+func TestSequencedFenceWithNoHandlerAcksUnavailable7147(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	s := &SessionSync{}
+	var payload [8]byte
+	binary.LittleEndian.PutUint64(payload[:], 5)
+	go s.handleMessage(client, syncMsgFence, payload[:])
+
+	msgType, body := readFrame(t, server)
+	if msgType != syncMsgFenceAck {
+		t.Fatalf("reply type = %d, want syncMsgFenceAck", msgType)
+	}
+	ack, ok := decodeFenceAckPayload(body)
+	if !ok {
+		t.Fatalf("undecodable ack: % x", body)
+	}
+	if ack.Confirmed() {
+		t.Errorf("a node with no fence handler CONFIRMED the fence (%+v); it disabled "+
+			"nothing, so the surviving node would take over believing the peer is dark", ack)
+	}
+}
+
+// A truncated ack on the receive path must be dropped rather than delivered as
+// a confirmation.
+func TestTruncatedFenceAckIsDropped7147(t *testing.T) {
+	t.Parallel()
+	s := &SessionSync{}
+	waiter := make(chan FenceAck, 1)
+	s.fenceAckMu.Lock()
+	s.fenceAckWaiters = map[uint64]chan FenceAck{1: waiter}
+	s.fenceAckMu.Unlock()
+
+	short := encodeFenceAckPayload(1, FenceResult{RGsFenced: 1, RGsTotal: 1, DataplaneAvailable: true})
+	s.handleMessage(nil, syncMsgFenceAck, short[:fenceAckPayloadLen-1])
+
+	select {
+	case ack := <-waiter:
+		t.Fatalf("a truncated ack was delivered to the waiter: %+v", ack)
+	default:
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Capability advertisement
+// ---------------------------------------------------------------------------
+
+func TestPeerFenceAckCapabilityDecoding7147(t *testing.T) {
+	t.Parallel()
+	s := &SessionSync{}
+	if s.PeerFenceAckCapable() {
+		t.Error("a peer that advertised nothing reported fence-ack capable; a " +
+			"confirmed-fence gate would then wait out its timeout on every takeover")
+	}
+
+	// A pre-#7147 peer: 2-byte frame, version only, no flags.
+	twoByte := make([]byte, 2)
+	binary.LittleEndian.PutUint16(twoByte, 8)
+	s.handleMessage(nil, syncMsgPeerCapabilities, twoByte)
+	if s.PeerSnapshotProtocolVersion() != 8 {
+		t.Errorf("version = %d, want 8 — the #6650 field must still decode from a "+
+			"2-byte frame", s.PeerSnapshotProtocolVersion())
+	}
+	if s.PeerFenceAckCapable() {
+		t.Error("a 2-byte (pre-#7147) capability frame was read as fence-ack capable")
+	}
+
+	// A #7147 peer.
+	threeByte := append(twoByte, capFlagFenceAck)
+	s.handleMessage(nil, syncMsgPeerCapabilities, threeByte)
+	if !s.PeerFenceAckCapable() {
+		t.Error("a peer advertising capFlagFenceAck was not read as capable, so the " +
+			"gate would never arm even between two current nodes")
+	}
+
+	// A downgrade on reconnect must revoke it.
+	s.handleMessage(nil, syncMsgPeerCapabilities, twoByte)
+	if s.PeerFenceAckCapable() {
+		t.Error("capability survived a peer re-advertising without the flag")
+	}
+}
+
+// This build must actually advertise the capability, or no peer can ever gate
+// on it. Binds the constant to the flag rather than assuming they agree.
+func TestThisBuildAdvertisesFenceAckCapability7147(t *testing.T) {
+	t.Parallel()
+	if localCapabilityFlags&capFlagFenceAck == 0 {
+		t.Fatal("localCapabilityFlags does not set capFlagFenceAck, so this node tells " +
+			"its peer it cannot acknowledge fences and every confirmed-fence takeover " +
+			"on a fully-upgraded cluster fails open")
+	}
+}
+
+// The capability must not survive the peer incarnation that proved it — the
+// same scoping #6650 applies to the version field, and it is bound to the real
+// disconnect path rather than to a hand-driven store.
+func TestDisconnectClearsFenceAckCapability7147(t *testing.T) {
+	t.Parallel()
+	src := readClusterSource(t, "sync_conn.go")
+	if !sourceContainsFlat(src, "s.peerCapabilityFlags.Store(0)") {
+		t.Error("the full-disconnect path does not clear peerCapabilityFlags. A " +
+			"downgraded peer that reconnects would inherit the previous incarnation's " +
+			"fence-ack bit, and every takeover against it would wait out the full " +
+			"timeout for an ack it can never send.")
+	}
+	if !sourceContainsFlat(src, "s.abortFenceAckWaiters()") {
+		t.Error("the full-disconnect path does not release pending fence-ack waiters, " +
+			"so a fence sent moments before the fabric dropped holds the takeover for " +
+			"the whole timeout")
+	}
+	if !sourceContainsFlat(src, "s.peerSnapshotProtocol.Store(0)") {
+		t.Error("the #6650 clear these are anchored beside has moved; re-verify both " +
+			"#7147 clears are still on the FULL-disconnect path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func readFrame(t *testing.T, conn net.Conn) (uint8, []byte) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	hdr := make([]byte, syncHeaderSize)
+	if _, err := io.ReadFull(conn, hdr); err != nil {
+		t.Fatalf("read frame header: %v", err)
+	}
+	length := binary.LittleEndian.Uint32(hdr[8:12])
+	body := make([]byte, length)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		t.Fatalf("read frame body: %v", err)
+	}
+	return hdr[4], body
+}
+
+// assertNoFrame fails if anything arrives within a short window.
+func assertNoFrame(t *testing.T, conn net.Conn) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 64)
+	n, err := conn.Read(buf)
+	if err == nil {
+		t.Fatalf("unexpected %d-byte frame on the wire: % x", n, buf[:n])
+	}
+	var ne net.Error
+	if !isTimeout(err, &ne) {
+		t.Fatalf("read failed for a reason other than the expected timeout: %v", err)
+	}
+}
+
+func isTimeout(err error, ne *net.Error) bool {
+	if e, ok := err.(net.Error); ok {
+		*ne = e
+		return e.Timeout()
+	}
+	return false
+}
+

--- a/pkg/cluster/fence_confirm_7147.go
+++ b/pkg/cluster/fence_confirm_7147.go
@@ -1,0 +1,104 @@
+package cluster
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Confirmed peer fencing policy (#7147).
+
+const (
+	// PeerFencingDisableRG is the original best-effort fence: send
+	// syncMsgFence and take over regardless. Behaviour is unchanged by #7147.
+	PeerFencingDisableRG = "disable-rg"
+
+	// PeerFencingDisableRGConfirmed sends a SEQUENCED fence before the
+	// single-node election and waits, bounded, for the peer to confirm that it
+	// disabled every redundancy group in its live config.
+	//
+	// It is strictly an ORDERING guarantee for the reachable-peer case, never
+	// an availability risk — every failure path proceeds with the takeover.
+	PeerFencingDisableRGConfirmed = "disable-rg-confirmed"
+)
+
+// FenceConfirmTimeout bounds the wait for a peer fence acknowledgement.
+//
+// HOW THIS NUMBER WAS CHOSEN, and why it is a constant rather than a knob.
+//
+// The wait can only be entered when the session-sync socket is live
+// (SendFenceAwait returns immediately with "peer not connected" otherwise), so
+// the EXPECTED cost is one TCP round trip on the fabric link plus the peer's
+// fenceAllRedundancyGroups — sub-millisecond plus a handful of dataplane
+// writes. 250ms is roughly three orders of magnitude of headroom over that.
+//
+// The bound matters for the one case that does spend it: a peer that has lost
+// power while its TCP socket has not yet noticed. There the socket looks alive,
+// no ack ever comes, and this timeout is what releases the takeover. It is
+// therefore sized against the heartbeat detection window that precedes it —
+// 200ms interval x threshold 5 = ~1s — so the worst case adds ~25% to a
+// detection that has already taken a second, rather than to the ~60ms VRRP
+// number, which this path is not on.
+//
+// It is not configurable because there is no operator input that would improve
+// it: shorter defeats the purpose on a loaded fabric, longer extends an outage
+// window in the only case that reaches it, and the policy leaf already
+// expresses the one decision an operator actually has (gate, or do not).
+const FenceConfirmTimeout = 250 * time.Millisecond
+
+// awaitPeerFenceLocked runs the confirmed peer fence.
+//
+// Called with m.mu HELD; it releases the lock across the network wait and
+// re-acquires it before returning, exactly as the `disable-rg` fence branch in
+// handlePeerTimeout does. handlePeerTimeout holds m.mu via defer, so the caller
+// keeps the lock afterwards either way.
+//
+// IT ALWAYS RETURNS AND NEVER BLOCKS THE TAKEOVER INDEFINITELY. That is the
+// central safety property, so it is worth stating what each path costs:
+//
+//   - no confirm function armed: returns immediately.
+//   - peer not connected: SendFenceAwait returns immediately. This is the
+//     ordinary dead-peer takeover and it is why the policy does not slow it
+//     down — with no socket there is nothing to wait on.
+//   - peer predates #7147: SendFenceAwait returns immediately on the missing
+//     capability, so a rolling upgrade never pays the timeout.
+//   - write failed: returns immediately.
+//   - peer answered: the common reachable-peer case, one fabric round trip.
+//   - peer silent with a live socket: bounded by FenceConfirmTimeout, then
+//     proceeds anyway.
+//
+// A takeover that proceeded WITHOUT confirmation is recorded to the EventFence
+// history with the reason, because the operator selected this policy expecting
+// a guarantee and the one case where they did not get it must be visible. It is
+// also counted in SyncStats.FenceAcksTimedOut for the timeout case.
+func (m *Manager) awaitPeerFenceLocked() {
+	fn := m.peerFenceConfirmFn
+	if fn == nil {
+		slog.Warn("cluster: fence: sync not available, taking over without peer confirmation")
+		m.history.Record(EventFence, -1, "Fence skipped: sync not available")
+		return
+	}
+
+	// Release the lock for the network call + bounded wait.
+	m.mu.Unlock()
+	ack, err := fn(FenceConfirmTimeout)
+	m.mu.Lock()
+
+	if err != nil {
+		slog.Warn("cluster: fence: taking over WITHOUT peer confirmation", "err", err)
+		m.history.Record(EventFence, -1, fmt.Sprintf("Fence unconfirmed, took over anyway: %v", err))
+		return
+	}
+	if ack.Confirmed() {
+		slog.Info("cluster: fence: peer confirmed fence",
+			"rgs_fenced", ack.RGsFenced, "rgs_total", ack.RGsTotal)
+		m.history.Record(EventFence, -1, fmt.Sprintf("Fence confirmed by peer (%s)", ack.Reason()))
+		return
+	}
+	// A negative ack is not retried: the peer has already told us it could not
+	// fully comply, and repeating the request cannot change that within the
+	// takeover window. Fail open, loudly.
+	slog.Warn("cluster: fence: peer reported an INCOMPLETE fence, taking over anyway",
+		"status", ack.Status, "rgs_fenced", ack.RGsFenced, "rgs_total", ack.RGsTotal)
+	m.history.Record(EventFence, -1, fmt.Sprintf("Fence NOT confirmed (%s), took over anyway", ack.Reason()))
+}

--- a/pkg/cluster/fence_confirm_7147.go
+++ b/pkg/cluster/fence_confirm_7147.go
@@ -71,6 +71,28 @@ const FenceConfirmTimeout = 250 * time.Millisecond
 // history with the reason, because the operator selected this policy expecting
 // a guarantee and the one case where they did not get it must be visible. It is
 // also counted in SyncStats.FenceAcksTimedOut for the timeout case.
+//
+// TWO CONSEQUENCES OF RELEASING m.mu HERE, both deliberate.
+//
+// First, this widens a window that `disable-rg` does not have. Under
+// `disable-rg` the peer-loss decision and electSingleNode run under one
+// unbroken hold of m.mu; here the lock is released between them, so a peer
+// heartbeat can land during the wait and set peerAlive back to true before the
+// election runs. This function does NOT abort on that, and must not: by the
+// time it could notice, the fence has already been delivered and the peer has
+// disabled every RG it owns. Aborting the takeover at that point would leave
+// the peer dark AND this node passive — a total outage, and a strictly worse
+// outcome than the momentary dual-primary the abort would be trying to avoid.
+// Having fenced, committing to the takeover is the only safe direction. (The
+// #2080 pre-guard re-check at the top of handlePeerTimeout still applies; it
+// runs BEFORE anything has been fenced, which is what makes aborting safe
+// there and unsafe here.)
+//
+// Second, handlePeerTimeout runs on the heartbeat receive path, so the wait
+// also delays heartbeat processing by up to FenceConfirmTimeout. That is
+// bounded, opt-in, and confined to the peer-loss event itself, which is why it
+// is accepted rather than moved to a goroutine — a fence that completed
+// asynchronously could not gate the election it exists to precede.
 func (m *Manager) awaitPeerFenceLocked() {
 	fn := m.peerFenceConfirmFn
 	if fn == nil {

--- a/pkg/cluster/fence_confirm_7147.go
+++ b/pkg/cluster/fence_confirm_7147.go
@@ -28,23 +28,40 @@ const (
 //
 // The wait can only be entered when the session-sync socket is live
 // (SendFenceAwait returns immediately with "peer not connected" otherwise), so
-// the EXPECTED cost is one TCP round trip on the fabric link plus the peer's
-// fenceAllRedundancyGroups — sub-millisecond plus a handful of dataplane
-// writes. 250ms is roughly three orders of magnitude of headroom over that.
+// the ordinary dead-peer takeover never spends any of it.
 //
-// The bound matters for the one case that does spend it: a peer that has lost
-// power while its TCP socket has not yet noticed. There the socket looks alive,
-// no ack ever comes, and this timeout is what releases the takeover. It is
-// therefore sized against the heartbeat detection window that precedes it —
-// 200ms interval x threshold 5 = ~1s — so the worst case adds ~25% to a
-// detection that has already taken a second, rather than to the ~60ms VRRP
-// number, which this path is not on.
+// WHAT THE PEER ACTUALLY DOES BEFORE IT CAN ANSWER. This was mis-sized at
+// first, on the assumption that the receiver's fence is a fabric round trip
+// plus "a handful of dataplane writes". It is not. Each RG's
+// SetRGActive(false) reaches userspace Manager.UpdateRGActive, which takes the
+// helper manager's OWN mutex — shared with the 1/s status poll, session
+// installs and snapshot apply — and issues an `update_ha_state` request on the
+// shared control socket, whose base deadline is controlBaseDeadline = 3s
+// (pkg/dataplane/userspace/process_control.go). That happens once per RG,
+// sequentially, and the reply then queues behind s.writeMu, which a stalled
+// send loop can hold for syncWriteDeadline = 2s. A peer loss frequently
+// follows a fabric reconnect, i.e. exactly when that socket is most contended.
+//
+// So no bound short enough to sit in a takeover path can GUARANTEE the ack
+// arrives. This value is therefore a POLICY bound, not a derivation of the
+// peer's worst case: wait long enough that an uncontended cluster — where the
+// round trip is milliseconds — actually gets its confirmation, and fail open
+// rather than let a contended control socket hold the takeover.
+//
+// 1s is that compromise. It comfortably covers several control round trips on
+// an idle helper, it is bounded well below a single 3s control deadline so a
+// genuinely wedged socket fails open instead of stalling, and it is on the
+// order of the ~1s heartbeat detection (200ms interval x threshold 5) that
+// already elapsed before this code runs — not the ~60ms VRRP number, which
+// this path is not on. FenceAcksTimedOut is what tells an operator the bound
+// is being exceeded in practice.
 //
 // It is not configurable because there is no operator input that would improve
-// it: shorter defeats the purpose on a loaded fabric, longer extends an outage
-// window in the only case that reaches it, and the policy leaf already
-// expresses the one decision an operator actually has (gate, or do not).
-const FenceConfirmTimeout = 250 * time.Millisecond
+// it: shorter stops the gate ever engaging on a loaded fabric, longer extends
+// an outage window in the only case that reaches it, and the policy leaf
+// already expresses the one decision an operator actually has (gate, or do
+// not).
+const FenceConfirmTimeout = 1 * time.Second
 
 // awaitPeerFenceLocked runs the confirmed peer fence.
 //
@@ -88,11 +105,18 @@ const FenceConfirmTimeout = 250 * time.Millisecond
 // runs BEFORE anything has been fenced, which is what makes aborting safe
 // there and unsafe here.)
 //
-// Second, handlePeerTimeout runs on the heartbeat receive path, so the wait
-// also delays heartbeat processing by up to FenceConfirmTimeout. That is
-// bounded, opt-in, and confined to the peer-loss event itself, which is why it
-// is accepted rather than moved to a goroutine — a fence that completed
-// asynchronously could not gate the election it exists to precede.
+// Second, on WHICH goroutine this blocks — the answer matters, because
+// believing it was the receive path is what made the hazard above look
+// impossible. handlePeerTimeout runs on heartbeatReceiver.timeoutLoop, a
+// dedicated ticker goroutine (heartbeat.go), NOT on the frame-receive path
+// that runs handlePeerHeartbeat. Those are different goroutines, so the
+// receive path keeps running for the whole wait — which is precisely how a
+// late heartbeat gets in to flip peerAlive.
+//
+// The cost of the wait itself is therefore only a delayed next timeout tick,
+// which is harmless: the re-entry hits handlePeerTimeout's `!m.peerAlive`
+// early return. The wait is not moved to a goroutine because a fence that
+// completed asynchronously could not gate the election it exists to precede.
 func (m *Manager) awaitPeerFenceLocked() {
 	fn := m.peerFenceConfirmFn
 	if fn == nil {
@@ -105,6 +129,38 @@ func (m *Manager) awaitPeerFenceLocked() {
 	m.mu.Unlock()
 	ack, err := fn(FenceConfirmTimeout)
 	m.mu.Lock()
+	// RE-ESTABLISH THE PEER-LOST DECISION. This is not defensive tidying; it
+	// repairs an atomicity that releasing m.mu above breaks, and getting it
+	// wrong strands the cluster with NO primary.
+	//
+	// handlePeerTimeout sets m.peerAlive = false specifically so that
+	// electSingleNode's #7161 readiness gate — armed only when
+	// `m.controlInterface != "" && (m.peerAlive || !m.peerEverSeen)`
+	// (election.go) — is BYPASSED on a genuine peer loss. Pre-#7147 that write
+	// and the election ran under one unbroken hold, so nothing could flip it in
+	// between. The wait above opens exactly that window, and
+	// handlePeerHeartbeat runs on a DIFFERENT goroutine that is blocked on
+	// m.mu: the moment we release it, a late heartbeat frame can set
+	// peerAlive = true.
+	//
+	// The consequence is not a stale field. It re-arms the readiness gate, so
+	// electSingleNode reaches `if !promote { continue }` and declines to
+	// promote — AFTER the fence has already driven every RG on the peer to
+	// rg_active=false. Peer dark, this node passive: the total outage this
+	// policy exists to avoid, produced by the policy itself.
+	//
+	// So the peer-loss decision, which was made and acted on before the fence
+	// went out, is re-asserted here. It is honest as well as necessary: we have
+	// just told the peer to relinquish everything, so "the peer does not own
+	// its groups" is exactly the state we created. A genuinely-recovered peer
+	// re-establishes peerAlive on its next heartbeat (<= one interval) and the
+	// normal election reconverges — the same recovery path as before #7147.
+	//
+	// Only peerAlive is restored: it is the sole field in the peer-loss block
+	// that electSingleNode's promotion decision reads. peerGroups/peerMonitors
+	// are rebuilt by whichever heartbeat won the window and do not gate
+	// promotion.
+	m.peerAlive = false
 
 	if err != nil {
 		slog.Warn("cluster: fence: taking over WITHOUT peer confirmation", "err", err)

--- a/pkg/cluster/fence_confirm_7147_test.go
+++ b/pkg/cluster/fence_confirm_7147_test.go
@@ -1,0 +1,313 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #7147 — the `peer-fencing disable-rg-confirmed` policy at the Manager level.
+//
+// Two properties, and the suite is only meaningful if it holds BOTH:
+//
+//  1. ORDERING. The fence is sent and confirmed BEFORE this node claims the
+//     redundancy groups. Without this the policy is decoration.
+//  2. LIVENESS. Every way the confirmation can fail still results in a
+//     takeover. Without this the policy is an outage generator, and it would be
+//     a worse defect than the gap #7147 set out to close.
+
+// confirmFenceManager returns a manager armed with the confirmed policy, primed
+// so handlePeerTimeout runs its fence branch.
+func confirmFenceManager(t *testing.T) *Manager {
+	t.Helper()
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100}))
+	cfg.PeerFencing = PeerFencingDisableRGConfirmed
+	m.UpdateConfig(cfg)
+	m.mu.Lock()
+	m.peerAlive = true
+	m.peerEverSeen = true
+	// Force SECONDARY. UpdateConfig already elects this node primary (it has
+	// the higher priority and no peer state is known), and from a
+	// already-primary start NOTHING electSingleNode does is observable — the
+	// ordering test below would then pass identically against the pre-#7147
+	// fence-after-election shape. Starting secondary is what makes the
+	// discriminator actually vary.
+	for _, rg := range m.groups {
+		rg.State = StateSecondary
+	}
+	m.mu.Unlock()
+	return m
+}
+
+func rgState(t *testing.T, m *Manager, rgID int) NodeState {
+	t.Helper()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	rg, ok := m.groups[rgID]
+	if !ok {
+		t.Fatalf("redundancy group %d missing", rgID)
+	}
+	return rg.State
+}
+
+// THE CORE CLAIM. Under `disable-rg-confirmed` the fence must be issued while
+// this node still does NOT own the groups — that ordering is the entire
+// difference between this policy and `disable-rg`.
+//
+// The assertion is made from INSIDE the confirm callback, sampling the real RG
+// state at the moment the fence is issued. Asserting only the end state would
+// pass just as happily with the pre-#7147 ordering (fence after election),
+// because both orderings end with the node primary.
+func TestConfirmedFenceRunsBeforeElection7147(t *testing.T) {
+	m := confirmFenceManager(t)
+
+	// Guard the discriminator: if the fixture were already primary, both
+	// orderings would sample StatePrimary inside the callback and this test
+	// would certify the shape it exists to reject.
+	if got := rgState(t, m, 0); got == StatePrimary {
+		t.Fatalf("fixture is already primary (%v); this test cannot distinguish the "+
+			"orderings from that starting point", got)
+	}
+
+	var stateAtFence NodeState
+	var called bool
+	m.SetPeerFenceConfirmFunc(func(timeout time.Duration) (FenceAck, error) {
+		called = true
+		stateAtFence = rgState(t, m, 0)
+		return FenceAck{Status: FenceAckOK, RGsFenced: 1, RGsTotal: 1}, nil
+	})
+
+	m.handlePeerTimeout()
+
+	if !called {
+		t.Fatal("the confirm function was never called under disable-rg-confirmed, so " +
+			"nothing gated the takeover")
+	}
+	if stateAtFence == StatePrimary {
+		t.Errorf("this node was ALREADY %v when the fence was issued; the fence must "+
+			"precede the election or the policy gates nothing", stateAtFence)
+	}
+	if got := rgState(t, m, 0); got != StatePrimary {
+		t.Errorf("after a CONFIRMED fence the node is %v, want primary — the takeover "+
+			"must still happen", got)
+	}
+}
+
+// LIVENESS, exhaustively. Every negative outcome must still end with the node
+// primary. A gate that can withhold ownership converts peer loss into an
+// outage, which is strictly worse than the unacknowledged fence it replaced.
+func TestConfirmedFenceAlwaysFailsOpen7147(t *testing.T) {
+	tests := []struct {
+		name    string
+		fn      func(time.Duration) (FenceAck, error)
+		wantMsg string
+	}{
+		{
+			name:    "no sync armed",
+			fn:      nil,
+			wantMsg: "Fence skipped: sync not available",
+		},
+		{
+			name:    "peer not connected",
+			fn:      func(time.Duration) (FenceAck, error) { return FenceAck{}, fmt.Errorf("peer not connected") },
+			wantMsg: "Fence unconfirmed, took over anyway: peer not connected",
+		},
+		{
+			name: "peer predates 7147",
+			fn: func(time.Duration) (FenceAck, error) {
+				return FenceAck{}, fmt.Errorf("peer does not support fence acknowledgement")
+			},
+			wantMsg: "Fence unconfirmed, took over anyway: peer does not support fence acknowledgement",
+		},
+		{
+			name: "ack timed out",
+			fn: func(d time.Duration) (FenceAck, error) {
+				return FenceAck{}, fmt.Errorf("timed out after %s waiting for peer fence ack seq=1", d)
+			},
+			wantMsg: "Fence unconfirmed, took over anyway: timed out",
+		},
+		{
+			name: "peer only partly fenced",
+			fn: func(time.Duration) (FenceAck, error) {
+				return FenceAck{Status: FenceAckPartial, RGsFenced: 1, RGsTotal: 3}, nil
+			},
+			wantMsg: "Fence NOT confirmed (peer disabled only 1/3 redundancy groups), took over anyway",
+		},
+		{
+			name: "peer has no dataplane",
+			fn: func(time.Duration) (FenceAck, error) {
+				return FenceAck{Status: FenceAckUnavailable}, nil
+			},
+			wantMsg: "Fence NOT confirmed (peer has no dataplane (config-only mode)), took over anyway",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := confirmFenceManager(t)
+			if tt.fn != nil {
+				m.SetPeerFenceConfirmFunc(tt.fn)
+			}
+
+			done := make(chan struct{})
+			go func() {
+				m.handlePeerTimeout()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(30 * time.Second):
+				t.Fatal("handlePeerTimeout never returned; the confirmed fence must " +
+					"never block a takeover indefinitely")
+			}
+
+			if got := rgState(t, m, 0); got != StatePrimary {
+				t.Errorf("node is %v after a FAILED confirmation, want primary — the "+
+					"takeover must proceed anyway or peer loss becomes an outage", got)
+			}
+
+			// The operator asked for a guarantee and did not get it. That must
+			// be visible, or a cluster failing open on every takeover looks
+			// exactly like one that confirms every time.
+			out := m.FormatInformation()
+			if !strings.Contains(out, tt.wantMsg) {
+				t.Errorf("`show chassis cluster information` does not report the "+
+					"fail-open reason %q:\n%s", tt.wantMsg, out)
+			}
+			if strings.Contains(out, "Fence confirmed by peer") {
+				t.Errorf("a FAILED confirmation was reported as confirmed:\n%s", out)
+			}
+		})
+	}
+}
+
+// A successful confirmation must be reported as such, and must name what the
+// peer actually disabled rather than merely that a message was sent.
+func TestConfirmedFenceReportsWhatThePeerDisabled7147(t *testing.T) {
+	m := confirmFenceManager(t)
+	m.SetPeerFenceConfirmFunc(func(time.Duration) (FenceAck, error) {
+		return FenceAck{Status: FenceAckOK, RGsFenced: 4, RGsTotal: 4}, nil
+	})
+	m.handlePeerTimeout()
+
+	out := m.FormatInformation()
+	want := "Fence confirmed by peer (peer disabled 4/4 redundancy groups)"
+	if !strings.Contains(out, want) {
+		t.Errorf("expected %q in:\n%s", want, out)
+	}
+	if !strings.Contains(out, "Action: disable-rg-confirmed") {
+		t.Errorf("the armed policy is not reported:\n%s", out)
+	}
+}
+
+// The bounded timeout must actually reach the sender. A gate that passed 0 (or
+// forgot the argument) would either never wait or wait forever, and both look
+// fine in an end-state assertion.
+func TestConfirmedFencePassesTheBoundedTimeout7147(t *testing.T) {
+	m := confirmFenceManager(t)
+	var got time.Duration
+	m.SetPeerFenceConfirmFunc(func(d time.Duration) (FenceAck, error) {
+		got = d
+		return FenceAck{Status: FenceAckOK}, nil
+	})
+	m.handlePeerTimeout()
+
+	if got != FenceConfirmTimeout {
+		t.Errorf("confirm fn received timeout %s, want FenceConfirmTimeout (%s)", got, FenceConfirmTimeout)
+	}
+	if got <= 0 {
+		t.Error("the fence confirmation wait is unbounded or instant; neither is the " +
+			"intended bounded fail-open policy")
+	}
+}
+
+// `disable-rg` must be untouched by #7147: it uses the fire-and-forget sender,
+// never the confirming one, so no already-deployed config changes behaviour.
+func TestDisableRGPolicyIsUnaffectedBy7147(t *testing.T) {
+	m := fenceInfoManager(t, PeerFencingDisableRG)
+	confirmCalled := false
+	bestEffortCalled := false
+	m.SetPeerFenceConfirmFunc(func(time.Duration) (FenceAck, error) {
+		confirmCalled = true
+		return FenceAck{Status: FenceAckOK}, nil
+	})
+	m.SetPeerFenceFunc(func() error {
+		bestEffortCalled = true
+		return nil
+	})
+
+	m.handlePeerTimeout()
+
+	if confirmCalled {
+		t.Error("`disable-rg` used the CONFIRMING fence path. #7147 must not change " +
+			"the behaviour of a policy value that operators already have deployed")
+	}
+	if !bestEffortCalled {
+		t.Error("`disable-rg` no longer sends its best-effort fence")
+	}
+	if got := rgState(t, m, 0); got != StatePrimary {
+		t.Errorf("node is %v, want primary", got)
+	}
+}
+
+// Symmetrically: an UNCONFIGURED peer-fencing leaf must not send anything at
+// all. Without this, the two policy tests above would both pass on an
+// implementation that fenced unconditionally.
+func TestNoFencingPolicySendsNoFence7147(t *testing.T) {
+	m := fenceInfoManager(t, "")
+	confirmCalled := false
+	bestEffortCalled := false
+	m.SetPeerFenceConfirmFunc(func(time.Duration) (FenceAck, error) {
+		confirmCalled = true
+		return FenceAck{Status: FenceAckOK}, nil
+	})
+	m.SetPeerFenceFunc(func() error {
+		bestEffortCalled = true
+		return nil
+	})
+
+	m.handlePeerTimeout()
+
+	if confirmCalled || bestEffortCalled {
+		t.Errorf("a node with no peer-fencing configured fenced its peer "+
+			"(confirm=%v best_effort=%v)", confirmCalled, bestEffortCalled)
+	}
+	if got := rgState(t, m, 0); got != StatePrimary {
+		t.Errorf("node is %v, want primary", got)
+	}
+}
+
+// The confirmation counters must reach the operator surface. FenceAcksTimedOut
+// is the number that says "you did not get the guarantee you selected", and it
+// appears nowhere else — FencesSent counts the same on a confirmed and an
+// unconfirmed takeover.
+func TestConfirmationCountersAreRendered7147(t *testing.T) {
+	m := confirmFenceManager(t)
+	ss := &SessionSync{}
+	ss.stats.FenceAcksReceived.Store(3)
+	ss.stats.FenceAcksTimedOut.Store(2)
+	ss.stats.FenceAcksSent.Store(1)
+	m.SetSyncStats(ss)
+
+	out := m.FormatInformation()
+	want := "Confirmations: received 3, timed out 2, sent to peer 1"
+	if !strings.Contains(out, want) {
+		t.Errorf("expected %q in `show chassis cluster information`:\n%s", want, out)
+	}
+}
+
+// The policy string the runtime branches on must be the one the config
+// compiler can actually produce. A constant that disagreed with the schema
+// enum would compile, pass every test above (they all use the constant), and
+// silently no-op in production.
+func TestPolicyConstantsMatchTheConfigEnum7147(t *testing.T) {
+	t.Parallel()
+	if PeerFencingDisableRG != "disable-rg" {
+		t.Errorf("PeerFencingDisableRG = %q, want the committed leaf value", PeerFencingDisableRG)
+	}
+	if PeerFencingDisableRGConfirmed != "disable-rg-confirmed" {
+		t.Errorf("PeerFencingDisableRGConfirmed = %q, want the committed leaf value",
+			PeerFencingDisableRGConfirmed)
+	}
+}

--- a/pkg/cluster/fence_confirm_7147_test.go
+++ b/pkg/cluster/fence_confirm_7147_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // #7147 — the `peer-fencing disable-rg-confirmed` policy at the Manager level.
@@ -297,17 +299,121 @@ func TestConfirmationCountersAreRendered7147(t *testing.T) {
 	}
 }
 
-// The policy string the runtime branches on must be the one the config
-// compiler can actually produce. A constant that disagreed with the schema
-// enum would compile, pass every test above (they all use the constant), and
-// silently no-op in production.
-func TestPolicyConstantsMatchTheConfigEnum7147(t *testing.T) {
+// The policy strings the runtime branches on must be values an operator can
+// actually COMMIT. A constant that disagreed with the config schema's enum
+// would compile, pass every test above (they all use the constant, so they
+// agree with themselves by construction), and silently no-op in production —
+// handlePeerTimeout would match neither arm and fence nothing.
+//
+// So this asserts the AGREEMENT by driving the real schema validator, rather
+// than pinning the constants to literals. Pinning would only prove the
+// constants equal whatever this test also hard-codes; it could not see the
+// schema rejecting them. The near-miss rows are what stop the check passing on
+// a validator loosened to a prefix match.
+func TestPolicyConstantsAreCommittable7147(t *testing.T) {
 	t.Parallel()
-	if PeerFencingDisableRG != "disable-rg" {
-		t.Errorf("PeerFencingDisableRG = %q, want the committed leaf value", PeerFencingDisableRG)
+
+	commit := func(t *testing.T, value string) error {
+		t.Helper()
+		tree := &config.ConfigTree{}
+		path, err := config.ParseSetCommand("set chassis cluster peer-fencing " + value)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", value, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", value, err)
+		}
+		return config.SchemaValidate(tree, nil)
 	}
-	if PeerFencingDisableRGConfirmed != "disable-rg-confirmed" {
-		t.Errorf("PeerFencingDisableRGConfirmed = %q, want the committed leaf value",
-			PeerFencingDisableRGConfirmed)
+
+	for _, v := range []string{PeerFencingDisableRG, PeerFencingDisableRGConfirmed} {
+		if err := commit(t, v); err != nil {
+			t.Errorf("the runtime branches on peer-fencing %q but the config schema "+
+				"REJECTS it (%v). handlePeerTimeout would match neither arm and fence "+
+				"nothing, while every other test here still passed because they all use "+
+				"this same constant.", v, err)
+		}
+	}
+
+	// Guard the guard: if the schema accepted anything, the loop above would
+	// pass no matter what the constants said.
+	for _, v := range []string{"disable-rg-confirm", "shoot-the-other-node"} {
+		if err := commit(t, v); err == nil {
+			t.Errorf("the schema accepted peer-fencing %q; the acceptance check above "+
+				"then proves nothing about the real constants", v)
+		}
+	}
+}
+
+// THE HAZARD THE FIRST DRAFT OF THIS SUITE COULD NOT SEE.
+//
+// `awaitPeerFenceLocked` releases m.mu across the wait. handlePeerTimeout sets
+// peerAlive=false precisely to BYPASS electSingleNode's #7161 readiness gate
+// (armed only when `controlInterface != "" && (peerAlive || !peerEverSeen)`),
+// so a heartbeat landing inside that window re-arms the gate and the election
+// declines to promote — after the peer has already been fenced dark. Peer dark
+// plus local node passive is a total outage, produced by the very policy that
+// exists to prevent split-brain.
+//
+// Every other test in this file is STRUCTURALLY BLIND to it: confirmFenceManager
+// builds its config with makeConfig, which never sets ControlInterface, so
+// `m.controlInterface == ""` makes the gate arm unreachable and the window
+// cannot change any outcome. This fixture arms the gate (ControlInterface set,
+// a takeover hold running so the RG is not takeover-ready) and simulates the
+// racing heartbeat from inside the confirm callback — the one place that is
+// genuinely inside the window.
+func TestConfirmedFencePromotesEvenIfAHeartbeatLandsInTheWindow7147(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100}))
+	cfg.PeerFencing = PeerFencingDisableRGConfirmed
+	// Arm the election gates: without this the branch under test is dead code
+	// and the test would pass against the unfixed implementation.
+	cfg.ControlInterface = "em0"
+	cfg.TakeoverHoldTime = int((30 * time.Second) / time.Millisecond)
+	m.UpdateConfig(cfg)
+
+	m.mu.Lock()
+	m.peerAlive = true
+	m.peerEverSeen = true
+	for _, rg := range m.groups {
+		rg.State = StateSecondary
+		// Ready, but only just — so IsReadyForTakeover is false for the whole
+		// takeover-hold window and readinessGateVerdictLocked would decline if
+		// the gate were armed.
+		rg.Ready = true
+		rg.ReadySince = time.Now()
+	}
+	if m.controlInterface == "" {
+		m.mu.Unlock()
+		t.Fatal("fixture did not arm the readiness gate (controlInterface empty); " +
+			"this test cannot observe the hazard it exists for")
+	}
+	if m.groups[0].IsReadyForTakeover(m.takeoverHoldTime) {
+		m.mu.Unlock()
+		t.Fatal("fixture RG is already takeover-ready, so the readiness gate would " +
+			"permit promotion regardless and the test would pass either way")
+	}
+	m.mu.Unlock()
+
+	m.SetPeerFenceConfirmFunc(func(time.Duration) (FenceAck, error) {
+		// Inside the window: m.mu is released here, exactly as a blocked
+		// handlePeerHeartbeat goroutine would find it. Take it and set
+		// peerAlive, which is all handlePeerHeartbeat needs to do to re-arm
+		// the gate.
+		m.mu.Lock()
+		m.peerAlive = true
+		m.mu.Unlock()
+		// The peer HAS been fenced: it reports every RG disabled.
+		return FenceAck{Status: FenceAckOK, RGsFenced: 1, RGsTotal: 1}, nil
+	})
+
+	m.handlePeerTimeout()
+
+	if got := rgState(t, m, 0); got != StatePrimary {
+		t.Fatalf("node is %v after a CONFIRMED fence, want primary. A heartbeat that "+
+			"landed while awaitPeerFenceLocked held m.mu open re-armed the #7161 "+
+			"readiness gate, so electSingleNode declined to promote — while the peer "+
+			"had already driven every RG to rg_active=false in response to our fence. "+
+			"Peer dark, this node passive: no primary anywhere.", got)
 	}
 }

--- a/pkg/cluster/heartbeat_manager.go
+++ b/pkg/cluster/heartbeat_manager.go
@@ -618,23 +618,36 @@ func (m *Manager) handlePeerTimeout() {
 		m.clearPeerTransferOutOverrideLocked(rgID)
 	}
 
+	// #7147: under `disable-rg-confirmed` the fence runs BEFORE the election
+	// and this node waits, bounded, for the peer to confirm it relinquished
+	// its redundancy groups. That ordering is the entire point of the policy —
+	// see awaitPeerFenceLocked for why it cannot stall a takeover.
+	if m.peerFencing == PeerFencingDisableRGConfirmed {
+		m.awaitPeerFenceLocked()
+	}
+
 	// Peer lost: re-run single-node election.
 	m.electSingleNode()
 
 	// Attempt peer fencing if configured.
 	//
-	// Ordering note (#72): the election above runs BEFORE the fence, and the
-	// fence is never a precondition for ownership. That is deliberate and not
-	// currently changeable by reordering alone — SendFence
-	// (sync_failover.go) writes syncMsgFence and returns; there is no
-	// fence-ack message on the wire, so "fence acknowledged" is not an
-	// observable this code could gate on. Gating takeover on the send
+	// Ordering note (#72): under `disable-rg` the election above runs BEFORE
+	// the fence, and the fence is never a precondition for ownership. That is
+	// deliberate: SendFence (sync_failover.go) writes syncMsgFence and returns
+	// without waiting, so a `sent to peer` result means the write reached the
+	// socket, not that the peer disabled anything. Gating takeover on the send
 	// SUCCEEDING would be worse than useless: the send fails precisely when
 	// the peer is unreachable, which is the split-brain case fencing exists
 	// to cover, so it would convert a dead peer into a total outage.
+	//
+	// #7147 added the acknowledged alternative rather than changing this one.
+	// An operator who wants ownership gated on a confirmed fence selects
+	// `disable-rg-confirmed` above; `disable-rg` behaves exactly as it always
+	// has, so no existing config changes behaviour.
+	//
 	// Every attempt and its result is recorded to the EventFence history and
 	// rendered by FormatInformation's "Peer fencing:" block.
-	if m.peerFencing == "disable-rg" {
+	if m.peerFencing == PeerFencingDisableRG {
 		fn := m.peerFenceFn
 		if fn != nil {
 			// Release lock for the network call.

--- a/pkg/cluster/hooks.go
+++ b/pkg/cluster/hooks.go
@@ -1,5 +1,7 @@
 package cluster
 
+import "time"
+
 // SetPreManualFailoverHook registers a callback that runs before ManualFailover
 // changes local RG ownership.
 func (m *Manager) SetPreManualFailoverHook(fn func(rgID int) error) {
@@ -63,6 +65,15 @@ func (m *Manager) SetPeerFenceFunc(fn func() error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.peerFenceFn = fn
+}
+
+// SetPeerFenceConfirmFunc sets the callback used to send a SEQUENCED fence and
+// wait for the peer's confirmation of what it disabled (#7147). Consulted only
+// under `peer-fencing disable-rg-confirmed`.
+func (m *Manager) SetPeerFenceConfirmFunc(fn func(timeout time.Duration) (FenceAck, error)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.peerFenceConfirmFn = fn
 }
 
 // SetPeerTimeoutGuard sets a callback that can suppress heartbeat-driven

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -440,6 +440,12 @@ type Manager struct {
 	// Set by daemon after sessionSync creation.
 	peerFenceFn func() error
 
+	// peerFenceConfirmFn sends a SEQUENCED fence and waits for the peer to
+	// report what it disabled (#7147). Used only by the
+	// `disable-rg-confirmed` policy; `disable-rg` keeps peerFenceFn's
+	// fire-and-forget behaviour unchanged.
+	peerFenceConfirmFn func(timeout time.Duration) (FenceAck, error)
+
 	// peerTimeoutGuardFn can suppress heartbeat-driven peer loss when an
 	// external signal proves the peer is still alive (for example, recent
 	// session-sync traffic on the control link).

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -429,6 +429,21 @@ func (m *Manager) FormatInformation() string {
 			action = "disabled"
 		}
 		fmt.Fprintf(&b, "  Action: %s\n", action)
+		// #7147: under the acknowledged policy the counters are the only place
+		// the guarantee's actual delivery rate is visible. An operator who
+		// selected `disable-rg-confirmed` gets a fail-open takeover whenever
+		// the ack does not arrive, and without this line a cluster that failed
+		// open on EVERY takeover renders identically to one that was confirmed
+		// every time — the "Attempts:" history would have to be read line by
+		// line to tell them apart. Shown whenever the policy is armed or any
+		// ack traffic has ever happened, so a disarmed-but-used history keeps
+		// its numbers.
+		if syncStats != nil && (fenceAction == PeerFencingDisableRGConfirmed ||
+			syncStats.FenceAcksSent > 0 || syncStats.FenceAcksReceived > 0 ||
+			syncStats.FenceAcksTimedOut > 0) {
+			fmt.Fprintf(&b, "  Confirmations: received %d, timed out %d, sent to peer %d\n",
+				syncStats.FenceAcksReceived, syncStats.FenceAcksTimedOut, syncStats.FenceAcksSent)
+		}
 		if len(fenceEvents) == 0 {
 			fmt.Fprintln(&b, "  Attempts: none")
 		} else {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -323,6 +323,13 @@ type SyncStats struct {
 	DHCPLeasesSeeded       atomic.Uint64
 	FencesSent             atomic.Uint64
 	FencesReceived         atomic.Uint64
+	// FenceAcksSent / FenceAcksReceived / FenceAcksTimedOut instrument the
+	// #7147 confirmed fence. FenceAcksTimedOut is the one that matters
+	// operationally: it counts takeovers that proceeded WITHOUT the
+	// confirmation the operator asked for, which is invisible in FencesSent.
+	FenceAcksSent     atomic.Uint64
+	FenceAcksReceived atomic.Uint64
+	FenceAcksTimedOut atomic.Uint64
 	Errors                 atomic.Uint64
 	DeletesDropped         atomic.Uint64
 	// DeletesStaleIgnored counts deletes refused by the #2170 install-
@@ -414,6 +421,9 @@ type SyncStatsSnapshot struct {
 	DHCPLeasesSeeded           uint64
 	FencesSent                 uint64
 	FencesReceived             uint64
+	FenceAcksSent              uint64
+	FenceAcksReceived          uint64
+	FenceAcksTimedOut          uint64
 	Errors                     uint64
 	DeletesDropped             uint64
 	DeletesStaleIgnored        uint64
@@ -693,8 +703,15 @@ type SessionSync struct {
 	// fenced before the batch failoverAckApplied reply is sent (#5640). reqID
 	// identifies the batch request whose barriers are being waited on (#6177).
 	WaitFailoverAppliedBatch func(rgIDs []int, reqID uint64) error
-	// OnFenceReceived requests this node to disable all RGs.
-	OnFenceReceived func()
+	// OnFenceReceived requests this node to disable all RGs, and reports what
+	// that achieved so a sequenced fence can be acknowledged truthfully
+	// (#7147). The returned FenceResult is encoded into syncMsgFenceAck; it is
+	// ignored for an unsequenced (pre-#7147) fence.
+	//
+	// It is invoked SYNCHRONOUSLY on the receive loop and the ack is written
+	// after it returns. That ordering is the whole guarantee: an ack sent
+	// before the fence had been applied would confirm nothing.
+	OnFenceReceived func() FenceResult
 	// OnPrepareActivation asks the peer to pre-warm neighbors for the given RG.
 	OnPrepareActivation func(rgID int)
 	// OnForwardSessionInstalled fires when a forward synced session is installed locally.
@@ -806,6 +823,27 @@ type SessionSync struct {
 	// peer INCARNATION that proved it, and the peer that reconnects may be a
 	// different, older process.
 	peerSnapshotProtocol atomic.Uint32
+
+	// peerCapabilityFlags holds the peer's advertised capability bits (#7147),
+	// carried in the trailing byte of syncMsgPeerCapabilities on top of #6650's
+	// version field. 0 means "advertises nothing", which for every bit means
+	// INCAPABLE — a pre-#7147 peer sends a 2-byte frame with no flags at all.
+	//
+	// Cleared on full disconnect alongside peerSnapshotProtocol and for the
+	// identical reason: the capability belongs to the peer INCARNATION that
+	// proved it, and the process that reconnects may be an older build. A
+	// retained fence-ack bit would make a confirmed-fence gate wait out its
+	// whole timeout against a downgraded peer that can never answer.
+	peerCapabilityFlags atomic.Uint32
+
+	// fenceSeq numbers sequenced peer fences (#7147). Starts at 0 and is only
+	// ever read via Add(1), so the first fence is seq 1 — seq 0 is reserved on
+	// the wire to mean "no ack requested", which is how a pre-#7147 fence's
+	// empty payload decodes.
+	fenceSeq        atomic.Uint64
+	fenceAckMu      sync.Mutex
+	fenceAckWaiters map[uint64]chan FenceAck
+
 	zoneRGMu             sync.RWMutex
 	zoneRGMap            map[uint16]int
 
@@ -1414,7 +1452,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), ImportsRefusedByHelper: s.stats.ImportsRefusedByHelper.Load(), ConfigsQueueFullDropped: s.stats.ConfigsQueueFullDropped.Load(), ConfigApplyNacksReceived: s.stats.ConfigApplyNacksReceived.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), ImportsRefusedByHelper: s.stats.ImportsRefusedByHelper.Load(), ConfigsQueueFullDropped: s.stats.ConfigsQueueFullDropped.Load(), ConfigApplyNacksReceived: s.stats.ConfigApplyNacksReceived.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), FenceAcksSent: s.stats.FenceAcksSent.Load(), FenceAcksReceived: s.stats.FenceAcksReceived.Load(), FenceAcksTimedOut: s.stats.FenceAcksTimedOut.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -327,6 +327,19 @@ type SyncStats struct {
 	// #7147 confirmed fence. FenceAcksTimedOut is the one that matters
 	// operationally: it counts takeovers that proceeded WITHOUT the
 	// confirmation the operator asked for, which is invisible in FencesSent.
+	//
+	// Directions and exact semantics, because two of these are easy to
+	// misread:
+	//   - FenceAcksSent counts acks THIS node sent, i.e. times this node was
+	//     the one being fenced. The other two are the outbound direction.
+	//   - FenceAcksReceived counts acks that reached a LIVE waiter. An ack
+	//     that arrives after its wait already timed out is dropped by the seq
+	//     match and is NOT counted here — it did not confirm anything the
+	//     takeover could act on, and counting it would make
+	//     received+timed_out exceed the number of fences sent.
+	//   - FenceAcksReceived includes NEGATIVE acks (partial/unavailable): it
+	//     counts fences the peer ANSWERED, not fences it satisfied. The
+	//     EventFence history distinguishes those.
 	FenceAcksSent     atomic.Uint64
 	FenceAcksReceived atomic.Uint64
 	FenceAcksTimedOut atomic.Uint64

--- a/pkg/cluster/sync_capabilities_6650_test.go
+++ b/pkg/cluster/sync_capabilities_6650_test.go
@@ -122,7 +122,7 @@ func TestPeerCapabilitiesMessageTypeIsUnique6650(t *testing.T) {
 				syncMsgPeerCapabilities, m.name)
 		}
 	}
-	if len(live) < 34 {
+	if len(live) < 35 {
 		t.Fatalf("the live-type list holds only %d entries — it has fallen behind "+
 			"sync.go and can no longer certify uniqueness", len(live))
 	}
@@ -150,17 +150,55 @@ func TestPeerCapabilitiesPayloadIsLengthGated6650(t *testing.T) {
 	}
 }
 
-// TestSendCapabilitiesStaysSilentWhenUnset6650 pins the "silence beats a
-// literal 0" encoding. Advertising 0 would be indistinguishable from a
-// pre-#6650 peer to the receiver while ALSO looking like a deliberate claim of
-// zero capability, so an un-wired node must send nothing at all.
-func TestSendCapabilitiesStaysSilentWhenUnset6650(t *testing.T) {
+// TestSendCapabilitiesAdvertisesUnconditionally6650_7147 SUPERSEDES the former
+// TestSendCapabilitiesStaysSilentWhenUnset6650, which pinned the opposite
+// source shape ("if v == 0 { return }") and is deliberately gone rather than
+// deleted silently.
+//
+// WHY THE CONTRACT CHANGED. #6650's frame carried only the snapshot version,
+// and for that payload silence was the more honest encoding of "not wired".
+// #7147 added capability FLAGS to the same frame. Flags are a property of the
+// BINARY, always true for this build, so suppressing the whole frame because an
+// unrelated field was 0 would have made the fence-ack capability depend on
+// userspace.ProtocolVersion staying nonzero — and had it ever been 0, the
+// confirmed-fence gate would have stopped arming while looking exactly like a
+// healthy pre-#7147 peer.
+//
+// WHAT SURVIVES. The invariant the old test actually protected is unchanged and
+// is re-asserted below: a receiver cannot distinguish "frame absent" from
+// "frame carrying version 0", because both leave peerSnapshotProtocol at 0 and
+// #6650's contract already reads 0 as INCAPABLE rather than unknown. So the
+// version SEMANTICS are identical; only the encoding moved.
+func TestSendCapabilitiesAdvertisesUnconditionally6650_7147(t *testing.T) {
 	t.Parallel()
 	src := readClusterSource(t, "sync_conn_write.go")
-	if !sourceContainsFlat(src, "v := s.localSnapshotProtocol.Load()") ||
-		!sourceContainsFlat(src, "if v == 0 { return }") {
-		t.Error("sendCapabilities does not suppress the advertisement when the local " +
-			"version is unset; an un-wired node would advertise a literal 0")
+	if !sourceContainsFlat(src, "v := s.localSnapshotProtocol.Load()") {
+		t.Error("sendCapabilities no longer reads localSnapshotProtocol")
+	}
+	if sourceContainsFlat(src, "if v == 0 { return }") {
+		t.Error("sendCapabilities still suppresses the advertisement when the local " +
+			"version is unset. #7147 requires the frame unconditionally: the capability " +
+			"FLAGS it now carries are a property of this binary and must not be gated on " +
+			"an unrelated version field being nonzero, or the confirmed-fence gate " +
+			"silently stops arming and looks identical to a healthy old peer.")
+	}
+	if !sourceContainsFlat(src, "buf[2] = localCapabilityFlags") {
+		t.Error("sendCapabilities does not append the #7147 capability flags byte, so " +
+			"no peer can ever learn this node acks fences and every confirmed-fence " +
+			"takeover fails open without waiting")
+	}
+
+	// The surviving #6650 invariant, asserted behaviourally rather than by
+	// source shape: version 0 on the wire and no frame at all must be
+	// indistinguishable to the receiver.
+	var ss SessionSync
+	if got := ss.PeerSnapshotProtocolVersion(); got != 0 {
+		t.Fatalf("a peer that never advertised reads %d, want 0", got)
+	}
+	ss.peerSnapshotProtocol.Store(uint32(uint16(0)))
+	if got := ss.PeerSnapshotProtocolVersion(); got != 0 {
+		t.Fatalf("a peer that advertised a literal 0 reads %d, want 0 — the two must "+
+			"stay indistinguishable, which is what makes the encoding change safe", got)
 	}
 }
 
@@ -222,6 +260,7 @@ func liveSyncMessageTypesExcept(under int) []syncMessageType {
 		{syncMsgAuthUpgradeHello, "AuthUpgradeHello"},
 		{syncMsgAuthUpgradeProof, "AuthUpgradeProof"},
 		{syncMsgAuthUpgradeAck, "AuthUpgradeAck"},
+		{syncMsgFenceAck, "FenceAck"},
 	}
 	out := make([]syncMessageType, 0, len(all))
 	for _, m := range all {

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -1012,6 +1012,15 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 		// for), so a retained capability would authorise a push the new
 		// incarnation cannot represent.
 		s.peerSnapshotProtocol.Store(0)
+		// #7147: the capability flags are scoped to the same peer incarnation
+		// for the same reason, and a retained fence-ack bit is worse than a
+		// retained version: it would make every confirmed-fence takeover wait
+		// out its full timeout against a downgraded peer that cannot answer.
+		s.peerCapabilityFlags.Store(0)
+		// #7147: release fence-ack waiters so a fence sent moments before the
+		// fabric dropped fails open NOW instead of holding the takeover for
+		// the whole timeout waiting for an answer that can no longer arrive.
+		s.abortFenceAckWaiters()
 		// #5718 C01a: peerHeartbeatAckEver is a capability probe of the peer
 		// PROCESS, not of this node, so it must be scoped to the peer
 		// incarnation exactly like clockSynced above. Full disconnect ends

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -951,6 +951,14 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 	}
 	connected := s.conn0 != nil || s.conn1 != nil
 	s.stats.Connected.Store(connected)
+	// #7147: release fence-ack waiters on ANY fabric drop, not only a full
+	// disconnect. The peer answers a fence on the connection it RECEIVED it
+	// on (sendFenceAck is handed the receive loop's conn), so once that
+	// connection is gone the ack can never arrive — the surviving fabric will
+	// not carry it. Leaving the waiter registered would make the takeover burn
+	// the whole FenceConfirmTimeout for an answer that is already impossible.
+	// Fail-open is preserved either way; this is what makes it immediate.
+	s.abortFenceAckWaiters()
 	if !connected {
 		pendingBarriers := s.barrierSeq.Load()
 		ackedBarriers := s.barrierAckSeq.Load()
@@ -1017,10 +1025,6 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 		// retained version: it would make every confirmed-fence takeover wait
 		// out its full timeout against a downgraded peer that cannot answer.
 		s.peerCapabilityFlags.Store(0)
-		// #7147: release fence-ack waiters so a fence sent moments before the
-		// fabric dropped fails open NOW instead of holding the takeover for
-		// the whole timeout waiting for an answer that can no longer arrive.
-		s.abortFenceAckWaiters()
 		// #5718 C01a: peerHeartbeatAckEver is a capability probe of the peer
 		// PROCESS, not of this node, so it must be scoped to the peer
 		// incarnation exactly like clockSynced above. Full disconnect ends

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -613,10 +613,37 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		s.completeFailoverBatchCommitWait(failoverBatchKey(rgIDs), reqID, failoverAck{status: status, detail: detail})
 	case syncMsgFence:
 		s.stats.FencesReceived.Add(1)
-		slog.Warn("cluster sync: fence received from peer — disabling all RGs")
-		if s.OnFenceReceived != nil {
-			s.OnFenceReceived()
+		// #7147: a fence may carry an 8-byte sequence number asking for a
+		// confirmation. A pre-#7147 sender writes a nil payload, which decodes
+		// to seq 0 = "no ack requested" — the reserved value SendFenceAwait
+		// never allocates (its sequences start at 1). Reading the payload
+		// leniently is what makes the new field additive on an existing type.
+		var fenceSeq uint64
+		if len(payload) >= 8 {
+			fenceSeq = binary.LittleEndian.Uint64(payload[:8])
 		}
+		slog.Warn("cluster sync: fence received from peer — disabling all RGs", "seq", fenceSeq)
+		var fenceRes FenceResult
+		if s.OnFenceReceived != nil {
+			// Synchronous on purpose: the ack below must not claim a fence
+			// that has not been applied yet.
+			fenceRes = s.OnFenceReceived()
+		}
+		if fenceSeq != 0 {
+			s.sendFenceAck(conn, fenceSeq, fenceRes)
+		}
+	case syncMsgFenceAck:
+		// #7147. A malformed or truncated ack is DROPPED rather than partially
+		// decoded: a short frame zero-filled into RGsFenced/RGsTotal/Status
+		// would decode to status 0 == FenceAckOK, i.e. a corrupt frame would
+		// read as a successful confirmation. The sender's timeout covers the
+		// drop and fails open.
+		ack, ok := decodeFenceAckPayload(payload)
+		if !ok {
+			slog.Warn("cluster sync: fence ack message too short", "len", len(payload))
+			return
+		}
+		s.completeFenceAckWait(ack)
 	case syncMsgPeerCapabilities:
 		// #6650. Length-gated with the #2170 trailing-field discipline: a
 		// SHORTER frame than we expect is a peer we cannot interpret, so it is
@@ -628,7 +655,15 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		}
 		peerProto := binary.LittleEndian.Uint16(payload[:2])
 		s.peerSnapshotProtocol.Store(uint32(peerProto))
-		slog.Info("cluster sync: peer advertised config-snapshot protocol version", "version", peerProto)
+		// #7147: capability flags ride in the trailing byte under the same
+		// discipline — a 2-byte frame is a pre-#7147 peer, and 0 flags is the
+		// correct reading of it (advertises no capabilities).
+		var peerFlags uint8
+		if len(payload) >= 3 {
+			peerFlags = payload[2]
+		}
+		s.peerCapabilityFlags.Store(uint32(peerFlags))
+		slog.Info("cluster sync: peer advertised capabilities", "version", peerProto, "flags", peerFlags)
 	case syncMsgClockSync:
 		if len(payload) < 8 {
 			slog.Warn("cluster sync: clock sync message too short")

--- a/pkg/cluster/sync_conn_write.go
+++ b/pkg/cluster/sync_conn_write.go
@@ -269,10 +269,22 @@ func (s *SessionSync) sendClockSync(conn net.Conn) {
 // sendCapabilities advertises this node's config-snapshot protocol version to
 // the peer (#6650). Called once per installed connection.
 //
-// A node whose version was never wired (0) sends NOTHING rather than
-// advertising 0: the receiver reads a missing advertisement as "pre-#6650
-// peer", and a literal 0 would be indistinguishable from that while ALSO
-// looking like a deliberate claim. Silence is the honest encoding.
+// #7147 CHANGED THE SEND CONDITION. This used to return early when the
+// snapshot version was 0, on the reasoning that silence is a more honest
+// encoding of "not wired" than a literal 0. That reasoning was sound for a
+// frame carrying only the version, but the frame now also carries capability
+// FLAGS, which are a property of the BINARY and are always true for this
+// build. Suppressing the whole frame on an unrelated field being 0 would have
+// made #7147's fence-ack capability silently depend on
+// `userspace.ProtocolVersion` staying nonzero — and if it ever were 0 the
+// confirmed-fence gate would quietly stop arming, which is indistinguishable
+// from a healthy pre-#7147 peer. Wrong failure to have.
+//
+// Sending an explicit 0 version is behaviourally identical to sending nothing:
+// the receiver has no way to distinguish "frame absent" from "frame with
+// version 0" — both leave peerSnapshotProtocol at 0 — and #6650's own contract
+// already states that 0 means INCAPABLE rather than unknown. So the version
+// semantics are preserved exactly; only the encoding changed.
 //
 // A send failure is logged and NOT escalated to handleDisconnect: unlike the
 // clock sync this is advisory metadata, and dropping a live fabric because an
@@ -280,16 +292,14 @@ func (s *SessionSync) sendClockSync(conn net.Conn) {
 // The receiver's 0-means-incapable default already fails closed.
 func (s *SessionSync) sendCapabilities(conn net.Conn) {
 	v := s.localSnapshotProtocol.Load()
-	if v == 0 {
-		return
-	}
-	var buf [2]byte
-	binary.LittleEndian.PutUint16(buf[:], uint16(v))
+	var buf [3]byte
+	binary.LittleEndian.PutUint16(buf[:2], uint16(v))
+	buf[2] = localCapabilityFlags
 	s.writeMu.Lock()
 	err := writeMsg(conn, syncMsgPeerCapabilities, buf[:])
 	s.writeMu.Unlock()
 	if err != nil {
-		slog.Warn("cluster sync: failed to advertise snapshot protocol version", "err", err)
+		slog.Warn("cluster sync: failed to advertise capabilities", "err", err)
 	}
 }
 

--- a/pkg/cluster/sync_fence_ack_7147.go
+++ b/pkg/cluster/sync_fence_ack_7147.go
@@ -1,0 +1,390 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+)
+
+// Peer-fence acknowledgement (#7147).
+//
+// THE GAP. `peer-fencing disable-rg` is best-effort and unacknowledged.
+// SessionSync.SendFence writes syncMsgFence and returns as soon as the bytes
+// reach the socket; the receiving node runs OnFenceReceived ->
+// fenceAllRedundancyGroups and replies with NOTHING. So a successful SendFence
+// means "the write succeeded", not "the peer stopped forwarding", and there was
+// no observable a takeover decision could legitimately be gated on. #72's
+// proposal item 3 ("optionally gate full active ownership until fence
+// acknowledged") was therefore unbuildable, and heartbeat_manager.go carried a
+// comment saying exactly that.
+//
+// WHY GATING ON THE OLD PRIMITIVES WOULD BE WORSE THAN NOTHING. Gating takeover
+// on SendFence *returning nil* gates on a socket write. Worse, SendFence fails
+// precisely when the sync channel is down, which is the common shape of a
+// genuinely dead peer — i.e. exactly the split-brain case fencing exists to
+// cover. A gate on send-success would convert a dead peer into a total outage.
+// The gate has to be on a REPLY, and the reply has to mean something.
+//
+// WHAT THE ACK MEANS HERE. Receipt is the weaker of the two candidate
+// observables and it is not the one an operator would assume. This
+// implementation sends the ack only AFTER the local fence has run, and reports
+// how many redundancy groups were actually driven to rg_active=false out of how
+// many the receiver's LIVE config contains. fenceAckOK therefore means "the
+// peer confirms it relinquished every RG it knows about", which is the property
+// a takeover gate should be built on. A peer in config-only mode (no published
+// dataplane) cannot relinquish anything and says so with fenceAckUnavailable
+// rather than reporting a vacuous success over an empty RG set.
+//
+// FAIL-OPEN IS A REQUIREMENT, NOT A COMPROMISE. Every negative path — no
+// connection, peer not capable, send error, timeout, partial or unavailable ack
+// — proceeds with the takeover. Availability of the surviving node is the
+// higher-order property: a fence gate that can withhold ownership indefinitely
+// turns every peer failure into an outage. What the gate buys is the ORDERING
+// in the case where the peer is reachable (the true split-brain risk: heartbeat
+// lost, sync channel alive) — there this node now waits for the peer to confirm
+// it went dark before claiming the groups. Each fail-open is recorded to the
+// EventFence history with its reason so an operator can never mistake one for a
+// confirmed fence; see docs/ha-failover-status.md.
+//
+// WHY THIS IS ADDITIVE — NO SessionSyncWireVersion / CurrentHAProtocolVersion
+// BUMP. Three independent reasons, each verified against this tree:
+//
+//  1. handleMessage's `switch msgType` (sync_conn_read.go) has NO default arm,
+//     and framing is length-prefixed, so a peer that predates syncMsgFenceAck
+//     skips the frame without desyncing the stream. This is the same property
+//     #2239 (syncMsgDHCPLease*) and #6650 (syncMsgPeerCapabilities) relied on,
+//     and both of those deliberately declined to bump for it.
+//  2. The seq payload added to syncMsgFence is trailing data on an existing
+//     type whose old receiver reads no payload at all, so an old peer is
+//     unaffected by its presence. The #2170 trailing-field discipline.
+//  3. Bumping would be actively harmful. MinCompatHAProtocolVersion ==
+//     CurrentHAProtocolVersion today, so the accepted HA window is a single
+//     point; GateMixedBaseSwap refuses when peerHAProtocol is outside
+//     [MinCompat, Current]. A bump makes the window [N+1, N+1] and refuses a
+//     peer at N — the bump itself would break the rolling upgrade this feature
+//     has to survive, converting a narrowing bug into an outage (#6650 records
+//     the same reasoning).
+//
+// A mixed-version pair degrades EXACTLY to pre-#7147 behaviour on both sides:
+// the old node ignores the ack request and never replies, the new node sees no
+// fence-ack capability advertised and does not wait at all.
+
+const (
+	// syncMsgFenceAck carries the receiving node's confirmation that it ran
+	// its peer-fence and what that fence achieved (#7147).
+	//
+	// 35 is the first FREE id. Ids 1..34 are all taken — note in particular
+	// that 30 is syncMsgConfigKeyExchange (#6629), so the "= 30" suggested in
+	// the #7147 discussion would have collided with the config-encryption
+	// handshake. sync_auth.go's syncMsgAuthHello=27 / syncMsgAuthProof=28 are
+	// PRE-INSTALL handshake frames and do not constrain this POST-INSTALL one,
+	// but the numbering is kept globally unique anyway so a reader never has
+	// to reason about which phase a frame belongs to.
+	syncMsgFenceAck = 35
+)
+
+// Fence acknowledgement status codes, carried in the syncMsgFenceAck payload.
+//
+// Only FenceAckOK authorises the sender to report a CONFIRMED fence. The other
+// two are distinct because they need distinct operator remediation, not because
+// the takeover behaviour differs — every one of them fails open.
+const (
+	// FenceAckOK: the peer disabled every redundancy group in its live config.
+	FenceAckOK uint8 = 0
+	// FenceAckPartial: at least one SetRGActive(false) failed. The peer may
+	// still be forwarding for that group.
+	FenceAckPartial uint8 = 1
+	// FenceAckUnavailable: the peer has no published dataplane (config-only
+	// mode), so it could not act on the fence at all. Reported explicitly
+	// rather than as a vacuous OK over an empty RG set — "nothing to disable"
+	// and "unable to disable anything" are different facts.
+	FenceAckUnavailable uint8 = 2
+)
+
+// Capability flag bits advertised in the trailing byte of the
+// syncMsgPeerCapabilities payload (#7147, on top of #6650's version field).
+const (
+	// capFlagFenceAck: the sender replies to a sequenced syncMsgFence with a
+	// syncMsgFenceAck. Absent => the peer predates #7147 and will never ack,
+	// so a confirmed-fence gate must not wait on it.
+	capFlagFenceAck uint8 = 1 << 0
+)
+
+// localCapabilityFlags is what this build advertises. It is a compile-time
+// constant: the capability is a property of the BINARY, not of runtime
+// configuration, so it must not be conditioned on anything a deployment can
+// turn off. In particular it is deliberately independent of
+// localSnapshotProtocol — see sendCapabilities for why that mattered.
+const localCapabilityFlags = capFlagFenceAck
+
+// FenceResult is what the local fence handler reports about what it achieved.
+// It is the daemon's answer to "did you actually relinquish everything", and
+// it is what gets encoded into the ack.
+type FenceResult struct {
+	// RGsFenced is the number of redundancy groups successfully driven to
+	// rg_active=false.
+	RGsFenced int
+	// RGsTotal is the number of redundancy groups in the receiver's LIVE
+	// config (#3917 — the live set, not a startup snapshot).
+	RGsTotal int
+	// DataplaneAvailable is false in config-only mode, where the fence could
+	// not be acted on at all.
+	DataplaneAvailable bool
+}
+
+// Status maps a fence outcome onto the wire status code.
+//
+// The RGsTotal == 0 case resolves to OK deliberately: a node with a dataplane
+// and no redundancy groups configured genuinely owns nothing, so it genuinely
+// cannot split-brain. That is a real confirmation, not a vacuous one — which is
+// exactly why the config-only case is a SEPARATE code rather than being folded
+// in here.
+func (r FenceResult) Status() uint8 {
+	if !r.DataplaneAvailable {
+		return FenceAckUnavailable
+	}
+	if r.RGsFenced < r.RGsTotal {
+		return FenceAckPartial
+	}
+	return FenceAckOK
+}
+
+// FenceAck is a decoded acknowledgement as observed by the fence SENDER.
+type FenceAck struct {
+	Seq       uint64
+	Status    uint8
+	RGsFenced int
+	RGsTotal  int
+}
+
+// Confirmed reports whether this ack authorises the sender to treat the peer as
+// fenced.
+func (a FenceAck) Confirmed() bool { return a.Status == FenceAckOK }
+
+// Reason renders the ack for the operator-facing EventFence history.
+func (a FenceAck) Reason() string {
+	switch a.Status {
+	case FenceAckOK:
+		return fmt.Sprintf("peer disabled %d/%d redundancy groups", a.RGsFenced, a.RGsTotal)
+	case FenceAckPartial:
+		return fmt.Sprintf("peer disabled only %d/%d redundancy groups", a.RGsFenced, a.RGsTotal)
+	case FenceAckUnavailable:
+		return "peer has no dataplane (config-only mode)"
+	default:
+		return fmt.Sprintf("unknown fence ack status %d", a.Status)
+	}
+}
+
+// fenceAckPayloadLen is the encoded size: seq(8) + status(1) + fenced(2) +
+// total(2).
+const fenceAckPayloadLen = 13
+
+func encodeFenceAckPayload(seq uint64, res FenceResult) []byte {
+	buf := make([]byte, fenceAckPayloadLen)
+	binary.LittleEndian.PutUint64(buf[0:8], seq)
+	buf[8] = res.Status()
+	binary.LittleEndian.PutUint16(buf[9:11], clampRGCount(res.RGsFenced))
+	binary.LittleEndian.PutUint16(buf[11:13], clampRGCount(res.RGsTotal))
+	return buf
+}
+
+// clampRGCount saturates an RG count into the uint16 wire field. RG ids are
+// 0..255 so a real cluster can never approach this, but the encode must not
+// wrap a hostile or corrupted count into a small number that would then read as
+// a successful fence.
+func clampRGCount(n int) uint16 {
+	if n < 0 {
+		return 0
+	}
+	if n > 0xFFFF {
+		return 0xFFFF
+	}
+	return uint16(n)
+}
+
+func decodeFenceAckPayload(payload []byte) (FenceAck, bool) {
+	if len(payload) < fenceAckPayloadLen {
+		return FenceAck{}, false
+	}
+	return FenceAck{
+		Seq:       binary.LittleEndian.Uint64(payload[0:8]),
+		Status:    payload[8],
+		RGsFenced: int(binary.LittleEndian.Uint16(payload[9:11])),
+		RGsTotal:  int(binary.LittleEndian.Uint16(payload[11:13])),
+	}, true
+}
+
+// PeerFenceAckCapable reports whether the peer advertised that it will reply to
+// a sequenced fence (#7147).
+//
+// false means "will never ack", not "unknown": the flags are cleared on full
+// disconnect and re-learned per peer incarnation, so a false reading is either
+// a pre-#7147 peer or a peer whose advertisement has not landed yet. Both must
+// be treated as "do not wait" — waiting on a peer that will never answer buys
+// nothing and spends the whole timeout on the takeover path.
+func (s *SessionSync) PeerFenceAckCapable() bool {
+	if s == nil {
+		return false
+	}
+	return uint8(s.peerCapabilityFlags.Load())&capFlagFenceAck != 0
+}
+
+// sendFenceAck replies to a sequenced fence with what the local fence achieved.
+//
+// Written directly under writeMu rather than through sendCh for the same reason
+// as sendBarrierAck: the sender is blocking on this reply inside the takeover
+// path, so it must not queue behind bulk session traffic.
+//
+// A write failure is logged and counted but NOT escalated to handleDisconnect.
+// The fence itself has already been applied locally by the time this runs, so
+// the safety action is done; tearing down the fabric because the confirmation
+// did not fit would add a sync outage to a peer-loss event. The sender's
+// timeout already covers a lost ack, and it fails open.
+func (s *SessionSync) sendFenceAck(conn net.Conn, seq uint64, res FenceResult) {
+	if conn == nil {
+		return
+	}
+	payload := encodeFenceAckPayload(seq, res)
+	s.writeMu.Lock()
+	err := writeMsg(conn, syncMsgFenceAck, payload)
+	s.writeMu.Unlock()
+	if err != nil {
+		s.stats.Errors.Add(1)
+		slog.Warn("cluster sync: fence ack write failed", "seq", seq, "err", err)
+		return
+	}
+	s.stats.FenceAcksSent.Add(1)
+	slog.Info("cluster sync: fence ack sent",
+		"seq", seq,
+		"status", res.Status(),
+		"rgs_fenced", res.RGsFenced,
+		"rgs_total", res.RGsTotal)
+}
+
+// completeFenceAckWait hands a received ack to the waiter that requested it.
+//
+// An ack whose seq matches no live waiter is dropped, which is the point of
+// carrying the seq at all: without it a LATE ack from a previous fence would
+// satisfy the next fence's gate instantly, and the gate would report a
+// confirmation the peer never gave for the fence in question.
+func (s *SessionSync) completeFenceAckWait(ack FenceAck) {
+	s.fenceAckMu.Lock()
+	waiter := s.fenceAckWaiters[ack.Seq]
+	delete(s.fenceAckWaiters, ack.Seq)
+	s.fenceAckMu.Unlock()
+	if waiter == nil {
+		slog.Debug("cluster sync: dropping fence ack with no waiter", "seq", ack.Seq)
+		return
+	}
+	// Buffered (cap 1) and removed from the map under the same lock, so
+	// exactly one send can ever reach it and this cannot block the read loop.
+	waiter <- ack
+}
+
+// abortFenceAckWaiters releases every pending fence-ack waiter on disconnect.
+//
+// Closing the channel (rather than sending) is what distinguishes "peer went
+// away" from "peer answered": SendFenceAwait reads a zero-value, not-ok result
+// from a closed channel and reports a disconnect, which fails open. Without
+// this a fence sent moments before the fabric dropped would hold the takeover
+// for the whole timeout even though the answer can no longer arrive.
+func (s *SessionSync) abortFenceAckWaiters() {
+	s.fenceAckMu.Lock()
+	waiters := s.fenceAckWaiters
+	s.fenceAckWaiters = nil
+	s.fenceAckMu.Unlock()
+	for _, waiter := range waiters {
+		close(waiter)
+	}
+}
+
+// SendFenceAwait sends a SEQUENCED fence and waits for the peer to confirm what
+// it disabled, bounded by timeout (#7147).
+//
+// This is the confirmed-fence primitive behind `peer-fencing
+// disable-rg-confirmed`. `peer-fencing disable-rg` still uses SendFence and is
+// completely unaffected.
+//
+// Every error return is a FAIL-OPEN signal, and the caller must treat it as
+// such — see the file header. The errors are distinguished so the EventFence
+// history can name the reason, not so the caller can branch on them:
+//
+//   - not connected: returns IMMEDIATELY. This is the structural reason the
+//     gate cannot delay the common dead-peer takeover — with no socket there is
+//     nothing to wait for, so no timeout is ever spent.
+//   - peer not fence-ack capable: returns immediately. A pre-#7147 peer will
+//     never answer; waiting the full timeout on every peer loss during a rolling
+//     upgrade would be a self-inflicted takeover delay.
+//   - write failed: returns immediately, and (unlike sendFenceAck) DOES
+//     escalate to handleDisconnect, matching SendFence — a fence that could not
+//     be written means the fabric is gone.
+//   - timeout: the peer is connected at the socket level but did not answer.
+//     This is the case a hard peer failure lands in when TCP has not yet
+//     noticed, and it is the only path that actually spends the timeout.
+func (s *SessionSync) SendFenceAwait(timeout time.Duration) (FenceAck, error) {
+	conn := s.getActiveConn()
+	if conn == nil {
+		return FenceAck{}, fmt.Errorf("peer not connected")
+	}
+	if !s.PeerFenceAckCapable() {
+		return FenceAck{}, fmt.Errorf("peer does not support fence acknowledgement")
+	}
+
+	// Sequences start at 1: seq 0 is reserved on the wire to mean "no ack
+	// requested", which is what a pre-#7147 SendFence's empty payload decodes
+	// to on a #7147 receiver.
+	seq := s.fenceSeq.Add(1)
+	waiter := make(chan FenceAck, 1)
+	s.fenceAckMu.Lock()
+	if s.fenceAckWaiters == nil {
+		s.fenceAckWaiters = make(map[uint64]chan FenceAck)
+	}
+	s.fenceAckWaiters[seq] = waiter
+	s.fenceAckMu.Unlock()
+
+	unregister := func() {
+		s.fenceAckMu.Lock()
+		delete(s.fenceAckWaiters, seq)
+		s.fenceAckMu.Unlock()
+	}
+
+	var payload [8]byte
+	binary.LittleEndian.PutUint64(payload[:], seq)
+	s.writeMu.Lock()
+	err := writeMsg(conn, syncMsgFence, payload[:])
+	s.writeMu.Unlock()
+	if err != nil {
+		unregister()
+		slog.Warn("cluster sync: fence send error", "seq", seq, "err", err)
+		s.stats.Errors.Add(1)
+		s.handleDisconnect(conn)
+		return FenceAck{}, fmt.Errorf("failed to send fence message: %w", err)
+	}
+	s.stats.FencesSent.Add(1)
+	slog.Info("cluster sync: sequenced fence sent to peer, awaiting confirmation",
+		"seq", seq, "timeout", timeout)
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case ack, ok := <-waiter:
+		if !ok {
+			// Channel closed by abortFenceAckWaiters: the fabric dropped
+			// before the peer answered.
+			return FenceAck{}, fmt.Errorf("session sync disconnected during fence ack wait seq=%d", seq)
+		}
+		s.stats.FenceAcksReceived.Add(1)
+		slog.Info("cluster sync: fence ack received",
+			"seq", ack.Seq,
+			"status", ack.Status,
+			"rgs_fenced", ack.RGsFenced,
+			"rgs_total", ack.RGsTotal)
+		return ack, nil
+	case <-timer.C:
+		unregister()
+		s.stats.FenceAcksTimedOut.Add(1)
+		return FenceAck{}, fmt.Errorf("timed out after %s waiting for peer fence ack seq=%d", timeout, seq)
+	}
+}

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -160,16 +160,24 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 			children:      nil,
 		},
 		"hitless-restart": {desc: "Keep dataplane forwarding active during daemon shutdown (HA default is fail-closed)", children: nil},
-		// xpf extension. Only "disable-rg" is acted on by the runtime
-		// (pkg/cluster/heartbeat_manager.go:362, failover.go:166); any
+		// xpf extension. Only the two values below are acted on by the
+		// runtime (pkg/cluster/heartbeat_manager.go handlePeerTimeout); any
 		// other string compiled silently no-ops — the enum closes that.
+		//
+		// "disable-rg" is best-effort and UNACKNOWLEDGED: the fence is sent
+		// after the local election and never gates ownership.
+		// "disable-rg-confirmed" (#7147) sends a sequenced fence BEFORE the
+		// election and waits, bounded and fail-open, for the peer to confirm
+		// it disabled every redundancy group. Both are kept because they are
+		// genuinely different trades, and "disable-rg" must not change
+		// behaviour for configs already deployed against it.
 		"peer-fencing": {
-			desc:          "Fencing action sent to the peer when its heartbeats are lost (disable-rg)",
+			desc:          "Fencing action sent to the peer when its heartbeats are lost (disable-rg, disable-rg-confirmed)",
 			args:          1,
 			valueType:     ValueEnumOf,
-			valueDesc:     "Fencing action on heartbeat timeout (disable-rg)",
-			valueExamples: []string{"disable-rg"},
-			validator:     ValidateEnum([]string{"disable-rg"}),
+			valueDesc:     "Fencing action on heartbeat timeout (disable-rg = best-effort, disable-rg-confirmed = wait for peer acknowledgement)",
+			valueExamples: []string{"disable-rg", "disable-rg-confirmed"},
+			validator:     ValidateEnum([]string{"disable-rg", "disable-rg-confirmed"}),
 			children:      nil,
 		},
 		// Milliseconds, xpf extension. 0 = immediate takeover once

--- a/pkg/config/schema_validate_chassis_test.go
+++ b/pkg/config/schema_validate_chassis_test.go
@@ -90,8 +90,17 @@ var chassisLeafMatrix = []chassisLeafCase{
 		name:     "peer-fencing",
 		leaf:     "peer-fencing",
 		template: "set chassis cluster peer-fencing %s",
-		accept:   []string{"disable-rg"},
-		reject:   []string{"disable", "DISABLE-RG", "fence", ""},
+		// #7147 added disable-rg-confirmed. It MUST be in accept: without a
+		// row here the schema could reject the value the runtime branches on
+		// and the whole policy would be uncommittable, while every test that
+		// uses the Go constant directly stayed green.
+		accept: []string{"disable-rg", "disable-rg-confirmed"},
+		// The near-misses are deliberate: "disable-rg-confirm" and
+		// "disable-rg confirmed" are the two spellings an operator actually
+		// types, and a validator loosened to a prefix or substring match would
+		// accept both while still passing every accept row above.
+		reject: []string{"disable", "DISABLE-RG", "fence", "disable-rg-confirm",
+			"disable-rg-confirmedx", "confirmed", ""},
 	},
 	{
 		name:     "redundancy-group node priority",

--- a/pkg/config/types_chassis.go
+++ b/pkg/config/types_chassis.go
@@ -149,7 +149,7 @@ type ClusterConfig struct {
 	DHCPLeaseSync         bool   // enable DHCP-server lease synchronization (#2239 PATH C: lease state held on standby, seeded into Kea on takeover)
 	RethAdvertiseInterval int    // RETH VRRP advertisement interval in milliseconds, 0=default(30)
 	HitlessRestart        bool   // preserve BPF state on shutdown (default false in HA — fail-closed)
-	PeerFencing           string // peer fencing action on heartbeat timeout: "", "disable-rg"
+	PeerFencing           string // peer fencing action on heartbeat timeout: "", "disable-rg", "disable-rg-confirmed" (#7147)
 	TakeoverHoldTime      int    // milliseconds, 0=immediate takeover once ready
 	NoRethVRRP            bool   // cluster directly manages VIPs (no VRRP for RETH interfaces)
 	PrivateRGElection     bool   // election over control link only, suppress RETH VRRP

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1114,9 +1114,18 @@ this. A received peer fence writes `SetRGActive(rg, false)` directly; before
 the fix a fenced primary never came back, because the reconcile pass that
 exists precisely to restore it could not see that anything had changed. (The
 fence itself is opt-in on the SENDING node — `set chassis cluster peer-fencing
-disable-rg`, `heartbeat_manager.go` — but the RECEIVING side is wired
-unconditionally, so a node with no fencing configured is still exposed to a
-peer that has it.)
+disable-rg` or `disable-rg-confirmed`, `heartbeat_manager.go` — but the
+RECEIVING side is wired unconditionally, so a node with no fencing configured
+is still exposed to a peer that has it.)
+
+#7147: `fenceAllRedundancyGroups` now RETURNS a `cluster.FenceResult` reporting
+how many RGs it drove to `rg_active=false` out of how many the live config
+holds, so a sequenced fence can be acknowledged truthfully. Two rules for
+anyone editing it: count a group only on a CLEAN `SetRGActive`, matching the
+"not known to have converged" reading the `InvalidateApplied` rule below
+already takes; and leave `DataplaneAvailable` false on the config-only path
+rather than returning a vacuous 0-of-0 success, which the peer would read as
+"this node is safely dark" when nothing was attempted.
 
 The fix is the class, not the call site: `rgStateMachine.InvalidateApplied()`
 re-arms the retry, and the fence calls it after each write. Rules for any

--- a/pkg/daemon/daemon_ha_comms_wiring.go
+++ b/pkg/daemon/daemon_ha_comms_wiring.go
@@ -428,7 +428,12 @@ func (d *Daemon) wireClusterFenceCallbacks(commsCtx context.Context, ss *cluster
 	// Wire peer fencing: on heartbeat timeout, cluster sends
 	// fence via sync; on receive, disable all local RGs.
 	d.cluster.SetPeerFenceFunc(ss.SendFence)
-	ss.OnFenceReceived = func() {
+	// #7147: the CONFIRMED variant of the same outbound fence, used only by
+	// `peer-fencing disable-rg-confirmed`. Wired beside the best-effort one
+	// because they share a lifecycle; the Manager picks between them off the
+	// committed policy, so `disable-rg` still takes the unsequenced path.
+	d.cluster.SetPeerFenceConfirmFunc(ss.SendFenceAwait)
+	ss.OnFenceReceived = func() cluster.FenceResult {
 		slog.Warn("cluster: fence received from peer")
 		// #3917: fence the CURRENT redundancy-group set, not the
 		// `cfg` snapshot captured in this closure at
@@ -440,7 +445,7 @@ func (d *Daemon) wireClusterFenceCallbacks(commsCtx context.Context, ss *cluster
 		// becomes active for it -> split-brain dual-active. The
 		// dp==nil (config-only) and nil-cluster guards live in
 		// fenceAllRedundancyGroups.
-		d.fenceAllRedundancyGroups(commsCtx)
+		return d.fenceAllRedundancyGroups(commsCtx)
 	}
 }
 

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1106,7 +1106,12 @@ func (d *Daemon) currentRedundancyGroups() []*config.RedundancyGroup {
 // the live config here (via currentRedundancyGroups) ensures day-2 RGs are
 // fenced too. Safe when the dataplane is nil (config-only mode) or the
 // config has no cluster/RGs.
-func (d *Daemon) fenceAllRedundancyGroups(ctx context.Context) {
+//
+// #7147: it now REPORTS what it achieved so a sequenced fence can be
+// acknowledged truthfully. The counts are what the peer's confirmed-fence gate
+// consults, so "fenced" means every RG in this node's live config was actually
+// driven to rg_active=false — not merely that the fence message arrived.
+func (d *Daemon) fenceAllRedundancyGroups(ctx context.Context) cluster.FenceResult {
 	// Guard the published dataplane: the daemon can run in config-only mode
 	// (no published dataplane)
 	// when the runtime dataplane factory rejects the configured backend —
@@ -1122,14 +1127,25 @@ func (d *Daemon) fenceAllRedundancyGroups(ctx context.Context) {
 			"action", "skip_rg_deactivation",
 			"remediation", "set system dataplane-type userspace and restart xpfd",
 		)
-		return
+		// #7147: DataplaneAvailable stays false, which the peer reads as
+		// FenceAckUnavailable. Reporting a vacuous "0 of 0 fenced, OK" here
+		// would tell the surviving node this peer is safely dark when in fact
+		// nothing was even attempted.
+		return cluster.FenceResult{}
 	}
 	rgs := d.currentRedundancyGroups()
+	res := cluster.FenceResult{RGsTotal: len(rgs), DataplaneAvailable: true}
 	slog.Warn("cluster: fence: disabling all RGs", "rg_count", len(rgs))
 	for _, rg := range rgs {
 		if err := rt.HA().SetRGActive(ctx, rg.ID, false); err != nil {
 			slog.Warn("cluster: fence: failed to disable rg_active",
 				"rg", rg.ID, "err", err)
+		} else {
+			// #7147: counted only on a CLEAN write. A failed SetRGActive may
+			// have partially landed, and the honest reading of "not known to
+			// have converged" is that this RG is not confirmed fenced — the
+			// same posture the InvalidateApplied call below takes.
+			res.RGsFenced++
 		}
 		// #6530: this write bypasses the RG state machine's transition
 		// path, so without re-arming, reconcileRGState's desired-vs-applied
@@ -1141,6 +1157,7 @@ func (d *Daemon) fenceAllRedundancyGroups(ctx context.Context) {
 		// once the cluster state says this node owns the RG again.
 		d.getOrCreateRGState(rg.ID).InvalidateApplied()
 	}
+	return res
 }
 
 // startHeartbeatWithRetry resolves the control-link local address and starts

--- a/pkg/daemon/fence_confirm_wiring_7147_test.go
+++ b/pkg/daemon/fence_confirm_wiring_7147_test.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+)
+
+// #7147 — the daemon half of the confirmed peer fence.
+//
+// Both directions are silent when unwired, which is why they get their own
+// assertions:
+//
+//   - if SetPeerFenceConfirmFunc is never called, `disable-rg-confirmed`
+//     degrades to "Fence skipped: sync not available" on EVERY takeover. That
+//     path fails open, so the cluster keeps working and nothing observable
+//     breaks — the operator simply never gets the guarantee they configured.
+//   - if OnFenceReceived returns a zero FenceResult, this node acks
+//     `unavailable` even when it fenced perfectly, and its peer reports an
+//     unconfirmed takeover forever.
+
+// TestWireClusterFenceCallbacksInstallsConfirmFunc_7147 binds the OUTBOUND
+// confirming sender. Asserting only that the best-effort SendFence is wired
+// (the #6428 test above) leaves this one free to be dropped.
+func TestWireClusterFenceCallbacksInstallsConfirmFunc_7147(t *testing.T) {
+	src := readDaemonSource(t, "daemon_ha_comms_wiring.go")
+	flat := strings.Join(strings.Fields(src), "")
+	if !strings.Contains(flat, "d.cluster.SetPeerFenceConfirmFunc(ss.SendFenceAwait)") {
+		t.Error("wireClusterFenceCallbacks does not install the #7147 confirming fence " +
+			"sender. `peer-fencing disable-rg-confirmed` would then record " +
+			"'Fence skipped: sync not available' on every takeover and gate nothing — " +
+			"and because that path fails open, the cluster would look entirely healthy.")
+	}
+	if !strings.Contains(flat, "d.cluster.SetPeerFenceFunc(ss.SendFence)") {
+		t.Error("the best-effort fence wiring this one is anchored beside has moved; " +
+			"re-verify both senders are still installed together")
+	}
+}
+
+// TestFenceHandlerReportsWhatItAchieved_7147 binds the INBOUND handler's
+// return value. A handler that fenced correctly but returned the zero
+// FenceResult would ack `unavailable`, and the peer would report every
+// takeover as unconfirmed while everything actually worked.
+func TestFenceHandlerReportsWhatItAchieved_7147(t *testing.T) {
+	d := newWiringTestDaemon()
+	ss := newWiringTestSessionSync()
+	d.wireClusterFenceCallbacks(t.Context(), ss)
+
+	if ss.OnFenceReceived == nil {
+		t.Fatal("wireClusterFenceCallbacks did not install ss.OnFenceReceived")
+	}
+
+	// This fixture has no published dataplane, so the honest answer is
+	// "unavailable" — NOT a vacuous 0-of-0 success. That distinction is the
+	// whole reason FenceResult carries DataplaneAvailable separately from the
+	// counts, so it is asserted rather than assumed.
+	got := ss.OnFenceReceived()
+	if got.DataplaneAvailable {
+		t.Errorf("a daemon with no published dataplane reported DataplaneAvailable: %+v", got)
+	}
+	if st := got.Status(); st != cluster.FenceAckUnavailable {
+		t.Errorf("Status() = %d, want FenceAckUnavailable (%d). Reporting OK here would "+
+			"tell the surviving node this peer is safely dark when it never even "+
+			"attempted a deactivation.", st, cluster.FenceAckUnavailable)
+	}
+	if got.Status() == cluster.FenceAckOK {
+		t.Error("a config-only node CONFIRMED a fence it could not perform")
+	}
+}


### PR DESCRIPTION
Closes #7147

## Premise first: the gap is real and unchanged at master

Verified at `759f776a2` rather than taken from the issue text:

- `SessionSync.SendFence` (`sync_failover.go:381`) still does `getActiveConn` → `writeMsg(syncMsgFence, nil)` → `FencesSent++` → return.
- The receive arm (`sync_conn_read.go:615`) bumps `FencesReceived`, calls `OnFenceReceived()`, and sends **nothing** back.
- `handlePeerTimeout` still runs `electSingleNode()` **before** the fence, carrying a comment saying gating is impossible because no ack exists.
- `LastFenceSeq` / `LastFenceAckAt` are still the bulk-sync install barrier (written under `syncMsgBarrierAck`), exactly as the issue warns — not reusable.
- `docs/ha-failover-status.md` asserted the gap in prose too ("best-effort and unacknowledged... there is no fence-ack message on the wire").

So the deliverable is real work, not a re-scope.

## Two corrections to the analysis already on the issue

The existing comment reached the right conclusion (additive, no bump) but two of its specifics were wrong, and both would have shipped defects:

1. It proposes `syncMsgFenceAck = 30`. **30 is already `syncMsgConfigKeyExchange`** (#6629). Ids 1–34 are all taken; the first free id is **35**. Taking 30 would have collided with the config-encryption handshake — the exact "old peer MISPARSES a known type" failure the uniqueness guard exists to prevent.
2. It proposes appending a capability bit to `syncMsgPeerCapabilities` as-is. That frame **was not always sent**: `sendCapabilities` returned early when `localSnapshotProtocol == 0`. Fence-ack capability would then have depended on an unrelated constant (`userspace.ProtocolVersion`, today 8) staying nonzero — and had it ever been 0, the gate would have silently stopped arming while looking exactly like a healthy pre-#7147 peer.

## Why this is additive — no version bump

Three reasons, each checked at my own head rather than inherited:

1. `handleMessage`'s `switch msgType` has **zero** `default:` arms (counted), and framing is length-prefixed, so an old peer skips an unknown type without desyncing. Same property #2239 and #6650 relied on.
2. The fence sequence is trailing data on an **existing** type whose old receiver reads no payload at all.
3. **Bumping would be actively harmful, in two independent ways.** `MinCompatHAProtocolVersion = CurrentHAProtocolVersion` (`heartbeat.go:51` — literally assigned from it), so the accepted HA window is a single point, and `GateMixedBaseSwap` refuses at `peerHAProtocol < MinCompat || peerHAProtocol > Current` (`imageversions.go:156`) — a bump makes the window `[N+1,N+1]` and refuses a peer at N. And session-sync is checked for **exact** equality (`imageversions.go:169`), so bumping `SessionSyncWireVersion` would refuse the mixed-base swap outright. The bump is what would break the rolling upgrade, not the feature.

A mixed-version pair degrades **exactly** to pre-#7147 behaviour on both sides: the old node ignores the sequence and never replies, the new node sees no capability advertised and does not wait at all.

## The three design questions the issue left open

**Q1 — what "fenced" means.** Peer-**confirmed**, not ack-of-receipt. The ack is written only after the receiver's `fenceAllRedundancyGroups` returns and carries `rgs_fenced / rgs_total`; only full success is reported as confirmed. A peer in config-only mode answers `unavailable` rather than a vacuous 0-of-0 success, because "nothing to disable" and "unable to disable anything" look identical in the counts and mean opposite things.

**Q2 — the bounded timeout against the failover target.** The crux the issue names ("a fence round trip sits directly in the takeover critical path") largely dissolves on a structural detail neither the issue nor the comment noticed: **`SendFenceAwait` returns immediately when there is no active connection.** The ordinary dead-peer takeover therefore pays *nothing* — there is no socket, so there is nothing to wait on. The wait is only reachable when the sync channel is live, which is precisely the split-brain-risk case where a fabric round trip is sub-millisecond and where waiting is the correct thing to do.

The one case that genuinely spends the bound is a peer that lost power while its TCP socket has not yet noticed. `FenceConfirmTimeout` is **1s**, and the way that number was arrived at is worth stating because the first attempt was wrong on the facts. 250ms was chosen on the assumption that the receiver's fence is a round trip plus "a handful of dataplane writes". It is not: each RG's `SetRGActive` reaches `userspace.Manager.UpdateRGActive`, which takes the helper's own mutex — shared with the 1/s status poll, session installs and snapshot apply — and issues an `update_ha_state` request on the shared control socket whose base deadline is **3s**, once per RG sequentially; the reply then queues behind `writeMu`, which a stalled send loop can hold for `syncWriteDeadline` = 2s. A peer loss frequently follows a fabric reconnect, i.e. exactly when that socket is most contended, so a 250ms bound would have timed out and failed open on essentially every takeover while `FenceAcksTimedOut` climbed.

No bound short enough to sit in a takeover path can *guarantee* the ack, so this is documented as a **policy** bound rather than a derivation of the peer's worst case: long enough that an uncontended cluster actually gets its confirmation, still well under a single 3s control deadline so a wedged socket fails open instead of stalling. It is a constant, not a knob: shorter stops the gate ever engaging on a loaded fabric, longer extends the only outage window it can create, and the policy leaf already expresses the one decision an operator actually has.

**Q3 — per-RG or node-global.** Node-global, matching the existing fence: `fenceAllRedundancyGroups` is all-RGs by construction.

## What this does NOT give you

**It reduces the split-brain window; it does not eliminate it, and the policy name overclaims.** The residual is a partition where the sync socket is live but BLACKHOLED — packets dropping, TCP not yet timed out — so the fence is written successfully, no ack can return, and after the bound this node takes over while the peer may still be forwarding. That is split-brain, exactly what a fence exists to prevent.

That is a deliberate trade. Failing *closed* has the worse failure mode for an appliance: a partition that never resolves leaves nobody forwarding, and an HA pair that will not fail over has lost the property it exists for. An operator selecting this mode buys confirmation **when confirmation was available** — the common case, since the ack only has to arrive when the socket is genuinely healthy — plus ordering in that case. They do not buy "the peer is always confirmed down before I take over".

**The config knob cannot express the difference**, which is why the event line matters: `Action: disable-rg-confirmed` renders identically whether every takeover was confirmed or every one fell open. `docs/ha-failover-status.md` now carries both the residual and a table mapping each `EventFence` attempt line to what actually happened, with `Confirmations: ... timed out N` as the aggregate. The name was kept over renaming or going fail-closed because a documented residual plus a distinguishable event line is the adequate mitigation, and the mechanism is the right trade regardless of what it is called.

## Fail-open is a requirement, not a compromise

Every negative path proceeds with the takeover — no connection, peer not capable, write error, timeout, partial ack, unavailable ack. A gate that can withhold ownership turns peer loss into an outage, which would be a worse defect than the gap being closed. Each fail-open records an `EventFence` line naming the reason, and a new `Confirmations: received N, timed out N, sent to peer N` line reports the timeout count — the only place it appears, since `Fences sent` counts a confirmed and an unconfirmed takeover identically.

`disable-rg` is untouched. It still fences *after* the election, still fire-and-forget, so no deployed config changes behaviour. Tests pin that both ways: `disable-rg` must never call the confirming path, and an unconfigured leaf must call neither (without the second, both policy tests would pass on an implementation that fenced unconditionally).

## A total-outage defect this change introduced, found by hostile review and fixed

Worth reading in full, because the first version of this PR shipped it and asserted in a code comment that it could not happen.

`awaitPeerFenceLocked` releases `m.mu` between marking the peer lost and electing — a window `disable-rg` does not have. `handlePeerTimeout` sets `peerAlive = false` **specifically to bypass** `electSingleNode`'s #7161 readiness gate, which is armed only when `controlInterface != "" && (peerAlive || !peerEverSeen)` (`election.go:476`). Before this change that write and the election ran under one unbroken hold. The wait opens the window — and `handlePeerHeartbeat` runs on a **different goroutine** already blocked on `m.mu` (`heartbeat_manager.go:460`). The moment the lock is released it sets `peerAlive = true`, re-arming the gate, and `electSingleNode` then reaches `if !promote { continue }` and declines to promote — *after* the fence has already driven every RG on the peer to `rg_active=false`.

Peer dark, this node passive, no primary anywhere: the exact outage the policy exists to prevent, produced by the policy.

**Why the tests could not see it.** `confirmFenceManager` builds its config with `makeConfig`, which never sets `ControlInterface`. With `m.controlInterface == ""` the readiness-gate arm is structurally unreachable, so all 26 tests were blind to that branch and the window could not change any outcome. Five other cluster tests in this repo set `cfg.ControlInterface = "em0"` for precisely this reason.

**The fix** re-asserts the peer-loss decision after re-acquiring the lock. Only `peerAlive` is restored — it is the sole field in the peer-loss block that the promotion decision reads. It is honest as well as necessary: having just told the peer to relinquish everything, "the peer does not own its groups" is the state we created, and a genuinely-recovered peer re-establishes `peerAlive` on its next heartbeat.

The new regression test arms the gate (`ControlInterface` plus a running takeover hold) and flips `peerAlive` from inside the confirm callback — the only place genuinely inside the window. **Paired cell: removing the one-line fix reds that test and nothing else; restoring it passes.**

Three lower-severity findings from the same review are fixed in the same commit: `abortFenceAckWaiters` ran only in the both-fabrics-down branch (a single-fabric drop left the waiter registered and burned the full timeout, even though the peer answers on the connection it received the fence on); the timeout re-sizing above; and a safety comment that named the wrong goroutine — it claimed `handlePeerTimeout` runs on the heartbeat receive path when it runs on `timeoutLoop`, and that wrong model is exactly what made the hazard look impossible.

Six classes came back clean: lock order (only one nesting, `s.mu` → `fenceAckMu`, never inverted), channel safety (no send-on-closed or double-close, provable because every map removal happens under `fenceAckMu` before the send or close), goroutine wedge, waiter leaks (all four post-registration exits unregister), wire decode, and `disable-rg` / unconfigured regression including every `peerSnapshotProtocol` reader.

## Validation

- `go test -count=1 ./...` — 69 ok, 5 no-test, **0 named `--- FAIL`, 0 build breaks, 0 "no space left"**.
- `make cluster-deploy && make test-failover` on `loss:xpf-userspace-fw0/fw1` under the #1875 lock (`with-cluster.sh`): **17 passed, 0 failed, 21.2 Gbps** on the pre-review-fix tree, and **17 passed, 0 failed, 22.9 Gbps** re-run after the review fixes. Both nodes run the #7147 build, so the capability is advertised in both directions, and `show chassis cluster status` reports **HA protocol version 1 on both** — the no-bump claim confirmed on real nodes, not just in the source. The legs that matter here are the ones that touch `handlePeerTimeout`: iperf3 survived an unclean `sysrq` reboot of fw0, fw0 rejoined as secondary without auto-preempt, and a manual failover of all three RGs held IPv4 and IPv6 transit. The 21.2 Gbps also rules out a leftover-CoS cap on the shared cluster.

  The re-run's first attempt tripped **#7962**, the known gate defect, not this branch: `cluster-deploy`'s post-deploy reassert checks ~30s after deploy while the degraded-promotion fallback is `DefaultDegradedPromoteTimeout` = **2 minutes**, so RG2 was still `secondary` with `Takeover ready: no (userspace XSK liveness not proven)`. The discriminator that rules this branch out is not timing but reachability: the cluster's committed config has **no `peer-fencing` leaf at all**, so `m.peerFencing == ""` and neither the new `disable-rg-confirmed` arm nor `awaitPeerFenceLocked` is reachable there. All three RGs promoted on their own once the 2-minute fallback elapsed, and the re-run then passed every leg. The cluster was left healthy: node0 primary for all three RGs, no manual latch, lock released.
- No Rust source changed (0 `*.rs` files in the diff), so `make test-rust` is not implicated.
- 27 new test functions (subtests bring the collected count higher); the superseded #6650 test is **replaced**, not deleted, by one that pins the new contract and re-asserts the invariant that actually survived (a receiver cannot distinguish "frame absent" from "version 0").

### Mutation matrix — 13 cells, full-package runs, no `-run` filter

Control clean (1058 / 2209 tests collected, 0 fails, no build break). Every cell produced a **named** `--- FAIL` with tests-collected > 0, so none is a build break wearing a red's clothes.

| # | mutation | reds | localised to |
|---|---|---|---|
| M1 | fence moved back AFTER `electSingleNode` (the pre-#7147 ordering) | 1 | `ConfirmedFenceRunsBeforeElection` |
| M2 | ack seq match removed (fire any waiter) | 1 | `FenceAckSeqMustMatchTheWaiter` |
| M3 | ack length gate removed (zero-fill short frames) | 2 | `TruncatedFenceAckIsDropped`, `ShortFrameIsRejectedNotZeroFilled` |
| M4 | peer-capability gate removed | 1 | `SendFenceAwaitFailsOpenImmediately` |
| M5 | `Status()` always returns OK | 4 | incl. `FenceResultStatusMapping` |
| M6 | ack written BEFORE the fence runs | 2 | `SequencedFenceIsAckedAfterFencing` |
| M7 | capability flags byte not advertised | 1 | `SendCapabilitiesAdvertisesUnconditionally` |
| M8 | fail-open reason not recorded | 1 | `ConfirmedFenceAlwaysFailsOpen` |
| M9 | `SetPeerFenceConfirmFunc` wiring dropped | 1 | `WireClusterFenceCallbacksInstallsConfirmFunc` |
| M10 | daemon reports vacuous success in config-only mode | 1 | `FenceHandlerReportsWhatItAchieved` |
| M11 | schema enum missing `disable-rg-confirmed` | 2 | `SchemaValidate_ChassisCluster_Matrix`, `PolicyConstantsAreCommittable` |
| M12 | runtime constant misspelled vs the schema | 2 | `PolicyConstantsAreCommittable`, `ConfirmedFenceReportsWhatThePeerDisabled` |
| M13 | the peer-loss re-assert removed (the P0 above) | **1** | `ConfirmedFencePromotesEvenIfAHeartbeatLandsInTheWindow` |

M13 is the paired cell for the outage defect: removing the one-line fix reds that test **and nothing else in the package**, and restoring it passes — necessary and sufficient, not merely correlated.

M9 is the one worth calling out: an unwired confirm function makes `disable-rg-confirmed` record "Fence skipped: sync not available" on every takeover and gate nothing — and because that path fails open, the cluster looks entirely healthy. Nothing else in the suite could see it.

The ordering fixture (M1) needed a correction found while writing it: `UpdateConfig` already elects the node primary, so both orderings would have sampled `StatePrimary` inside the callback and the test would have certified the shape it exists to reject. The fixture now forces `StateSecondary` and guards that precondition explicitly.

## Docs

Updated in the same change: `docs/ha-failover-status.md` (the fence section split by policy, with the fail-open cost table and the mixed-version note), `pkg/cluster/README.md` (the additive-wire section beside the #2239 and #6650 precedents, plus the `Confirmations:` render), `pkg/daemon/README.md` (the two rules for editing `fenceAllRedundancyGroups`'s new return value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACWxU8wCM6am182N4END6m
