### PR TITLE
kernel Gate 4: refuse beacon targets that cannot prove the dataplane forwards

### DIFF
--- a/cmd/xpfd/upgrade_kernel.go
+++ b/cmd/xpfd/upgrade_kernel.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/upgrade"
 	"github.com/psaab/xpf/pkg/upgrade/lock"
 )
@@ -258,12 +259,18 @@ func newKernelConfig(journalPath string, strictWatchdog bool, beaconDeadline tim
 		// xpf-kernel-promote.service, not an operator command line), and
 		// upgradeControlSock already falls back to the default socket path when
 		// that dir is absent or unreadable.
+		//
+		// #7157: config.IsManagementIfName is the beacon's management-interface
+		// classifier — the #7515 SSOT already shared by the vrf-mgmt binder, the
+		// networkd `VRF=` emitter and the ip-monitoring next-hop validator, so
+		// this is a fourth CONSUMER of one rule rather than a fourth copy of it.
 		Sys: upgrade.NewKernelSystemWithHelperStatus(
 			func(ctx context.Context) (bool, error) {
 				return upgradeUnitActive(ctx, upgrade.DefaultUnit)
 			},
 			upgradeHelperStatus,
 			upgradeControlSock(upgrade.DefaultConfigDBDir),
+			config.IsManagementIfName,
 		),
 		Logf: func(format string, a ...any) { fmt.Printf(format+"\n", a...) },
 	}

--- a/cmd/xpfd/upgrade_kernel_beacon_6607_test.go
+++ b/cmd/xpfd/upgrade_kernel_beacon_6607_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -50,5 +51,46 @@ func TestNewKernelConfig_WiresGate4DataplaneProbe_6607(t *testing.T) {
 	if ok {
 		t.Fatalf("ForwardBeacon reported forward progress with the helper up but NOT forwarding "+
 			"(err=%v) — a kernel that breaks the dataplane would be promoted", err)
+	}
+}
+
+// TestNewKernelConfig_WiresBeaconTargetClassifier_7157 binds the #7157 beacon
+// target classifier at the PRIMARY production construction site.
+//
+// Same reasoning as the #6607 wiring test above: pkg/upgrade's tests set
+// IsManagementIface by hand, so reverting this site to nil leaves all of them
+// green while production loses the ability to refuse a beacon target that
+// egresses the out-of-band management interface.
+//
+// Asserts BEHAVIOUR: a locally-written copy of the three prefixes would satisfy
+// a nil-check while being free to drift from config.IsManagementIfName, which
+// #7515 records as always a bug.
+func TestNewKernelConfig_WiresBeaconTargetClassifier_7157(t *testing.T) {
+	cfg := newKernelConfig("/unused-journal", false, time.Second)
+	v := reflect.Indirect(reflect.ValueOf(cfg.Sys))
+	if v.Kind() != reflect.Struct {
+		t.Fatalf("kernel system is %s, not a struct", v.Kind())
+	}
+	f := v.FieldByName("IsManagementIface")
+	if !f.IsValid() || f.IsNil() {
+		t.Fatal("newKernelConfig did not wire IsManagementIface — ForwardBeacon cannot refuse " +
+			"a beacon target that egresses the management interface, so a candidate kernel " +
+			"that keeps management up while breaking transit forwarding is promoted (#7157)")
+	}
+	fn, ok := f.Interface().(func(string) bool)
+	if !ok {
+		t.Fatalf("IsManagementIface has type %s, want func(string) bool", f.Type())
+	}
+	for _, tc := range []struct {
+		iface string
+		want  bool
+	}{
+		{"fxp0", true}, {"em0", true}, {"fab0", true},
+		{"ge-0-0-1", false}, {"reth0.50", false}, {"lo", false},
+	} {
+		if got := fn(tc.iface); got != tc.want {
+			t.Errorf("wired classifier(%q) = %v, want %v — it must be config.IsManagementIfName, "+
+				"the #7515 SSOT, not a local copy free to drift from it", tc.iface, got, tc.want)
+		}
 	}
 }

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -976,6 +976,87 @@ test) and falls back to the `xpfd`-liveness check alone — "no
 information" is not "unhealthy", and failing closed on it would revert
 every such caller's promotion.
 
+### Beacon target eligibility (#7157)
+
+Gate 4's ping only means something if it CAN fail. Three target classes make it
+succeed regardless of dataplane health, and before #7157 the gate could not tell
+them from a healthy probe. Each is now refused before the ping, with a named
+reason that reaches the operator through `KernelRollOutcome.Reason`:
+
+| refused class | why the ping is uninformative |
+|---|---|
+| egress `dev lo` (a LOCAL target) | the host stack answers without a packet leaving the box |
+| egress a MANAGEMENT interface | a candidate kernel can keep the OOB path working while the dataplane cannot forward transit traffic |
+| no route at all | nothing can leave, so nothing can be concluded |
+
+The `lo` case is the one that was reachable and unconditional. Measured on
+`loss:xpf-userspace-fw0`:
+
+```
+# ip route get 172.16.50.8          <- the box's OWN dataplane address
+local 172.16.50.8 dev lo table local src 172.16.50.8
+# ping -c 1 172.16.50.8
+1 packets transmitted, 1 received, 0% packet loss, rtt 0.055 ms
+```
+
+55 microseconds, over `lo`, with the dataplane in any state. So
+`XPF_KERNEL_BEACON_TARGET` set to the box's own dataplane address made Gate 4
+pass for **every** candidate kernel — and this document's own guidance ("set it
+to a dataplane-side target") is what leads an operator to type it. **Set it to an
+OFF-BOX address reachable over a dataplane interface** — the far end of a
+transit link, or the HA peer's dataplane address.
+
+The management classifier is `config.IsManagementIfName`, the #7515 SSOT already
+shared by the daemon's `vrf-mgmt` binder, the networkd `VRF=` emitter and the
+ip-monitoring next-hop validator. It is injected by the caller for the same
+reason `HelperStatus` is, and a `nil` classifier is "no information" rather than
+"ineligible" — but both production constructors wire it, and tests bind that
+rather than leaving it to a comment.
+
+Note that on an xpf-managed box the management default route is NOT what the
+fallback finds: `fxp*`/`fab*`/`em*` are enslaved to `vrf-mgmt` (table 999), so
+`ip -4 route show default` reads the main table and returns a dataplane route.
+The management refusal therefore guards an operator-set target and a posture
+where that VRF isolation is absent, not the default-gateway fallback.
+
+### Known limitation: the beacon cannot pass on an HA secondary (#7157)
+
+On a RETH-based HA secondary, FRR blackholes the static default while the peer
+holds the VIP. Measured on `loss:xpf-userspace-fw1`:
+
+```
+# ip -4 route show default
+blackhole default proto static metric 20
+# ip route get 1.1.1.1
+RTNETLINK answers: Invalid argument
+```
+
+`defaultGateway()` finds no `via`, so Gate 4 fails closed and the promotion
+reverts — on the node an HA operator upgrades FIRST. The direction is safe (a
+revert, never a brick), but a gate that cannot pass is a wall rather than a gate.
+The workaround today is to set `XPF_KERNEL_BEACON_TARGET` to an address the
+drained secondary can still reach over a dataplane interface. Whether a drained
+secondary should instead be allowed to promote on preconditions A+B alone is a
+deliberate weakening of a security gate and is tracked on #7157, not decided
+here.
+
+### Still open on #7157: this is eligibility, not a transit witness
+
+None of the above shows that a packet crossed ingress AF_XDP → filter/PBR → zone
+policy → session/NAT → egress. The ping is still host-originated, so it does not
+traverse the forwarding path a transit packet takes. What eligibility buys is
+that a PASS is now capable of being a FAIL. The external tagged transit witness
+— an isolated source, a configured ingress, an expected egress, an explicit
+policy/NAT expectation, bound to the candidate boot identity, IPv4 and IPv6 —
+remains open, and needs an observer outside the box that the unattended
+boot-time gate does not have.
+
+Related, and also still open: `KernelJournal.ArmNonce` is written on every arm
+and **never compared anywhere** (assignment sites only; the sole reads are in a
+test asserting two attempts differ). It is provenance, not an anti-stale
+mechanism, so #7157's "reject a stale result from an earlier candidate boot"
+case has no implementation behind it.
+
 ### Operator visibility (#6495)
 
 During a roll the channel is legible from the CLI the operator already has,

--- a/docs/log/7157.md
+++ b/docs/log/7157.md
@@ -1,0 +1,203 @@
+# 7157 — kernel promotion gates on a host-stack ping, not a forwarding proof
+
+Premise-checked at `origin/master` `a1009d4e5`, in a worktree, before writing
+anything. #7157 is the #1930 remainder; PR #7916 landed the staged half
+(`HelperStatus` on the daemon self-recover path). What follows is what is
+actually true at master, measured rather than read off the issue.
+
+## Premise findings
+
+### 1. `ProbeFunc` is still assigned nowhere — CONFIRMED
+
+`grep -rn ProbeFunc .` over the whole tree, all file types: a doc comment, the
+declaration, a nil check, an invocation, and three prose hits in `docs/`. No
+production assignment and no test assignment. The seam is still dead.
+
+### 2. The issue's headline scenario is NOT reachable through the fallback
+
+> "On a box whose default route is the OOB management NIC — the common case —
+> the beacon proves the management path and nothing else."
+
+Measured, this does not happen on an xpf-managed box. `fxp*`, `fab*` and `em*`
+are enslaved to **`vrf-mgmt` (table 999)** whenever any of them is configured
+(`managementVRFIfaceSet` → `config.IsManagementIfName`,
+`daemon_apply_interfaces.go:191-213`), so the DHCP-learned management default
+lives in table 999 while `ip -4 route show default` reads `main`.
+
+On `loss:xpf-userspace-fw0`:
+
+```
+# ip -4 route show default
+default nhid 115 via 172.16.50.1 dev ge-0-0-2.50 proto static metric 20
+# ip -4 route show table all | grep 'default.*fxp0'
+default via 10.136.126.1 dev fxp0 table 999 proto dhcp
+# ip rule show          <- nothing points at 999; it is reached via the VRF
+0:  from all lookup local
+1000:   from all lookup [l3mdev-table]
+31000:  from all to 10.255.192.40/30 iif ge-0-0-1 lookup 488570
+32766:  from all lookup main
+32767:  from all lookup default
+```
+
+`beaconDefaultGateway()` therefore returns a DATAPLANE next hop by construction.
+The management false-PASS is reachable only via an operator-set
+`XPF_KERNEL_BEACON_TARGET`, or on a posture with no `fxp*`/`fab*`/`em*`
+interface (so no mgmt VRF).
+
+Stating this matters because it is the premise the whole issue is built on, and
+building an elaborate defence of a path that cannot be taken is worse than
+building nothing.
+
+### 3. The reachable false-PASS is a LOCAL target, and it is unconditional
+
+The real hole is one the issue does not name, and this document's own guidance
+walks operators into it. `ForwardBeacon`'s godoc says:
+
+> the operator SHOULD set XPF_KERNEL_BEACON_TARGET to a DATAPLANE-side target
+
+The obvious reading is "the box's dataplane address". Measured on
+`loss:xpf-userspace-fw0`:
+
+```
+# ip route get 172.16.50.8        <- the box's OWN WAN address
+local 172.16.50.8 dev lo table local src 172.16.50.8
+# ping -c 1 -w 2 172.16.50.8
+1 packets transmitted, 1 received, 0% packet loss
+rtt min/avg/max/mdev = 0.055/0.055/0.055/0.000 ms
+```
+
+55 microseconds, over `lo`. The packet never leaves the box, so the ping
+succeeds with the dataplane in **any** state — Gate 4 then promotes every
+candidate kernel that reaches the promote verb. Same for IPv6
+(`local 2001:559:8585:80::8 ... dev lo`) and for the LAN VIP (`10.0.61.1`).
+
+This is the security defect actually fixed here.
+
+### 4. On an HA secondary the beacon can never pass — measured
+
+`loss:xpf-userspace-fw1`, the secondary:
+
+```
+# ip -4 route show default
+blackhole default proto static metric 20
+# ip -6 route show default
+blackhole default dev lo proto static metric 20 pref medium
+# ip route get 1.1.1.1
+RTNETLINK answers: Invalid argument
+```
+
+FRR blackholes the static default while the peer holds the RETH VIP.
+`defaultGateway()` finds no `via`, returns `""`, and `ForwardBeacon` fail-closes
+with "no forward-beacon target". A kernel promotion on the secondary therefore
+ALWAYS reverts — on the node an HA operator upgrades FIRST.
+
+The direction is safe (a revert, never a brick) but a gate that cannot pass is a
+wall, not a gate. Recorded in `docs/in-place-upgrade.md` as a known limitation
+with its workaround. Whether a drained secondary should be allowed to promote on
+preconditions A+B alone is a deliberate weakening of a security gate; that is a
+decision to take explicitly, not to slip into a PR whose subject is the opposite.
+
+### 5. `ArmNonce` is written and never compared — issue R3 has nothing behind it
+
+`grep -rn "ArmNonce\|arm_nonce"` over all file types: the declaration, one
+assignment (`kernel_run.go:373`), the generator, and three reads in
+`kernel_arm_two_phase_5847_test.go` asserting two attempts differ. Nothing in
+the promote path compares it. Its godoc says it "distinguishes a fresh arm from
+a stale journal", which overstates what the code does — nothing distinguishes
+anything.
+
+So #7157's RED case 5, "stale result from an earlier candidate boot → reject",
+has no implementation behind it. Not fixed here; recorded so it is not assumed.
+
+### 6. A test that re-implemented its own subject
+
+`TestDefaultGatewayParseLogic` opened with `// mimic defaultGateway()'s field
+scan` and then wrote the scan out again inside the test. It pinned the COPY. A
+change to the production parse left it green — and neither of the two shapes
+this product actually emits (`nhid ... via ...`; `blackhole default`) was in its
+table. Fixed by extracting the parse and having both call it.
+
+## What was built
+
+Target ELIGIBILITY, issue requirements R4 (positive dataplane selection, OOB
+management ineligible) and R6 (fail closed, never a silent weakening).
+
+`beaconTargetEligible` resolves the target's egress interface (`ip route get`)
+and refuses three classes before the ping, each with a named reason that reaches
+the operator through `KernelRunner.revert` → `KernelRollOutcome.Reason`:
+
+| class | why the ping is uninformative |
+|---|---|
+| `dev lo` | the host stack answers; nothing leaves the box (finding 3) |
+| a management interface | a candidate kernel can keep OOB working while transit forwarding is broken |
+| no route | nothing can leave, so nothing can be concluded (finding 4) |
+
+The classifier is `config.IsManagementIfName`, injected — the #7515 SSOT already
+shared by the `vrf-mgmt` binder, the networkd `VRF=` emitter and the
+ip-monitoring next-hop validator. A fourth CONSUMER of one rule, not a fourth
+copy of three prefixes; #7515 records that a divergence between them is always a
+bug. Its known looseness (`emergency0`, `fabric0` match) is safe in this
+direction: the predicate only REFUSES, so a false positive costs a fail-safe
+revert, never a promotion.
+
+`NewKernelSystemWithHelperStatus` takes the classifier as a REQUIRED parameter
+rather than a settable field, so a new caller cannot silently leave it nil — the
+compiler asks the question.
+
+### What this is NOT
+
+It is not a transit witness. The ping is still host-originated and never crosses
+ingress AF_XDP → filter/PBR → policy → session/NAT → egress. What eligibility
+buys is narrow and worth stating exactly: **a PASS is now capable of being a
+FAIL.** Before it, three target classes made the probe succeed by construction.
+
+The external tagged witness — isolated source, configured ingress, expected
+egress, explicit policy/NAT expectation, bound to candidate boot identity, IPv4
+and IPv6 — stays open on #7157. It needs an observer outside the box, which an
+unattended boot-time gate does not have.
+
+## Validation
+
+`go test -count=1 ./...` green. New tests: 7 in `pkg/upgrade`, 1 in `cmd/xpfd`,
+1 in `pkg/daemon` (selection counts verified non-zero — a `-run <issue-number>`
+filter matches filenames, not test names, and can select zero while exiting 0).
+
+### A hermeticity defect the change exposed in an existing test
+
+`TestForwardBeaconPassesWhenEverythingHealthy_6607` reaches the new eligibility
+check with no seam stubbed, so it ran a real `ip route get 192.0.2.1`. It passed
+on this dev box because `ip route get 192.0.2.1` happens to answer `dev ix0`. On
+a host with no route it fails; on a host whose default egresses a NIC named
+`em*`/`fab*`/`fxp*` it fails for a reason the assertion cannot name. Now stubs
+`beaconRouteGet`, the same reasoning the file already documents for `beaconPing`.
+
+### Mutation matrix (full-suite runs, one mutation per cell)
+
+Gated on the count of `^--- FAIL` lines, not on `rc != 0`: a build break is not a
+red.
+
+| mutation | named FAILs | which |
+|---|---|---|
+| M1 drop the eligibility call from `ForwardBeacon` | 2 | `ForwardBeaconRefusesLocalTarget_7157`, `ForwardBeaconRefusesManagementEgress_7157` |
+| M2 stop refusing `dev lo` | 2 | `BeaconTargetEligible_7157`, `ForwardBeaconRefusesLocalTarget_7157` |
+| M3 stop refusing a management egress | 2 | `BeaconTargetEligible_7157`, `ForwardBeaconRefusesManagementEgress_7157` |
+| M4 revert the `cmd/xpfd` wiring to nil | 1 | `NewKernelConfig_WiresBeaconTargetClassifier_7157` |
+| M5 revert the `pkg/daemon` wiring to nil | 1 | `DaemonKernelSystemWiresIsManagementIface_7157` |
+| M6 flattened (pre-#7157) default-route parse | 1 | `ParseDefaultRoute_7157` |
+| M7 treat a route-get error as eligible | 1 | `BeaconTargetEligible_7157` |
+
+Every cell applied (verified by diffing against a pristine copy before running)
+and every cell produced a NAMED failing test rather than a build break. All four
+mutated files were byte-identical to the originals after the run.
+
+M4 and M5 red only their OWN site's test, which is the property that matters for
+a two-caller gate: an enumeration failure at one call site cannot be masked by
+the other still being wired. M6 reddens only the new table, not
+`TestDefaultGatewayParseLogic` — the flattened parse gives the same answer for
+that test's four simple rows, so the measured shapes are what carry the
+property.
+
+M1 is the wiring cell and M2 the helper cell, and they red DIFFERENT tests —
+which is the point: the helper-level table stays green under M1, so without the
+two end-to-end tests the eligibility check could have been unreachable from
+`ForwardBeacon` and every helper row would still have passed.

--- a/pkg/daemon/kernel_system_helperstatus_7157.go
+++ b/pkg/daemon/kernel_system_helperstatus_7157.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/psaab/xpf/pkg/config"
 	"time"
 
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
@@ -35,11 +36,23 @@ import (
 // (dpuserspace.DefaultControlSocketPath(nil), bootstrap.go) rather than from the
 // active config: this runs on a promotion/self-recover path where the config may
 // not have compiled.
+// #7157: config.IsManagementIfName is passed as the beacon's management-interface
+// classifier. It is the #7515 SSOT for exactly this question — the same function
+// the vrf-mgmt binder (managementVRFIfaceSet), the networkd `VRF=` emitter and
+// the ip-monitoring next-hop validator use — so this becomes a fourth consumer of
+// one rule rather than a fourth copy of three prefixes. #7515 records that a
+// divergence between those consumers is always a bug.
+//
+// Its known looseness (`emergency0`, `fabric0` and `fxpanything` all match — the
+// defect is acknowledged in ifname_class_6731.go) is safe in THIS direction: the
+// beacon uses the predicate only to REFUSE a target, so a false positive costs a
+// fail-safe revert, never a promotion on an unproven kernel.
 func daemonKernelSystem() upgrade.KernelSystem {
 	return upgrade.NewKernelSystemWithHelperStatus(
 		nil,
 		daemonUpgradeHelperStatus,
 		dpuserspace.DefaultControlSocketPath(nil),
+		config.IsManagementIfName,
 	)
 }
 

--- a/pkg/daemon/kernel_system_helperstatus_7157_test.go
+++ b/pkg/daemon/kernel_system_helperstatus_7157_test.go
@@ -129,3 +129,46 @@ func stripGoComments7157(s string) string {
 		}
 	}
 }
+
+// TestDaemonKernelSystemWiresIsManagementIface_7157 binds the #7157 beacon
+// target classifier at the daemon's production construction site.
+//
+// beaconTargetEligible treats a NIL classifier as "no information" and does not
+// refuse a management egress — the right contract for an embedder that cannot
+// classify interfaces, and the reason the refusal is DEAD unless a caller
+// supplies the predicate. A test that only drove beaconTargetEligible would stay
+// green with this call site reverted to nil.
+//
+// It asserts BEHAVIOUR, not just non-nil: wiring some other predicate (or a
+// locally-written copy of the three prefixes) would satisfy a nil-check while
+// diverging from config.IsManagementIfName, which #7515 records as always a bug.
+func TestDaemonKernelSystemWiresIsManagementIface_7157(t *testing.T) {
+	v := reflect.Indirect(reflect.ValueOf(daemonKernelSystem()))
+	f := v.FieldByName("IsManagementIface")
+	if !f.IsValid() {
+		t.Fatal("no IsManagementIface field: the #7157 beacon target classifier cannot be observed")
+	}
+	if f.IsNil() {
+		t.Fatal("IsManagementIface is nil, so ForwardBeacon cannot refuse a beacon target that " +
+			"egresses the out-of-band management interface — a candidate kernel can keep " +
+			"management reachable while the dataplane cannot forward transit traffic (#7157)")
+	}
+	fn, ok := f.Interface().(func(string) bool)
+	if !ok {
+		t.Fatalf("IsManagementIface has type %s, want func(string) bool", f.Type())
+	}
+	for _, tc := range []struct {
+		iface string
+		want  bool
+	}{
+		{"fxp0", true}, {"em0", true}, {"fab0", true},
+		{"ge-0-0-1", false}, {"reth0.50", false}, {"lo", false},
+	} {
+		if got := fn(tc.iface); got != tc.want {
+			t.Errorf("wired classifier(%q) = %v, want %v — it must be "+
+				"config.IsManagementIfName, the #7515 SSOT shared with the vrf-mgmt binder, "+
+				"the networkd VRF= emitter and the ip-monitoring next-hop validator, not a "+
+				"local copy that can drift from it", tc.iface, got, tc.want)
+		}
+	}
+}

--- a/pkg/upgrade/kernel_beacon_target_7157.go
+++ b/pkg/upgrade/kernel_beacon_target_7157.go
@@ -1,0 +1,186 @@
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+)
+
+// kernel_beacon_target_7157.go — Gate 4's beacon TARGET ELIGIBILITY check
+// (#7157, the #1930 remainder).
+//
+// THE DEFECT THIS CLOSES
+//
+// ForwardBeacon proves the candidate kernel forwards by pinging a target and
+// treating a reply as proof. A reply proves that SOMETHING answered. It does
+// not prove the packet ever left the box, and the gate had no way to tell the
+// two apart.
+//
+// Measured on loss:xpf-userspace-fw0:
+//
+//	# ip route get 172.16.50.8          <- the box's OWN dataplane address
+//	local 172.16.50.8 dev lo table local src 172.16.50.8
+//	# ping -c 1 172.16.50.8
+//	1 packets transmitted, 1 received, 0% packet loss, rtt 0.055 ms
+//
+// A ping to the box's own address is answered by the local stack over `lo` in
+// 55 microseconds, with the dataplane in any state whatsoever. So
+// XPF_KERNEL_BEACON_TARGET set to the box's own dataplane address makes Gate 4
+// pass UNCONDITIONALLY — and ForwardBeacon's own guidance ("set
+// XPF_KERNEL_BEACON_TARGET to a DATAPLANE-side target") is exactly what leads
+// an operator to type it. The gate then promotes any candidate kernel that
+// reaches the promote verb, which is the whole failure #1930's Gate 4 exists to
+// prevent.
+//
+// The same hole admits the issue's original scenario: a target whose egress is
+// the out-of-band MANAGEMENT interface proves the management path answered, not
+// that the security dataplane forwards.
+//
+// THE CHECK
+//
+// Before pinging, resolve the target's EGRESS INTERFACE (`ip route get`) and
+// require it to be one a transit packet could actually leave by. Three classes
+// are refused, each with a named reason that reaches the durable last-roll
+// record (KernelRunner.revert stamps the error text into KernelRollOutcome):
+//
+//	no route          the target is unreachable from this box. Measured on the
+//	                  HA SECONDARY, where main's only default is
+//	                  `blackhole default` and `ip route get` returns EINVAL for
+//	                  every address — so this is not a hypothetical branch, it
+//	                  is the steady state of the node an HA operator upgrades
+//	                  FIRST.
+//	dev lo            the target is local. The ping never leaves the box and
+//	                  cannot fail, so a pass carries no information at all.
+//	management iface  the probe would traverse the OOB management path, which a
+//	                  candidate kernel can keep working while the dataplane
+//	                  cannot forward a transit packet.
+//
+// This is an ELIGIBILITY check, not a transit witness. It cannot show that a
+// packet crossed ingress AF_XDP -> filter/PBR -> policy -> session/NAT ->
+// egress; that needs an external observer and stays open on #7157. What it does
+// is remove the cases where the ping's success is guaranteed regardless of
+// dataplane health, so that a pass is at least CAPABLE of being a failure.
+
+// beaconRouteGet is the egress-interface resolver. A package var for the same
+// reason as beaconPing and beaconDefaultGateway (#6607): it is the only other
+// thing in the eligibility path that reaches outside the process, so without a
+// seam every assertion about the code AFTER it is decided by the routing table
+// of whatever machine runs the suite.
+//
+// `ip route get` selects the family from the address, so one form covers IPv4
+// and IPv6 (verified against both on the loss cluster).
+var beaconRouteGet = func(target string) (string, error) {
+	return captureCmd("ip", "route", "get", target)
+}
+
+// parseDefaultRoute extracts the next-hop and egress device from
+// `ip -4 route show default` output.
+//
+// SINGLE-SOURCED deliberately. This logic used to live inline in
+// defaultGateway(), which shells out — so TestDefaultGatewayParseLogic pinned a
+// COPY of the scan written inside the test, and a change to the production
+// parse would have left it green. A test that re-implements its subject is not
+// testing it. Both the production resolver and the test now call this.
+//
+// Parsed PER LINE, and the device is taken from the SAME line as the via. The
+// old flattened `strings.Fields(out)` scan could pair a `via` from one default
+// route with a `dev` from another, which matters as soon as the caller wants
+// the device: measured output on this platform includes a lone
+// `blackhole default proto static metric 20` (no via, no dev) and an FRR
+// nexthop-group form `default nhid 115 via 172.16.50.1 dev ge-0-0-2.50 proto
+// static metric 20`. Returns ("", "") when no line carries a via.
+func parseDefaultRoute(out string) (gw, dev string) {
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		var lineGW, lineDev string
+		for i := 0; i+1 < len(fields); i++ {
+			switch fields[i] {
+			case "via":
+				if lineGW == "" {
+					lineGW = fields[i+1]
+				}
+			case "dev":
+				if lineDev == "" {
+					lineDev = fields[i+1]
+				}
+			}
+		}
+		if lineGW != "" {
+			return lineGW, lineDev
+		}
+	}
+	return "", ""
+}
+
+// parseRouteGetDev extracts the egress device from `ip route get` output.
+//
+// Measured shapes, all four of which the selftest carries verbatim:
+//
+//	172.16.50.1 dev ge-0-0-2.50 src 172.16.50.8 uid 0        (on-link v4)
+//	10.136.126.1 via 172.16.50.1 dev ge-0-0-2.50 src ...     (via a gateway)
+//	2001:...::1 from :: dev ge-0-0-2.50 proto kernel src ... (v6)
+//	local 172.16.50.8 dev lo table local src 172.16.50.8     (the box itself)
+//
+// Returns "" when the output carries no `dev` field. The caller treats that as
+// UNRESOLVED — never as eligible: an absent device is "I could not tell where
+// this packet would go", which is the one answer that must not permit a probe
+// whose whole purpose is to establish where the packet went.
+func parseRouteGetDev(out string) string {
+	// Only the FIRST line describes the route; `cache`/`cache <local>`
+	// continuation lines carry no dev but must not be scanned for one either.
+	line := out
+	if i := strings.IndexByte(out, '\n'); i >= 0 {
+		line = out[:i]
+	}
+	fields := strings.Fields(line)
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == "dev" {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+// beaconTargetEligible reports whether a ping to target could carry any
+// information about dataplane forwarding.
+//
+// TOTAL: returns nil (eligible) or a non-nil error naming exactly which class
+// refused it. The error text is what reaches the operator, through
+// KernelRunner.revert -> KernelRollOutcome.Detail, so each one says what to do
+// rather than only what happened.
+//
+// isManagement may be nil, which means THIS CALLER CANNOT CLASSIFY interfaces.
+// That is treated as "no information", not "ineligible" — the same contract
+// ForwardBeacon's nil-HelperStatus branch documents, and for the same reason:
+// failing closed on a missing seam reverts every embedder's promotion. Both
+// production constructors wire it, and TestBothProductionCallersWireIsManagement_7157
+// binds that claim so "production always wires it" is asserted rather than
+// asserted-in-a-comment.
+func beaconTargetEligible(target string, isManagement func(string) bool) error {
+	out, err := beaconRouteGet(target)
+	if err != nil {
+		return fmt.Errorf("beacon target %s has no route from this box (%v) — a ping to it "+
+			"cannot leave, so a pass would carry no information. On an HA SECONDARY this is "+
+			"expected: the RETH default is a blackhole while the peer holds the VIP. Set "+
+			"XPF_KERNEL_BEACON_TARGET to an address reachable over a dataplane interface on "+
+			"THIS node", target, err)
+	}
+	dev := parseRouteGetDev(out)
+	if dev == "" {
+		return fmt.Errorf("beacon target %s: could not determine the egress interface from "+
+			"%q — refusing to probe a target whose path is unknown", target, strings.TrimSpace(out))
+	}
+	if dev == "lo" {
+		return fmt.Errorf("beacon target %s is LOCAL to this box (egress dev lo) — the ping is "+
+			"answered by the host stack without a packet ever leaving, so it succeeds with the "+
+			"dataplane in ANY state and proves nothing. Set XPF_KERNEL_BEACON_TARGET to an "+
+			"OFF-BOX address reachable over a dataplane interface", target)
+	}
+	if isManagement != nil && isManagement(dev) {
+		return fmt.Errorf("beacon target %s egresses the MANAGEMENT interface %s — a candidate "+
+			"kernel can keep management reachable while the security dataplane cannot forward "+
+			"transit traffic, so this probe cannot substantiate a promotion. Set "+
+			"XPF_KERNEL_BEACON_TARGET to an address reachable over a dataplane interface",
+			target, dev)
+	}
+	return nil
+}

--- a/pkg/upgrade/kernel_beacon_target_7157_test.go
+++ b/pkg/upgrade/kernel_beacon_target_7157_test.go
@@ -1,0 +1,315 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Measured verbatim on loss:xpf-userspace-fw0/fw1 (#7157). Using the real
+// shapes rather than invented ones matters here: the FRR nexthop-group form
+// (`nhid 115 via ...`) and the HA-secondary blackhole form are both produced by
+// this product on its own reference cluster, and neither appeared in the parse
+// table this code shipped with.
+const (
+	routeGetOnLinkV4 = "172.16.50.1 dev ge-0-0-2.50 src 172.16.50.8 uid 0 \n    cache \n"
+	routeGetViaGWV4  = "10.136.126.1 via 172.16.50.1 dev ge-0-0-2.50 src 172.16.50.8 uid 0 \n    cache \n"
+	routeGetV6       = "2001:559:8585:50::1 from :: dev ge-0-0-2.50 proto kernel src 2001:559:8585:50::8 metric 256 pref medium\n"
+	routeGetLocalV4  = "local 172.16.50.8 dev lo table local src 172.16.50.8 uid 0 \n    cache <local> \n"
+	routeGetLocalV6  = "local 2001:559:8585:80::8 from :: dev lo table local proto kernel src 2001:559:8585:80::8 metric 0 pref medium\n"
+	routeGetMgmt     = "10.136.126.1 dev fxp0 src 10.136.126.113 uid 0 \n    cache \n"
+)
+
+// TestParseRouteGetDev_7157 pins the egress-device extraction against the
+// measured shapes.
+func TestParseRouteGetDev_7157(t *testing.T) {
+	for _, tc := range []struct{ name, out, want string }{
+		{"on-link v4", routeGetOnLinkV4, "ge-0-0-2.50"},
+		{"via gateway v4", routeGetViaGWV4, "ge-0-0-2.50"},
+		{"v6", routeGetV6, "ge-0-0-2.50"},
+		{"local v4 (the false-PASS shape)", routeGetLocalV4, "lo"},
+		{"local v6", routeGetLocalV6, "lo"},
+		{"management", routeGetMgmt, "fxp0"},
+		// An unreadable answer must yield "", which the caller treats as
+		// UNRESOLVED. It must never fall through to a device name that would
+		// pass the eligibility check.
+		{"empty", "", ""},
+		{"whitespace", "   \n  \n", ""},
+		{"no dev field", "broadcast 10.0.0.255 table local src 10.0.0.1\n", ""},
+		// `dev` as the LAST token has no value after it; the scan must not
+		// index past the end, and must not report the literal "dev".
+		{"trailing dev with no value", "1.2.3.4 dev", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseRouteGetDev(tc.out); got != tc.want {
+				t.Errorf("parseRouteGetDev(%q) = %q, want %q", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseDefaultRoute_7157 pins the default-route parse — the PRODUCTION
+// function, which TestDefaultGatewayParseLogic used to re-implement inside
+// itself.
+func TestParseDefaultRoute_7157(t *testing.T) {
+	for _, tc := range []struct{ name, out, wantGW, wantDev string }{
+		{"classic", "default via 10.0.0.1 dev eth0 proto dhcp", "10.0.0.1", "eth0"},
+		// MEASURED on loss:xpf-userspace-fw0. FRR installs the default through a
+		// nexthop GROUP, so the line leads with `nhid <id>` before the via. A
+		// positional parse (`$3`) reads the nexthop-group id as the gateway.
+		{
+			"FRR nexthop-group form (measured)",
+			"default nhid 115 via 172.16.50.1 dev ge-0-0-2.50 proto static metric 20 \n",
+			"172.16.50.1", "ge-0-0-2.50",
+		},
+		// MEASURED on loss:xpf-userspace-fw1, the HA SECONDARY. FRR blackholes
+		// the static default while the peer holds the RETH VIP, so there is no
+		// via at all and the beacon has no target — on the node an HA operator
+		// upgrades FIRST.
+		{"HA-secondary blackhole (measured)", "blackhole default proto static metric 20 \n", "", ""},
+		{"HA-secondary blackhole v6 (measured)", "blackhole default dev lo proto static metric 20 pref medium\n", "", ""},
+		{"empty", "", "", ""},
+		{"no via (point-to-point)", "default dev wg0 scope link", "", ""},
+		// A blackhole line FOLLOWED by a real default: the device must come from
+		// the SAME line as the via. The old flattened field scan would have
+		// paired this via with the blackhole line's `dev lo` and reported the
+		// beacon target as egressing lo — which the eligibility check would then
+		// refuse, reverting a promotion that should have been allowed.
+		{
+			"blackhole line then a real default",
+			"blackhole default dev lo proto static metric 20\ndefault via 172.16.50.1 dev ge-0-0-2.50 proto static\n",
+			"172.16.50.1", "ge-0-0-2.50",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gw, dev := parseDefaultRoute(tc.out)
+			if gw != tc.wantGW || dev != tc.wantDev {
+				t.Errorf("parseDefaultRoute(%q) = (%q, %q), want (%q, %q)",
+					tc.out, gw, dev, tc.wantGW, tc.wantDev)
+			}
+		})
+	}
+}
+
+// TestBeaconTargetEligible_7157 is the total verdict table.
+//
+// Every row fixes the ROUTE-GET result, so the only thing that can decide the
+// outcome is the eligibility rule itself. Without that seam each row would be
+// decided by the routing table of whatever machine runs the suite, and a row
+// that rejects because the test host has no route to 192.0.2.1 cannot be told
+// apart from a row that rejects for the reason it was written to assert.
+func TestBeaconTargetEligible_7157(t *testing.T) {
+	isMgmt := func(dev string) bool {
+		return strings.HasPrefix(dev, "fxp") || strings.HasPrefix(dev, "fab") || strings.HasPrefix(dev, "em")
+	}
+	for _, tc := range []struct {
+		name     string
+		out      string
+		getErr   error
+		isMgmt   func(string) bool
+		wantErr  bool
+		wantWord string // a distinguishing fragment, so a row cannot pass on the WRONG rejection
+	}{
+		{name: "dataplane v4 is eligible", out: routeGetOnLinkV4, isMgmt: isMgmt},
+		{name: "dataplane v6 is eligible", out: routeGetV6, isMgmt: isMgmt},
+		{name: "via a gateway is eligible", out: routeGetViaGWV4, isMgmt: isMgmt},
+		{
+			// THE LIVE FALSE-PASS. `ping <own dataplane address>` is answered by
+			// the local stack in 55us with the dataplane in any state, so before
+			// this check an operator who set XPF_KERNEL_BEACON_TARGET to the
+			// box's own dataplane address — which ForwardBeacon's own guidance
+			// invites — made Gate 4 pass unconditionally.
+			name: "LOCAL target (dev lo) is refused", out: routeGetLocalV4, isMgmt: isMgmt,
+			wantErr: true, wantWord: "LOCAL",
+		},
+		{name: "local v6 is refused", out: routeGetLocalV6, isMgmt: isMgmt, wantErr: true, wantWord: "LOCAL"},
+		{
+			name: "management egress is refused", out: routeGetMgmt, isMgmt: isMgmt,
+			wantErr: true, wantWord: "MANAGEMENT",
+		},
+		{
+			// MEASURED on the HA secondary: `ip route get` returns EINVAL for
+			// every address because main's only default is a blackhole.
+			name: "no route at all is refused", getErr: errors.New("RTNETLINK answers: Invalid argument"),
+			isMgmt: isMgmt, wantErr: true, wantWord: "no route",
+		},
+		{
+			name: "unresolvable egress device is refused", out: "broadcast 10.0.0.255 table local\n",
+			isMgmt: isMgmt, wantErr: true, wantWord: "egress interface",
+		},
+		{
+			// A nil classifier is "no information", not "ineligible" — the same
+			// contract the nil-HelperStatus branch documents. Failing closed here
+			// would revert every embedder that cannot classify interfaces.
+			name: "nil classifier does not refuse a management egress", out: routeGetMgmt, isMgmt: nil,
+		},
+		{
+			// ...but `lo` needs no classifier to be recognised, so the nil case
+			// must NOT become a blanket bypass of the whole check. This row is
+			// what stops "nil means skip everything" from being an easy and
+			// wrong simplification.
+			name: "nil classifier still refuses a LOCAL target", out: routeGetLocalV4, isMgmt: nil,
+			wantErr: true, wantWord: "LOCAL",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := beaconRouteGet
+			t.Cleanup(func() { beaconRouteGet = orig })
+			var probed string
+			beaconRouteGet = func(target string) (string, error) {
+				probed = target
+				return tc.out, tc.getErr
+			}
+			err := beaconTargetEligible("198.51.100.7", tc.isMgmt)
+			if probed != "198.51.100.7" {
+				t.Fatalf("beaconTargetEligible resolved %q, want the target it was given", probed)
+			}
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("want a refusal, got nil — an ineligible target would be probed and its "+
+					"ping treated as proof of forwarding (case %s)", tc.name)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("want eligible, got refusal: %v", err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.wantWord) {
+				t.Fatalf("refusal %q does not name %q — the row could be passing on a "+
+					"DIFFERENT rejection than the one it asserts", err, tc.wantWord)
+			}
+		})
+	}
+}
+
+// TestForwardBeaconRefusesLocalTarget_7157 is the security regression: the
+// end-to-end gate, not the helper.
+//
+// Every other precondition is forced HEALTHY and the ping is forced to SUCCEED,
+// so the target eligibility check is the only thing left that can reject. That
+// is what makes this a proof rather than a coincidence: without the forced ping
+// the case passes even with the check deleted, because a real ping to the
+// target fails and the beacon returns false for a reason the assertion cannot
+// see (the same trap the #6607 tests in this package document).
+func TestForwardBeaconRefusesLocalTarget_7157(t *testing.T) {
+	origUnit, origPing, origGet := unitActiveProbeCtx, beaconPing, beaconRouteGet
+	t.Cleanup(func() {
+		unitActiveProbeCtx, beaconPing, beaconRouteGet = origUnit, origPing, origGet
+	})
+	unitActiveProbeCtx = func(context.Context, string) (bool, error) { return true, nil }
+	pinged := false
+	beaconPing = func(string, int) error { pinged = true; return nil }
+	beaconRouteGet = func(string) (string, error) { return routeGetLocalV4, nil }
+
+	s := &realKernelSystem{
+		BeaconTarget: "172.16.50.8", // the box's OWN dataplane address
+		HelperStatus: func(string, time.Duration) (bool, bool, int, error) {
+			return true, true, 1234, nil
+		},
+		IsManagementIface: func(string) bool { return false },
+	}
+	ok, err := s.ForwardBeacon(time.Second)
+	if ok {
+		t.Fatal("ForwardBeacon PASSED on a target local to the box. The ping is answered by " +
+			"the host stack without a packet leaving, so it succeeds with the dataplane in any " +
+			"state — Gate 4 would promote every candidate kernel unconditionally")
+	}
+	if err == nil || !strings.Contains(err.Error(), "LOCAL") {
+		t.Fatalf("ForwardBeacon err = %v; want a refusal naming the LOCAL target, because that "+
+			"text is what reaches the operator through KernelRollOutcome.Reason", err)
+	}
+	if pinged {
+		t.Fatal("ForwardBeacon pinged a target it had already established could not leave the box")
+	}
+}
+
+// TestForwardBeaconRefusesManagementEgress_7157 is the issue's original form of
+// the same defect: a candidate kernel can keep management reachable while the
+// dataplane cannot forward transit traffic.
+func TestForwardBeaconRefusesManagementEgress_7157(t *testing.T) {
+	origUnit, origPing, origGet := unitActiveProbeCtx, beaconPing, beaconRouteGet
+	t.Cleanup(func() {
+		unitActiveProbeCtx, beaconPing, beaconRouteGet = origUnit, origPing, origGet
+	})
+	unitActiveProbeCtx = func(context.Context, string) (bool, error) { return true, nil }
+	pinged := false
+	beaconPing = func(string, int) error { pinged = true; return nil }
+	beaconRouteGet = func(string) (string, error) { return routeGetMgmt, nil }
+
+	s := &realKernelSystem{
+		BeaconTarget: "10.136.126.1",
+		HelperStatus: func(string, time.Duration) (bool, bool, int, error) {
+			return true, true, 1, nil
+		},
+		IsManagementIface: func(dev string) bool { return strings.HasPrefix(dev, "fxp") },
+	}
+	ok, err := s.ForwardBeacon(time.Second)
+	if ok || err == nil || !strings.Contains(err.Error(), "MANAGEMENT") {
+		t.Fatalf("ForwardBeacon = (%v, %v) for a target egressing fxp0; want a refusal naming "+
+			"the management interface", ok, err)
+	}
+	if pinged {
+		t.Fatal("ForwardBeacon pinged a target it had established leaves via management")
+	}
+}
+
+// TestForwardBeaconPassesEligibleDataplaneTarget_7157 is the positive control
+// for the two refusals above: without it, an eligibility check that refused
+// EVERYTHING would satisfy both.
+func TestForwardBeaconPassesEligibleDataplaneTarget_7157(t *testing.T) {
+	origUnit, origPing, origGet := unitActiveProbeCtx, beaconPing, beaconRouteGet
+	t.Cleanup(func() {
+		unitActiveProbeCtx, beaconPing, beaconRouteGet = origUnit, origPing, origGet
+	})
+	unitActiveProbeCtx = func(context.Context, string) (bool, error) { return true, nil }
+	beaconPing = func(string, int) error { return nil }
+	beaconRouteGet = func(string) (string, error) { return routeGetOnLinkV4, nil }
+
+	s := &realKernelSystem{
+		BeaconTarget: "172.16.50.1",
+		HelperStatus: func(string, time.Duration) (bool, bool, int, error) {
+			return true, true, 1, nil
+		},
+		IsManagementIface: func(string) bool { return false },
+	}
+	if ok, err := s.ForwardBeacon(time.Second); !ok || err != nil {
+		t.Fatalf("ForwardBeacon = (%v, %v) for an off-box target egressing a dataplane "+
+			"interface with every precondition healthy; want (true, nil)", ok, err)
+	}
+}
+
+// TestBothProductionConstructorsWireIsManagement_7157 binds the WIRING.
+//
+// beaconTargetEligible treats a nil classifier as "no information" and does not
+// refuse a management egress, which is the right contract for an embedder that
+// cannot classify — but it means the management refusal is DEAD unless the
+// production callers actually pass the predicate. A test that only drove
+// beaconTargetEligible would stay green with both call sites reverted to nil,
+// which is the exact defect #7916 had to fix in its own first attempt.
+//
+// realKernelSystem is unexported but its fields are exported, so reflection
+// reaches them without widening the type's API.
+func TestBothProductionConstructorsWireIsManagement_7157(t *testing.T) {
+	s := NewKernelSystemWithHelperStatus(nil, nil, "", nil)
+	f := reflect.ValueOf(s).Elem().FieldByName("IsManagementIface")
+	if !f.IsValid() {
+		t.Fatal("realKernelSystem has no IsManagementIface field — the beacon's #7157 " +
+			"management refusal has no way to be wired")
+	}
+	if !f.IsNil() {
+		t.Fatal("NewKernelSystemWithHelperStatus(.., nil) left IsManagementIface non-nil; " +
+			"the constructor must pass through what the caller gave it")
+	}
+	want := func(string) bool { return true }
+	s = NewKernelSystemWithHelperStatus(nil, nil, "", want)
+	if reflect.ValueOf(s).Elem().FieldByName("IsManagementIface").IsNil() {
+		t.Fatal("NewKernelSystemWithHelperStatus dropped the IsManagementIface argument — " +
+			"every production caller's management refusal would be dead")
+	}
+	// The bare constructor must NOT silently supply one: a caller that has not
+	// thought about the classifier should get the documented "no information"
+	// behaviour, not a hidden default that could refuse a legitimate target.
+	if !reflect.ValueOf(NewKernelSystem()).Elem().FieldByName("IsManagementIface").IsNil() {
+		t.Fatal("NewKernelSystem() pre-set IsManagementIface; the seam must stay caller-supplied")
+	}
+}

--- a/pkg/upgrade/kernel_forward_beacon_6607_test.go
+++ b/pkg/upgrade/kernel_forward_beacon_6607_test.go
@@ -118,18 +118,31 @@ func TestForwardBeaconDataplaneCondition_6607(t *testing.T) {
 func TestForwardBeaconPassesWhenEverythingHealthy_6607(t *testing.T) {
 	origUnit := unitActiveProbeCtx
 	origPing := beaconPing
+	// #7157: the target-eligibility check runs a real `ip route get` unless the
+	// seam is stubbed, and this test then passes or fails on the routing table
+	// of whatever machine runs the suite. Measured on one dev box,
+	// `ip route get 192.0.2.1` answers `dev ix0` and the case passes by
+	// accident; on a host with no route it fails, and on a host whose default
+	// egresses a NIC named em*/fab*/fxp* it would fail for a reason this
+	// assertion cannot name. Same reasoning as the beaconPing stub below.
+	origGet := beaconRouteGet
 	t.Cleanup(func() {
 		unitActiveProbeCtx = origUnit
 		beaconPing = origPing
+		beaconRouteGet = origGet
 	})
 	unitActiveProbeCtx = func(context.Context, string) (bool, error) { return true, nil }
 	beaconPing = func(string, int) error { return nil }
+	beaconRouteGet = func(string) (string, error) {
+		return "192.0.2.1 via 172.16.50.1 dev ge-0-0-2.50 src 172.16.50.8 uid 0\n", nil
+	}
 
 	s := &realKernelSystem{
 		BeaconTarget: "192.0.2.1",
 		HelperStatus: func(string, time.Duration) (bool, bool, int, error) {
 			return true, true, 1234, nil
 		},
+		IsManagementIface: func(string) bool { return false },
 	}
 	if ok, err := s.ForwardBeacon(time.Second); !ok || err != nil {
 		t.Fatalf("ForwardBeacon = (%v, %v) with xpfd active, the dataplane armed and the "+

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -64,6 +64,24 @@ type realKernelSystem struct {
 	// StatusTimeout bounds a single control-socket status query (default 2s).
 	StatusTimeout time.Duration
 
+	// IsManagementIface classifies a KERNEL INTERFACE NAME as management
+	// (out-of-band) rather than dataplane, for ForwardBeacon's #7157 target
+	// eligibility check. Injected for the same reason HelperStatus is: the
+	// answer belongs to config.IsManagementIfName — the #7515 SSOT already
+	// shared by the daemon's vrf-mgmt binder, the networkd `VRF=` emitter and
+	// the ip-monitoring next-hop validator — and pkg/upgrade deliberately does
+	// not import pkg/config. Passing the SSOT rather than copying its three
+	// prefixes is the point: #7515 records that a divergence between the
+	// consumers of that rule is always a bug, and this is a fourth consumer.
+	//
+	// nil means this caller cannot classify interfaces, which is treated as "no
+	// information" and NOT as ineligible — the same contract the nil-HelperStatus
+	// branch documents below, and for the same reason (failing closed on a
+	// missing seam reverts every embedder's promotion). Both production
+	// constructors wire it, and that claim is bound by a test rather than left
+	// to this comment.
+	IsManagementIface func(iface string) bool
+
 	// Test seams (#5076). All nil/"" in production; a test injects them to
 	// drive the purge-failure path deterministically without shelling out to
 	// apt/dpkg or touching the real /boot + /lib/modules.
@@ -133,11 +151,13 @@ func NewKernelSystemWithHelperStatus(
 	unitActive func(ctx context.Context) (bool, error),
 	status HelperStatusFunc,
 	controlSocket string,
+	isManagementIface func(iface string) bool,
 ) *realKernelSystem {
 	s := NewKernelSystem()
 	s.UnitActive = unitActive
 	s.HelperStatus = status
 	s.ControlSocket = controlSocket
+	s.IsManagementIface = isManagementIface
 	return s
 }
 
@@ -822,6 +842,20 @@ func (s *realKernelSystem) ForwardBeacon(deadline time.Duration) (bool, error) {
 		// can set BeaconTarget to enable promotion on a box with no gateway).
 		return false, fmt.Errorf("no forward-beacon target (no default gateway; set BeaconTarget)")
 	}
+	// #7157: the target must be one a probe can actually FAIL against. A ping
+	// to the box's own address is answered by the local stack over `lo` in tens
+	// of microseconds with the dataplane in any state (measured: `ip route get
+	// 172.16.50.8` -> `local ... dev lo`, ping 0.055ms), so pointing
+	// XPF_KERNEL_BEACON_TARGET at a local dataplane address — which the
+	// guidance above actively invites — makes this gate pass UNCONDITIONALLY.
+	// A target egressing the out-of-band management interface is the same
+	// failure in the issue's original form. Refuse both, and refuse a target
+	// with no route at all, naming which: the error reaches the operator through
+	// KernelRunner.revert -> KernelRollOutcome.Reason, where "forward beacon
+	// FAILED" alone would not tell them what to change.
+	if err := beaconTargetEligible(target, s.IsManagementIface); err != nil {
+		return false, err
+	}
 	secs := int(deadline.Seconds())
 	if secs < 1 {
 		secs = 1
@@ -855,19 +889,18 @@ var beaconPing = func(target string, secs int) error {
 var beaconDefaultGateway = defaultGateway
 
 // defaultGateway returns the IPv4 default-route next hop, or "" if none.
+//
+// The parse itself lives in parseDefaultRoute (kernel_beacon_target_7157.go) so
+// the test can call the PRODUCTION function instead of a copy of it written
+// inside the test — which is what TestDefaultGatewayParseLogic used to do, and
+// which would have stayed green through any change made here.
 func defaultGateway() string {
 	out, err := captureCmd("ip", "-4", "route", "show", "default")
 	if err != nil {
 		return ""
 	}
-	// "default via 10.0.0.1 dev eth0 ..."
-	fields := strings.Fields(out)
-	for i := 0; i+1 < len(fields); i++ {
-		if fields[i] == "via" {
-			return fields[i+1]
-		}
-	}
-	return ""
+	gw, _ := parseDefaultRoute(out)
+	return gw
 }
 
 func (s *realKernelSystem) SetBootOrderFront(bootID string) error {

--- a/pkg/upgrade/kernel_linux_test.go
+++ b/pkg/upgrade/kernel_linux_test.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -44,19 +43,15 @@ func TestSlotSelectorRegex(t *testing.T) {
 }
 
 // TestDefaultGatewayParse locks the `ip -4 route show default` parse used by
-// ForwardBeacon's fallback target discovery (r2 Codex Critical fix). The parse
-// is a pure helper over the command output; exercise the field extraction.
+// ForwardBeacon's fallback target discovery (r2 Codex Critical fix).
+//
+// #7157: this used to MIMIC defaultGateway()'s field scan with a copy of the
+// loop written inside the test — so it pinned the copy, and a change to the
+// production parse left it green. It now calls parseDefaultRoute, the function
+// defaultGateway() actually uses. The measured real-world shapes (the FRR
+// nexthop-group form and the HA-secondary blackhole, neither of which appeared
+// in the table below) are in TestParseDefaultRoute_7157.
 func TestDefaultGatewayParseLogic(t *testing.T) {
-	// mimic defaultGateway()'s field scan
-	parse := func(out string) string {
-		fields := splitFields(out)
-		for i := 0; i+1 < len(fields); i++ {
-			if fields[i] == "via" {
-				return fields[i+1]
-			}
-		}
-		return ""
-	}
 	cases := []struct{ out, want string }{
 		{"default via 10.0.0.1 dev eth0 proto dhcp", "10.0.0.1"},
 		{"default via 192.168.1.254 dev ens3", "192.168.1.254"},
@@ -64,10 +59,8 @@ func TestDefaultGatewayParseLogic(t *testing.T) {
 		{"default dev wg0 scope link", ""}, // no via (point-to-point)
 	}
 	for _, c := range cases {
-		if got := parse(c.out); got != c.want {
-			t.Errorf("parse(%q) = %q, want %q", c.out, got, c.want)
+		if got, _ := parseDefaultRoute(c.out); got != c.want {
+			t.Errorf("parseDefaultRoute(%q) = %q, want %q", c.out, got, c.want)
 		}
 	}
 }
-
-func splitFields(s string) []string { return strings.Fields(s) }


### PR DESCRIPTION
Closes #7157

The venue-bound remainder — the external tagged transit witness — is split out as
**#7978**, with the two adjacent gaps found while measuring (`ArmNonce` is never
compared; no structured per-gate result exists) recorded there so they are not
re-derived.

## The defect: a Gate-4 pass that cannot be a fail

Gate 4 promotes a candidate kernel when a ping to `XPF_KERNEL_BEACON_TARGET`
succeeds. A reply proves *something answered*. It does not prove the packet ever
left the box, and the gate had no way to tell those apart.

Measured on `loss:xpf-userspace-fw0`:

```
# ip route get 172.16.50.8        <- the box's OWN dataplane address
local 172.16.50.8 dev lo table local src 172.16.50.8
# ping -c 1 -w 2 172.16.50.8
1 packets transmitted, 1 received, 0% packet loss
rtt min/avg/max/mdev = 0.055/0.055/0.055/0.000 ms
```

55 microseconds, over `lo`, with the dataplane in any state. So
`XPF_KERNEL_BEACON_TARGET` set to the box's own dataplane address makes Gate 4
pass for **every** candidate kernel — and `ForwardBeacon`'s own godoc (*"set it
to a DATAPLANE-side target"*) is what leads an operator to type it. Same for
IPv6 and for the LAN VIP. This is the one gate that is supposed to assert
packets actually move.

## Premise: two corrections that changed what was worth building

Each of #7157's claims was re-checked at `origin/master` `a1009d4e5` in a
worktree before any code was written.

### The issue's headline scenario is not reachable through the fallback

> "On a box whose default route is the OOB management NIC — the common case —
> the beacon proves the management path and nothing else."

`fxp*`/`fab*`/`em*` are enslaved to **`vrf-mgmt` (table 999)** whenever any is
configured, so the DHCP-learned management default lives there while
`ip -4 route show default` reads `main`:

```
# ip -4 route show default
default nhid 115 via 172.16.50.1 dev ge-0-0-2.50 proto static metric 20
# ip -4 route show table all | grep 'default.*fxp0'
default via 10.136.126.1 dev fxp0 table 999 proto dhcp
# ip rule show      <- nothing points at 999; it is reached via the VRF
0:      from all lookup local
1000:   from all lookup [l3mdev-table]
31000:  from all to 10.255.192.40/30 iif ge-0-0-1 lookup 488570
32766:  from all lookup main
32767:  from all lookup default
```

`beaconDefaultGateway()` returns a dataplane next hop **by construction**. The
management refusal below therefore guards an operator-set target and a posture
without that VRF isolation — not the default-gateway fallback. Building an
elaborate defence of a path that cannot be taken would have been worse than
building nothing, and saying so is most of the value of the premise check.

### On an HA secondary the beacon can never pass

`loss:xpf-userspace-fw1`, the secondary:

```
# ip -4 route show default
blackhole default proto static metric 20
# ip route get 1.1.1.1
RTNETLINK answers: Invalid argument
```

FRR blackholes the static default while the peer holds the RETH VIP.
`defaultGateway()` finds no `via`, and Gate 4 fail-closes — **on the node an HA
operator upgrades first**. Safe direction, but a gate that cannot pass is a wall
rather than a gate. Documented as a known limitation with its workaround.
Whether a drained secondary should promote on preconditions A+B alone is a
deliberate weakening of a security gate; that is a decision to take explicitly,
not to slip into a PR whose subject is the opposite.

## The fix: eligibility

Resolve the target's egress interface before pinging and refuse three classes,
each with a named reason that reaches the operator through
`KernelRunner.revert` → `KernelRollOutcome.Reason` (where "forward beacon
FAILED" alone would not tell them what to change):

| refused | why the ping is uninformative |
|---|---|
| `dev lo` | the host stack answers; nothing leaves the box |
| a management NIC | a candidate kernel can keep the OOB path working while the dataplane cannot forward transit |
| no route | nothing can leave, so nothing can be concluded |

The classifier is `config.IsManagementIfName`, **injected** — the #7515 SSOT
already shared by the `vrf-mgmt` binder, the networkd `VRF=` emitter and the
ip-monitoring next-hop validator. A fourth *consumer* of one rule, not a fourth
copy of three prefixes; #7515 records that a divergence between them is always a
bug. Its known looseness (`emergency0`, `fabric0` match) is safe in this
direction: the predicate only REFUSES, so a false positive costs a fail-safe
revert, never a promotion on an unproven kernel.

`NewKernelSystemWithHelperStatus` takes it as a **required parameter** rather
than a settable field, so a new caller cannot silently leave it nil — the
compiler asks the question.

### A test that re-implemented its own subject

`TestDefaultGatewayParseLogic` opened with `// mimic defaultGateway()'s field
scan` and then wrote the scan out again inside the test. It pinned the **copy**;
a change to the production parse left it green. Neither shape this product
actually emits was in its table — the FRR nexthop-group form
(`default nhid 115 via … dev …`) or the HA-secondary blackhole. The parse is now
one function both call, and parses per line so the device comes from the same
line as the via.

## What this is NOT

It is not a transit witness. The ping is still host-originated and never crosses
ingress AF_XDP → filter/PBR → policy → session/NAT → egress. What eligibility
buys is narrow and worth stating exactly: **a PASS is now capable of being a
FAIL.** Before it, three target classes made the probe succeed by construction.
The external witness is #7978.

## Validation

`go test -count=1 ./...` — rc=0, **0 `--- FAIL`**, 0 "no space left", 69 packages
ok. Nine new tests across `pkg/upgrade` (7), `cmd/xpfd` (1) and `pkg/daemon` (1);
selection counts verified non-zero, since a `-run <issue-number>` filter matches
filenames rather than test names and can select zero while exiting 0.

**A hermeticity defect the change exposed in an existing test.**
`TestForwardBeaconPassesWhenEverythingHealthy_6607` reaches the new check with no
seam stubbed, so it ran a real `ip route get 192.0.2.1` — passing on this dev box
only because that answers `dev ix0`. On a host with no route it fails; on one
whose default egresses a NIC named `em*`/`fab*`/`fxp*` it fails for a reason the
assertion cannot name. Now stubs `beaconRouteGet`, the same reasoning the file
already documents for `beaconPing`.

### Mutation matrix — full-suite runs, one mutation per cell

Gated on the count of named `^--- FAIL` lines, not `rc != 0`: a build break is
not a red. Every cell verified to have applied (diff against a pristine copy),
and all four mutated files byte-identical to the originals afterwards.

| mutation | named FAILs | which |
|---|---|---|
| M1 drop the eligibility call from `ForwardBeacon` | 2 | `ForwardBeaconRefusesLocalTarget_7157`, `ForwardBeaconRefusesManagementEgress_7157` |
| M2 stop refusing `dev lo` | 2 | `BeaconTargetEligible_7157`, `ForwardBeaconRefusesLocalTarget_7157` |
| M3 stop refusing a management egress | 2 | `BeaconTargetEligible_7157`, `ForwardBeaconRefusesManagementEgress_7157` |
| M4 revert the `cmd/xpfd` wiring to nil | 1 | `NewKernelConfig_WiresBeaconTargetClassifier_7157` |
| M5 revert the `pkg/daemon` wiring to nil | 1 | `DaemonKernelSystemWiresIsManagementIface_7157` |
| M6 flattened (pre-#7157) default-route parse | 1 | `ParseDefaultRoute_7157` |
| M7 treat a route-get error as eligible | 1 | `BeaconTargetEligible_7157` |

**M1 and M2 red different tests, and that is the point.** M1 is the wiring cell,
M2 the helper cell: the helper-level table stays green under M1, so without the
two end-to-end tests the eligibility check could have been unreachable from
`ForwardBeacon` with every helper row still passing. M4 and M5 red only their own
site's test — an enumeration failure at one call site cannot be masked by the
other still being wired.

## Docs

`docs/in-place-upgrade.md` gains the eligibility rules with the measured
evidence, the HA-secondary limitation and its workaround, and an explicit
statement of what remains open. `docs/log/7157.md` carries the full premise
record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fSMeD3QCCvtZ1zRaxikJZ
