### PR TITLE
docs/log: move the #7976 entry out of the closed _Log.md

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -107071,14 +107071,3 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/daemon/external_hostname_watch_6863.go, pkg/daemon/mgmt_listener_reassert.go, pkg/daemon/management.go, pkg/daemon/daemon.go
 
 <!-- LOG-CLOSED-SENTINEL-6874: nothing may be appended below this line. Write to docs/log/<issue>.md instead. -->
-
-- **Timestamp**: 2026-08-29 19:40 UTC
-  - **Action**: Document that a GitHub closing keyword cannot be negated, in
-    the PR-discipline section of docs/engineering-style.md. Six issues have
-    been auto-closed against the explicit written intent of the PRs that
-    closed them, and were recovered only by an ad-hoc sweep. Includes the
-    merge pre-flight (which must run on the FLATTENED body, because these
-    phrases wrap across lines), the periodic victim sweep, and the
-    merge/close timestamp-gap test that distinguishes a parser accident
-    from a deliberate close.
-  - **File(s)**: docs/engineering-style.md

--- a/docs/log/7976.md
+++ b/docs/log/7976.md
@@ -1,0 +1,12 @@
+# PR #7976 — a closing keyword cannot be negated
+
+- **Timestamp**: 2026-08-29 19:40 UTC
+  - **Action**: Document that a GitHub closing keyword cannot be negated, in
+    the PR-discipline section of docs/engineering-style.md. Six issues have
+    been auto-closed against the explicit written intent of the PRs that
+    closed them, and were recovered only by an ad-hoc sweep. Includes the
+    merge pre-flight (which must run on the FLATTENED body, because these
+    phrases wrap across lines), the periodic victim sweep, and the
+    merge/close timestamp-gap test that distinguishes a parser accident
+    from a deliberate close.
+  - **File(s)**: docs/engineering-style.md


### PR DESCRIPTION
Master is RED. PR #7976 appended its action log to the repository-root `_Log.md`, which #6874 closed to new entries, and `TestLogMdIsClosedToNewEntries6874` (`pkg/refactoraudit`) fires on every line past the LOG-CLOSED sentinel.

```
--- FAIL: TestLogMdIsClosedToNewEntries6874
    _Log.md line 107075 is AFTER the LOG-CLOSED sentinel
    _Log.md line 107076 is AFTER the LOG-CLOSED sentinel
    _Log.md line 107077 is AFTER the LOG-CLOSED sentinel
```

The entry's **content** is fine and is preserved verbatim — only its location was wrong. `docs/log/README.md` directs per-change logs to `docs/log/<issue>.md`, one file per issue or PR, which is exactly the convention that stops an append-only root file conflicting across every open branch.

**Why this is worth a standalone PR rather than folding into the next one.** The failure is invisible from the diff of any branch that does not touch `_Log.md`. The content arrives through the merge base, so a lane gating against this master sees a named FAIL in a package it never touched, with nothing in its own change to explain it. I hit exactly that while gating #7975 — the branch's `git diff --stat -- _Log.md` was empty, which is what sent me to check master itself rather than the branch.

It also reads as worse than it is: the guard reports one line per offending line, so a three-line log entry produces three failure lines and looks like a broader breakage.

**Validation:** `go test -count=1 ./...` — **69 packages, 0 FAIL** (was 1 before this change), verified in a worktree at master with only this change applied.