### PR TITLE
Document the residual split-brain window in peer-fencing disable-rg-confirmed

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -527,6 +527,54 @@ A `Confirmations: received N, timed out N, sent to peer N` line accompanies
 it is the only place that number appears, since `Fences sent` counts a
 confirmed and an unconfirmed takeover identically.
 
+### What `disable-rg-confirmed` does NOT give you
+
+**It reduces the split-brain window. It does not eliminate it, and the policy
+name overclaims slightly — read this section, not the name.**
+
+The residual is a partition in which the sync socket is LIVE BUT BLACKHOLED:
+packets are being dropped, TCP has not yet timed out, so the connection is not
+nil and the fence is written successfully, but no ack can come back. After
+`FenceConfirmTimeout` this node takes over anyway while the peer may still be
+alive and still forwarding. That is split-brain, and it is exactly the scenario
+a fence exists to prevent.
+
+**This is a deliberate trade, not an oversight.** The alternative — failing
+CLOSED, refusing to take over without a confirmation — has the worse failure
+mode for an appliance: a partition that never resolves leaves NOBODY
+forwarding, and an HA pair that will not fail over has lost the property it
+exists for. A bounded delay plus a smaller split-brain window is the trade on
+offer here; a guarantee is not.
+
+So an operator selecting this mode is buying:
+
+- **confirmation when confirmation was available** — which is the common case,
+  because the ack only has to arrive when the socket is genuinely healthy, and
+  there a fabric round trip is milliseconds; and
+- **ordering** in that case: this node does not claim the groups until the peer
+  says it released them.
+
+They are NOT buying "the peer is always confirmed down before I take over".
+
+### Telling a confirmed fence from a fail-open — the event line is the only way
+
+**The config knob cannot express the difference.** `Action: disable-rg-confirmed`
+renders identically whether every takeover was confirmed or every one of them
+fell open, so an operator reading only the configured action will assume the
+stronger property. The `EventFence` attempt line is the discriminator, and it
+is the ONLY one:
+
+| Attempt line | What actually happened |
+|---|---|
+| `Fence confirmed by peer (peer disabled N/N redundancy groups)` | The guarantee held. The peer acknowledged relinquishing every RG before this node claimed them. |
+| `Fence unconfirmed, took over anyway: <reason>` | **No confirmation.** Takeover proceeded regardless. The reason names which path — not connected, peer predates #7147, disconnected mid-wait, or timed out. |
+| `Fence NOT confirmed (<detail>), took over anyway` | The peer ANSWERED but reported it had not fully complied (partial, or no dataplane). |
+
+The `Confirmations: received N, timed out N, sent to peer N` line summarises the
+same thing in aggregate; `timed out` is the count of takeovers that proceeded
+without the guarantee. Neither `Fences sent` nor the configured action
+distinguishes them, which is why both surfaces exist.
+
 **Mixed-version clusters are safe and need no coordinated upgrade.** Both wire
 changes are additive: `syncMsgFenceAck` is a new type that an old peer skips
 via the receive switch's missing `default` arm, and the fence sequence is

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -2671,6 +2671,15 @@ operator-facing table.
   or a negative ack all proceed with the takeover, each recorded to
   `EventFence` with its reason. `SendFenceAwait` returns immediately when there
   is no active connection, so the ordinary dead-peer takeover pays nothing.
+- **It REDUCES the split-brain window; it does not eliminate it.** The residual
+  is a partition where the sync socket is live but blackholed — TCP has not
+  timed out, so the fence is written and no ack returns, and after the bound
+  this node takes over while the peer may still be forwarding. Failing CLOSED
+  instead would be worse for an appliance (a partition that never resolves
+  leaves nobody forwarding), so this is a deliberate trade. The policy NAME
+  overclaims; `docs/ha-failover-status.md` states the residual, and the
+  `EventFence` line is the only surface that distinguishes a confirmed fence
+  from a fail-open — the configured action renders identically either way.
 
 DHCP-server (Kea) leases ride the SAME session-sync channel and follow the
 IPsec-SA-sync precedent (`QueueIPsecSA` / `peerIPsecSAs` /


### PR DESCRIPTION
Follow-up to #7975 (merged). Docs only — no code change.

## Why this is a separate PR

#7975 merged at `b18a3b80b` while this commit was being written, so it landed
without the two doc items team-lead asked for. Rather than leave the commit
stranded on a deleted branch, it is cherry-picked onto master here. The
merged code is unchanged and correct; what was missing is the honest statement
of what it does **not** do.

## 1. The residual split-brain window is now named, not implied

`peer-fencing disable-rg-confirmed` **reduces** the split-brain window; it does
not eliminate it, and the policy name overclaims slightly.

The residual is a partition in which the sync socket is **live but blackholed**
— packets dropping, TCP not yet timed out. The connection is not nil, so the
fence is written successfully, but no ack can return; after
`FenceConfirmTimeout` this node takes over while the peer may still be alive
and forwarding. That is split-brain, and it is exactly what a fence exists to
prevent.

It is a deliberate trade, and the docs now say so. Failing **closed** has the
worse failure mode for an appliance: a partition that never resolves leaves
*nobody* forwarding, and an HA pair that will not fail over has lost the
property it exists for. So an operator selecting this mode buys confirmation
*when confirmation was available* — the common case, since the ack only has to
arrive when the socket is genuinely healthy — plus ordering in that case. They
do not buy "the peer is always confirmed down before I take over".

## 2. The event line is documented as the only discriminator

**The config knob cannot express the difference.** `Action:
disable-rg-confirmed` renders identically whether every takeover was confirmed
or every one of them fell open, so an operator reading the configured action
alone will assume the stronger property. `docs/ha-failover-status.md` now
carries a table mapping each `EventFence` attempt line to what actually
happened — confirmed, unconfirmed-took-over-anyway, or peer-answered-but-did-
not-comply — with the `Confirmations: … timed out N` counter as the aggregate.
`timed out` is the count of takeovers that proceeded without the guarantee, and
nothing else distinguishes them.

`pkg/cluster/README.md` gets the compact version beside the mechanism.

## On the third item

The prose that asserted the pre-#7147 gap — "the fence is best-effort and
unacknowledged … there is no fence-ack message on the wire" — was already
rewritten by the first commit of #7975 and shipped in that merge. Re-verified
absent here **wrap-insensitively** (the claim spans a line break, so a plain
`grep -F` would not have seen it), rather than assumed.

## Validation

`go build ./...`, `go test -count=1 ./pkg/cluster/ ./pkg/refactoraudit/` — green.
Docs-only diff: 2 files, +57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACWxU8wCM6am182N4END6m
