### PR TITLE
docs: name the split-brain residual disable-rg-confirmed does not close

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -516,10 +516,30 @@ takeover:
 | Peer partly fenced | none | `Fence NOT confirmed (peer disabled only 1/3 redundancy groups), took over anyway` |
 | Peer confirmed | one fabric round trip | `Fence confirmed by peer (peer disabled 4/4 redundancy groups)` |
 
-The only row that spends the timeout is a peer whose TCP socket has not yet
-noticed it is gone. The ordinary dead-peer takeover costs nothing extra,
+The only row that spends the timeout is one where the TCP socket is still up
+but no ack comes back. The ordinary dead-peer takeover costs nothing extra,
 because `SendFenceAwait` returns immediately when there is no active
 connection — there is nothing to wait for.
+
+**That row does not establish that the peer is gone, and this is the residual
+this mode does not close.** A socket that is up but blackholed — a partition
+dropping packets with TCP not yet timed out — produces exactly the same
+observation as a peer that lost power before its socket noticed: silence for
+250 ms. In the first case the peer is ALIVE and may still be forwarding, and
+taking over is precisely the dual-active split-brain a fence exists to prevent.
+
+So `disable-rg-confirmed` **reduces** the split-brain window rather than
+eliminating it. It converts every case where the peer can answer into a
+confirmed fence, and leaves unconfirmed only the case where the peer cannot be
+reached within the bound — where it is usually, but not provably, already gone.
+An operator selecting this mode is buying a smaller window in exchange for a
+bounded delay, not a guarantee.
+
+The config leaf cannot express that difference, so the `EventFence` attempt
+line is the only place a confirmed fence is distinguishable from a fallback.
+`Fence confirmed by peer (...)` is the guarantee; every `took over anyway`
+variant is not. Read the attempt line, not the policy name, when establishing
+what actually happened during a takeover.
 
 A `Confirmations: received N, timed out N, sent to peer N` line accompanies
 `Action` whenever the policy is armed or any ack traffic has occurred. Read


### PR DESCRIPTION
Follow-up to #7975 (merged). The mechanism is right; one sentence describing it was not.

The #7147 section said the only row spending the fence timeout is *"a peer whose TCP socket has not yet noticed it is gone"*. That asserts the peer is gone, and the observation does not support it.

A socket that is up but **blackholed** — a partition dropping packets with TCP not yet timed out — produces exactly the same observation as a peer that lost power before its socket noticed: silence for 250 ms. In the first case the peer is **alive and may still be forwarding**, and taking over is precisely the dual-active split-brain a fence exists to prevent.

**Nothing about the implementation changes, and fail-open remains the right trade.** Fail-closed would mean an unresolved partition leaves nobody forwarding, which is worse for an appliance than a bounded split-brain risk. What was wrong was the *claim*: `disable-rg-confirmed` **reduces** the split-brain window rather than eliminating it, and the policy name promises more than the mechanism delivers.

Because the config leaf cannot express that difference, the doc now says plainly that the `EventFence` attempt line is the only place a confirmed fence is distinguishable from a fallback — `Fence confirmed by peer (...)` is the guarantee, every `took over anyway` variant is not — and that an operator establishing what happened during a takeover should read that line rather than the policy name.

This matters because an operator who selects a mode called "confirmed" and is not told otherwise will reason about their safety posture as though confirmation were guaranteed. The existing table was accurate row by row; the prose beneath it drew a conclusion the rows do not support.

**Validation:** `go test -count=1 ./...` — 69 packages, 0 FAIL. Docs-only change.