### PR TITLE
docs: drop my duplicated residual paragraph and correct the fence timeout figure

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -512,7 +512,7 @@ takeover:
 | Peer not connected | none — returns immediately | `Fence unconfirmed, took over anyway: peer not connected` |
 | Peer predates #7147 | none — capability not advertised | `Fence unconfirmed, took over anyway: peer does not support fence acknowledgement` |
 | Sync channel dropped mid-wait | none — waiter released at once | `Fence unconfirmed, took over anyway: session sync disconnected...` |
-| Socket alive, peer silent | up to `FenceConfirmTimeout` (250 ms) | `Fence unconfirmed, took over anyway: timed out after 250ms...` |
+| Socket alive, peer silent | up to `FenceConfirmTimeout` (1 s) | `Fence unconfirmed, took over anyway: timed out after 1s...` |
 | Peer partly fenced | none | `Fence NOT confirmed (peer disabled only 1/3 redundancy groups), took over anyway` |
 | Peer confirmed | one fabric round trip | `Fence confirmed by peer (peer disabled 4/4 redundancy groups)` |
 
@@ -520,26 +520,6 @@ The only row that spends the timeout is one where the TCP socket is still up
 but no ack comes back. The ordinary dead-peer takeover costs nothing extra,
 because `SendFenceAwait` returns immediately when there is no active
 connection — there is nothing to wait for.
-
-**That row does not establish that the peer is gone, and this is the residual
-this mode does not close.** A socket that is up but blackholed — a partition
-dropping packets with TCP not yet timed out — produces exactly the same
-observation as a peer that lost power before its socket noticed: silence for
-250 ms. In the first case the peer is ALIVE and may still be forwarding, and
-taking over is precisely the dual-active split-brain a fence exists to prevent.
-
-So `disable-rg-confirmed` **reduces** the split-brain window rather than
-eliminating it. It converts every case where the peer can answer into a
-confirmed fence, and leaves unconfirmed only the case where the peer cannot be
-reached within the bound — where it is usually, but not provably, already gone.
-An operator selecting this mode is buying a smaller window in exchange for a
-bounded delay, not a guarantee.
-
-The config leaf cannot express that difference, so the `EventFence` attempt
-line is the only place a confirmed fence is distinguishable from a fallback.
-`Fence confirmed by peer (...)` is the guarantee; every `took over anyway`
-variant is not. Read the attempt line, not the policy name, when establishing
-what actually happened during a takeover.
 
 A `Confirmations: received N, timed out N, sent to peer N` line accompanies
 `Action` whenever the policy is armed or any ack traffic has occurred. Read


### PR DESCRIPTION
Two defects, both mine, from merging #7982 and #7981 in the wrong order.

**1. Duplicated prose.** I wrote #7982's residual paragraph while #7981 was in flight, and merged mine first. Master carried the same split-brain residual argument twice, in two voices. They agreed, which is what makes it quiet — a reader hits the argument twice and cannot tell which is current, and a later edit to one leaves the other contradicting it.

#7981's version survives; mine is removed. Its version is better on both counts: it carries the per-attempt-line discriminator table, and it refers to `FenceConfirmTimeout` rather than hardcoding a number.

**2. A wrong timeout figure — the more serious half.** My paragraph said *"silence for 250 ms"* and the table row read `FenceConfirmTimeout (250 ms)`. The shipped constant is **1 s**. It was raised in #7975 after the author found the original 250 ms rationale wrong on the facts: each RG's `SetRGActive` is a control-socket round trip with a 3 s base deadline, not a map poke, so 250 ms would have failed open on essentially every takeover.

I wrote the doc against the number in the PR description rather than the constant in the tree, and the table row was stale from before that change.

This is not cosmetic. An operator sizing a maintenance window, or reading the `Confirmations: … timed out N` counter against an expected bound, computes from a figure four times too small.

**Validation:** `go test -count=1 ./...` — 69 packages, 0 FAIL. Docs-only. Verified afterwards that no `250 ms`/`250ms` reference survives and the residual appears once.